### PR TITLE
[Webex] Add unit tests to cover adaptive cards functionality

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Bot.Schema;
 using Newtonsoft.Json;
-using Thrzn41.WebexTeams;
 using Thrzn41.WebexTeams.Version1;
 
 namespace Microsoft.Bot.Builder.Adapters.Webex

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexClientWrapper.cs
@@ -18,6 +18,10 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
 {
     public class WebexClientWrapper
     {
+        private const string WebhookUrl = "https://api.ciscospark.com/v1/webhooks";
+        private const string MessageUrl = "https://api.ciscospark.com/v1/messages";
+        private const string ActionsUrl = "https://api.ciscospark.com/v1/attachment/actions";
+
         private TeamsAPIClient _api;
 
         /// <summary>
@@ -64,7 +68,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         public virtual async Task<string> CreateMessageWithAttachmentsAsync(string toPersonOrEmail, string text, IList<Attachment> attachments, string token)
         {
             Message result = null;
-            var url = "https://api.ciscospark.com/v1/messages";
+            var url = MessageUrl;
 
             var attachmentsContent = new List<object>();
 
@@ -118,7 +122,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         {
             Message result = null;
 
-            var url = $"https://api.ciscospark.com/v1/attachment/actions/{actionId}";
+            var url = $"{ActionsUrl}/{actionId}";
 
             var http = (HttpWebRequest)WebRequest.Create(new Uri(url));
             http.PreAuthenticate = true;
@@ -228,7 +232,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         {
             Webhook result = null;
 
-            var url = "https://api.ciscospark.com/v1/webhooks";
+            var url = WebhookUrl;
             var data = new NameValueCollection
             {
                 ["name"] = name,
@@ -263,7 +267,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         {
             Webhook result = null;
 
-            var url = $"https://api.ciscospark.com/v1/webhooks/{webhookId}";
+            var url = $"{WebhookUrl}/{webhookId}";
             var data = new NameValueCollection
             {
                 ["name"] = name,

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/Files/MessageWithInputs.json
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/Files/MessageWithInputs.json
@@ -1,0 +1,21 @@
+{
+  "id": "test_id",
+  "roomId": "test_room",
+  "roomType": null,
+  "toPersonId": null,
+  "toPersonEmail": null,
+  "text": null,
+  "markdown": null,
+  "files": null,
+  "personId": "test_person_id",
+  "personEmail": null,
+  "created": "2019-09-05T13:28:20.346Z",
+  "mentionedPeople": null,
+  "mentionedGroups": null,
+  "html": null,
+  "type": "submit",
+  "messageId": "test_message_id",
+  "inputs": {
+    "Name": "test_input"
+  }
+}

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/Files/MessageWithText.json
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/Files/MessageWithText.json
@@ -1,0 +1,21 @@
+{
+  "id": "test_id",
+  "roomId": "test_room",
+  "roomType": null,
+  "toPersonId": null,
+  "toPersonEmail": null,
+  "text": "message with inputs",
+  "markdown": null,
+  "files": null,
+  "personId": "test_person_id",
+  "personEmail": null,
+  "created": "2019-09-05T13:28:20.346Z",
+  "mentionedPeople": null,
+  "mentionedGroups": null,
+  "html": null,
+  "type": "submit",
+  "messageId": "test_message_id",
+  "inputs": {
+    "Name": "test_input"
+  }
+}

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/Files/PayloadAttachmentActions.json
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/Files/PayloadAttachmentActions.json
@@ -1,0 +1,23 @@
+{
+  "id": "test_id",
+  "name": "Webex AttachmentActions",
+  "resource": "attachmentActions",
+  "event": "created",
+  "filter": null,
+  "orgId": "test_org_id",
+  "createdBy": "test_creatorId",
+  "appId": "test_appId",
+  "ownedBy": "creator",
+  "status": "active",
+  "actorId": "test_personId",
+  "targetUrl": "https://f7f6772c.ngrok.io/api/messages",
+  "created": "2019-09-04T20:53:25.258Z",
+  "data": {
+    "id": "test_actionId",
+    "type": "submit",
+    "messageId": "test_messageId",
+    "personId": "test_personId",
+    "roomId": "test_roomId",
+    "created": "2019-09-05T14:28:08.041Z"
+  }
+}

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/Files/WebhookAttachmentActions.json
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/Files/WebhookAttachmentActions.json
@@ -1,0 +1,15 @@
+{
+  "id": "new_webhook_id",
+  "name": "New_Webhook",
+  "targetUrl": "https://contoso.com/api/messages",
+  "resource": "attachmentActions",
+  "event": "all",
+  "filter": null,
+  "secret": "test-secret-1234",
+  "status": "active",
+  "created": "2019-07-17T16:58:37.164Z",
+  "orgId": "test_org_id",
+  "createdBy": "test_creator_id",
+  "appId": "test_app_id",
+  "ownedBy": "creator"
+}

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/Files/WebhookList.json
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/Files/WebhookList.json
@@ -2,7 +2,7 @@
   "items": [
     {
       "id": "test_webhook_id1",
-      "name": "TestWH",
+      "name": "Webex AttachmentActions",
       "targetUrl": "https://contoso.com/api/messages",
       "resource": "all",
       "event": "all",

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/Microsoft.Bot.Builder.Adapters.Webex.Tests.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/Microsoft.Bot.Builder.Adapters.Webex.Tests.csproj
@@ -45,6 +45,9 @@
     <None Update="Files\Webhook.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Files\WebhookAttachmentActions.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Files\WebhookList.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/Microsoft.Bot.Builder.Adapters.Webex.Tests.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/Microsoft.Bot.Builder.Adapters.Webex.Tests.csproj
@@ -27,6 +27,12 @@
     <None Update="Files\MessageHtml.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Files\MessageWithInputs.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Files\MessageWithText.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Files\Payload.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/Microsoft.Bot.Builder.Adapters.Webex.Tests.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/Microsoft.Bot.Builder.Adapters.Webex.Tests.csproj
@@ -39,6 +39,9 @@
     <None Update="Files\Payload2.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Files\PayloadAttachmentActions.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Files\Person.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/WebexAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/WebexAdapterTests.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
             var httpRequest = new Mock<HttpRequest>();
             httpRequest.SetupGet(req => req.Body).Returns(stream);
             httpRequest.Setup(req => req.Headers.ContainsKey(It.IsAny<string>())).Returns(true);
-            httpRequest.SetupGet(req => req.Headers[It.IsAny<string>()]).Returns("61E7F071CE5C9FA21C773E7D6E9C6FF3B8A21F80");
+            httpRequest.SetupGet(req => req.Headers[It.IsAny<string>()]).Returns("0DAE6B9150DA80E6049E81B9DC5AF3D57831AC60");
 
             var httpResponse = new Mock<HttpResponse>();
             var bot = new Mock<IBot>();
@@ -224,7 +224,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
             var httpRequest = new Mock<HttpRequest>();
             httpRequest.SetupGet(req => req.Body).Returns(stream);
             httpRequest.Setup(req => req.Headers.ContainsKey(It.IsAny<string>())).Returns(true);
-            httpRequest.SetupGet(req => req.Headers[It.IsAny<string>()]).Returns("9C32875928D2901E0BE90AEDDF4063174E25BB4E");
+            httpRequest.SetupGet(req => req.Headers[It.IsAny<string>()]).Returns("1F8A7273D461C5517505A7A7551609FDF45CBF7B");
 
             var httpResponse = new Mock<HttpResponse>();
             var bot = new Mock<IBot>();
@@ -510,6 +510,49 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
             await webexAdapter.DeleteActivityAsync(turnContext, conversationReference, default);
 
             Assert.Equal(1, deletedMessages);
+        }
+
+        [Fact]
+        public async void RegisterAdaptiveCardsWebhookSubscriptionAsync_CreateWebhook_Should_Succeed()
+        {
+            var testPublicAddress = "http://contoso.com/api/messages";
+            var webhookName = "New_Webhook";
+
+            var options = new WebexAdapterOptions("Test", testPublicAddress, "Test", webhookName);
+
+            var webhookList = JsonConvert.DeserializeObject<WebhookList>(File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\WebhookList.json"));
+            var webhook = JsonConvert.DeserializeObject<Webhook>(File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\WebhookAttachmentActions.json"));
+
+            var webexApi = new Mock<WebexClientWrapper>();
+            webexApi.SetupAllProperties();
+            webexApi.Setup(x => x.CreateAdaptiveCardsWebhookAsync(It.IsAny<string>(), It.IsAny<Uri>(), It.IsAny<EventType>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(webhook));
+
+            var webexAdapter = new WebexAdapter(options, webexApi.Object);
+
+            var actualWebhook = await webexAdapter.RegisterAdaptiveCardsWebhookSubscriptionAsync("api/messages", webhookList);
+
+            Assert.Equal(webhook.Id, actualWebhook.Id);
+            Assert.Equal(webhook.Name, actualWebhook.Name);
+        }
+
+        [Fact]
+        public async void RegisterAdaptiveCardsWebhookSubscriptionAsync_UpdateWebhook_Should_Succeed()
+        {
+            var testPublicAddress = "http://contoso.com/api/messages";
+
+            var options = new WebexAdapterOptions("Test", testPublicAddress, "Test");
+
+            var webhookList = JsonConvert.DeserializeObject<WebhookList>(File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\WebhookList.json"));
+
+            var webexApi = new Mock<WebexClientWrapper>();
+            webexApi.SetupAllProperties();
+            webexApi.Setup(x => x.UpdateAdaptiveCardsWebhookAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(webhookList.Items[0]));
+
+            var webexAdapter = new WebexAdapter(options, webexApi.Object);
+
+            var webhook = await webexAdapter.RegisterAdaptiveCardsWebhookSubscriptionAsync("api/messages", webhookList);
+
+            Assert.Equal(webhookList.Items[0].Id, webhook.Id);
         }
     }
 }

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/WebexAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/WebexAdapterTests.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         [Fact]
         public async void ContinueConversationAsync_Should_Succeed()
         {
-            bool callbackInvoked = false;
+            var callbackInvoked = false;
             var testPublicAddress = "http://contoso.com/api/messages";
 
             var options = new WebexAdapterOptions("Test", testPublicAddress, "Test");
@@ -132,7 +132,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
 
             await Assert.ThrowsAsync<ArgumentNullException>(async () =>
             {
-                await webexAdapter.ProcessAsync(null, httpResponse.Object, bot.Object, default(CancellationToken));
+                await webexAdapter.ProcessAsync(null, httpResponse.Object, bot.Object, default);
             });
         }
 
@@ -149,7 +149,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
 
             await Assert.ThrowsAsync<ArgumentNullException>(async () =>
             {
-                await webexAdapter.ProcessAsync(httpRequest.Object, null, default(IBot), default(CancellationToken));
+                await webexAdapter.ProcessAsync(httpRequest.Object, null, default, default);
             });
         }
 
@@ -166,7 +166,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
 
             await Assert.ThrowsAsync<ArgumentNullException>(async () =>
             {
-                await webexAdapter.ProcessAsync(httpRequest.Object, httpResponse.Object, null, default(CancellationToken));
+                await webexAdapter.ProcessAsync(httpRequest.Object, httpResponse.Object, null, default);
             });
         }
 
@@ -250,7 +250,6 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
             WebexHelper.Identity = JsonConvert.DeserializeObject<Person>(File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\Person.json"));
             var payload = File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\Payload2.json");
             var stream = new MemoryStream(Encoding.UTF8.GetBytes(payload.ToString()));
-            var call = false;
 
             var httpRequest = new Mock<HttpRequest>();
             httpRequest.SetupGet(req => req.Body).Returns(stream);
@@ -259,10 +258,6 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
 
             var httpResponse = new Mock<HttpResponse>();
             var bot = new Mock<IBot>();
-            bot.Setup(x => x.OnTurnAsync(It.IsAny<TurnContext>(), It.IsAny<CancellationToken>())).Callback(() =>
-            {
-                call = true;
-            });
 
             await Assert.ThrowsAsync<Exception>(async () =>
             {
@@ -433,7 +428,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
 
             await Assert.ThrowsAsync<Exception>(async () =>
             {
-                await webexAdapter.SendActivitiesAsync(turnContext, activities, default(CancellationToken));
+                await webexAdapter.SendActivitiesAsync(turnContext, activities, default);
             });
         }
 
@@ -487,7 +482,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
 
             await Assert.ThrowsAsync<Exception>(async () =>
             {
-                await webexAdapter.SendActivitiesAsync(turnContext, new Activity[] { activity.Object }, default(CancellationToken));
+                await webexAdapter.SendActivitiesAsync(turnContext, new Activity[] { activity.Object }, default);
             });
         }
 
@@ -510,9 +505,10 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
             activity.Object.Type = "message";
             activity.Object.Recipient = new ChannelAccount(id: "MockId");
             activity.Object.Text = "Hello, Bot!";
-            var image = new Attachment("image/png", "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQtB3AwMUeNoq4gUBGe6Ocj8kyh3bXa9ZbV7u1fVKQoyKFHdkqU");
-            activity.Object.Attachments = new List<Attachment>();
-            activity.Object.Attachments.Add(image);
+            activity.Object.Attachments = new List<Attachment>
+            {
+                new Attachment("image/png", "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQtB3AwMUeNoq4gUBGe6Ocj8kyh3bXa9ZbV7u1fVKQoyKFHdkqU"),
+            };
 
             var turnContext = new TurnContext(webexAdapter, activity.Object);
 
@@ -539,10 +535,9 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
             activity.Object.Type = "message";
             activity.Object.Recipient = new ChannelAccount(id: "MockId");
             activity.Object.Text = "Hello, Bot!";
-            var card = new Attachment("application/vnd.microsoft.card.adaptive");
             activity.Object.Attachments = new List<Attachment>
             {
-                card,
+                new Attachment("application/vnd.microsoft.card.adaptive"),
             };
 
             var turnContext = new TurnContext(webexAdapter, activity.Object);

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/WebexHelperTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/WebexHelperTests.cs
@@ -138,5 +138,47 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
 
             Assert.Equal(message.FileCount, attachmentList.Count);
         }
+
+        [Fact]
+        public void AttachmentActionToActivity_With_Null_Message_Should_Fail()
+        {
+            Assert.Null(WebexHelper.AttachmentActionToActivity(null));
+        }
+
+        [Fact]
+        public void AttachmentActionToActivity_Should_Return_Activity_With_Empty_Text()
+        {
+            WebexHelper.Identity = JsonConvert.DeserializeObject<Person>(File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\Person.json"));
+            var message =
+                JsonConvert.DeserializeObject<Message>(
+                    File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\MessageWithInputs.json"));
+
+            var data = JsonConvert.SerializeObject(message);
+            var messageExtraData = JsonConvert.DeserializeObject<AttachmentActionData>(data);
+
+            var activity = WebexHelper.AttachmentActionToActivity(message);
+
+            Assert.Equal(message.Id, activity.Id);
+            Assert.Equal(messageExtraData.Inputs, activity.Value);
+            Assert.Equal(string.Empty, activity.Text);
+        }
+
+        [Fact]
+        public void AttachmentActionToActivity_Should_Return_Activity_With_Text()
+        {
+            WebexHelper.Identity = JsonConvert.DeserializeObject<Person>(File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\Person.json"));
+            var message =
+                JsonConvert.DeserializeObject<Message>(
+                    File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\MessageWithText.json"));
+
+            var data = JsonConvert.SerializeObject(message);
+            var messageExtraData = JsonConvert.DeserializeObject<AttachmentActionData>(data);
+
+            var activity = WebexHelper.AttachmentActionToActivity(message);
+
+            Assert.Equal(message.Id, activity.Id);
+            Assert.Equal(messageExtraData.Inputs, activity.Value);
+            Assert.Equal(message.Text, activity.Text);
+        }
     }
 }


### PR DESCRIPTION
## Description
Add unit tests to cover the new adaptive cards functionality.

## Changes Made
- Added 3 tests for _AttachmentActionToActivity_ method
- Added 2 tests for _RegisterAdaptiveCardsWebhookSubscriptionAsync_ method
- Added 1 test for _ProcessAsync_ method 
- Added 1 tests for _SendActivitiesAsync_ method
- Simplified code by using var instead of specific types and simplifying default parameters

![image](https://user-images.githubusercontent.com/44245136/64361832-bbfda980-cfe3-11e9-89f9-a03133f32006.png)
