### PR TITLE
[StyleCop] Update XML documentation suppress rule

### DIFF
--- a/BotBuilder-DotNet.ruleset
+++ b/BotBuilder-DotNet.ruleset
@@ -21,16 +21,18 @@
   </Rules>
 
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" /> <!-- XML documentation comments --> 
     <Rule Id="SA1101" Action="None" /> <!-- local calls prefixed with this -->       
     <Rule Id="SA1129" Action="None" /> <!-- don't use value type constructor-->
     <Rule Id="SA1200" Action="None" />
-    <Rule Id="SA1214" Action="None"/>    <!-- encapsalate field in property-->
+    <Rule Id="SA1214" Action="None"/> <!-- encapsalate field in property-->
     <Rule Id="SA1305" Action="Warning" />
     <Rule Id="SA1309" Action="None" />
     <Rule Id="SA1412" Action="Warning" />
     <Rule Id="SA1600" Action="None" />
     <Rule Id="SA1609" Action="Warning" />
     <Rule Id="SA1633" Action="None" /> 
+    <Rule Id="SA1652" Action="None" /> <!-- XML documentation comments -->
   </Rules>
   
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -21,16 +21,6 @@
     <Product>Microsoft Bot Builder SDK</Product>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>        
-    <NoWarn>$(NoWarn),1573,1591,1712</NoWarn>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Documentation|AnyCPU'">
-	  <GenerateDocumentationFile>true</GenerateDocumentationFile>    
-    <NoWarn>$(NoWarn),1573,1591,1712</NoWarn>
-	</PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebugType>full</DebugType>
@@ -53,15 +43,5 @@
       replace PackageLicenseUrl with PackageLicenseExpression.
     -->
     <NoWarn>$(NoWarn);NU5125</NoWarn>
-  </PropertyGroup>
-  <PropertyGroup Condition="$(Configuration) == 'Debug'">
-    <!-- For debug builds, we don't generate documentation. Supress the StyleCop rule that warns about this. -->
-    <NoWarn>$(NoWarn);SA0001</NoWarn>
-  </PropertyGroup>
-  <PropertyGroup Condition="$(Configuration) == 'Debug - NuGet Packages'">
-    <!-- For debug Nuget builds, we don't generate documentation. Supress the StyleCop rule that warns about this. -->
-    <NoWarn>$(NoWarn);SA0001</NoWarn>
-
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Remove the Property used to suppress the rule [SA0001](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA0001.md). This was applied to the projects that didn't support ruleset files, but now all the projects use an unique ruleset file. 

![image](https://user-images.githubusercontent.com/37461749/54716477-93b4e800-4b34-11e9-9e22-a91c579a368d.png)

Also, the rules [SA0001](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA0001.md) and [SA1652](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1652.md) about the `XML documentation` were moved into the ruleset file.
![image](https://user-images.githubusercontent.com/37461749/54716585-d1197580-4b34-11e9-928f-d6b51e5e4eb5.png)

Finally, we updated the StyleCop version to 1.1.0-beta008, to properly support the C# version used by the projects of the solution.
![image](https://user-images.githubusercontent.com/37461749/54716450-84359f00-4b34-11e9-9924-6a4a6a187e35.png)

Currently, all the projects are configured to set the latest major version of C#. and uses some features of c# 7.0 like: 
- `throw` expressions
This feature enables using throw expressions in initialization expressions:
![image](https://user-images.githubusercontent.com/37461749/54753859-d7edca00-4bc0-11e9-8ca9-9e26cd287f12.png)

- `is` expression 
The is pattern expression extends the familiar `is` operator to query an object beyond its type.
![image](https://user-images.githubusercontent.com/37461749/54754336-07510680-4bc2-11e9-9a31-4f7974ab87c3.png)

- `tuples` syntax
![image](https://user-images.githubusercontent.com/37461749/54754198-b6d9a900-4bc1-11e9-96c0-78c8d26c3ac1.png)

