### PR TITLE
[Fix][C#] Add LangVersion to Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,10 @@
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
   </ItemGroup>
+  
+  <PropertyGroup>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
 
   <PropertyGroup>
     <Company>Microsoft</Company>


### PR DESCRIPTION
Fixes #149

## Description
There is an issue when trying to build the solution in VS2017. Some `default literal` expressions were added and VS2017 by default is building with `C#7.0` which does not support it.

We added the `LangVersion` property to the `Directory.Build.props`  and set it to latest to ensure that it's always using the latest version of C#.
