### PR TITLE
[Webex Adapter] Add regex coverage test

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task<Webhook> RegisterWebhookSubscriptionAsync(string webhookPath, WebhookList webhookList)
         {
-            var webHookName = _config.WebhookName ?? "Botkit Firehose";
+            var webHookName = _config.WebhookName ?? "Webex Firehose";
 
             string hookId = null;
 

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexHelper.cs
@@ -152,15 +152,16 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
 
             if (decryptedMessage.HasHtml)
             {
-                var pattern = new Regex($"^(<p>)?<spark-mention .*?data-object-id=\"{Identity.Id}\".*?>.*?</spark-mention>");
+                // strip the mention & HTML from the message
+                var pattern = new Regex($"^(<p>)?<spark-mention .*?data-object-id=\"{Identity.Id}\".*?>.*?</spark-mention>", RegexOptions.IgnoreCase | RegexOptions.Multiline);
                 if (!decryptedMessage.Html.Equals(pattern))
                 {
                     // this should look like ciscospark://us/PEOPLE/<id string>
-                    var match = Regex.Match(Identity.Id, "/ciscospark://.*/(.*)/im");
+                    var match = Regex.Match(Identity.Id, "/ciscospark://.*/(.*)", RegexOptions.IgnoreCase | RegexOptions.Multiline);
                     if (match.Captures.Count > 0)
                     {
                         pattern = new Regex(
-                            $"^(<p>)?<spark-mention .*?data-object-id=\"{match.Captures[1]}\".*?>.*?</spark-mention>");
+                            $"^(<p>)?<spark-mention .*?data-object-id=\"{match.Captures[0]}\".*?>.*?</spark-mention>", RegexOptions.IgnoreCase | RegexOptions.Multiline);
                     }
                 }
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/Files/Payload.json
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/Files/Payload.json
@@ -1,6 +1,6 @@
 {
   "id": "test_id",
-  "name": "Botkit Firehose",
+  "name": "Webex Firehose",
   "resource": "messages",
   "event": "created",
   "filter": null,

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/Files/Payload2.json
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/Files/Payload2.json
@@ -1,6 +1,6 @@
 {
   "id": "test_id",
-  "name": "Botkit Firehose",
+  "name": "Webex Firehose",
   "resource": "messages",
   "event": "updated",
   "filter": null,

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/Files/WebhookList.json
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/Files/WebhookList.json
@@ -17,7 +17,7 @@
     },
     {
       "id": "test_webhook_id2",
-      "name": "Botkit Firehose",
+      "name": "Webex Firehose",
       "targetUrl": "https://contoso.com/api/messages",
       "resource": "all",
       "event": "all",

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/WebexAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/WebexAdapterTests.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
             var httpRequest = new Mock<HttpRequest>();
             httpRequest.SetupGet(req => req.Body).Returns(stream);
             httpRequest.Setup(req => req.Headers.ContainsKey(It.IsAny<string>())).Returns(true);
-            httpRequest.SetupGet(req => req.Headers[It.IsAny<string>()]).Returns("0DAE6B9150DA80E6049E81B9DC5AF3D57831AC60");
+            httpRequest.SetupGet(req => req.Headers[It.IsAny<string>()]).Returns("61E7F071CE5C9FA21C773E7D6E9C6FF3B8A21F80");
 
             var httpResponse = new Mock<HttpResponse>();
             var bot = new Mock<IBot>();
@@ -224,7 +224,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
             var httpRequest = new Mock<HttpRequest>();
             httpRequest.SetupGet(req => req.Body).Returns(stream);
             httpRequest.Setup(req => req.Headers.ContainsKey(It.IsAny<string>())).Returns(true);
-            httpRequest.SetupGet(req => req.Headers[It.IsAny<string>()]).Returns("1F8A7273D461C5517505A7A7551609FDF45CBF7B");
+            httpRequest.SetupGet(req => req.Headers[It.IsAny<string>()]).Returns("9C32875928D2901E0BE90AEDDF4063174E25BB4E");
 
             var httpResponse = new Mock<HttpResponse>();
             var bot = new Mock<IBot>();

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/WebexHelperTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/WebexHelperTests.cs
@@ -119,6 +119,22 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
+        public void DecryptedMessageToActivity_With_Html_Should_Return_Activity_When_Match()
+        {
+            var serializedPerson = "{\"id\":\"/ciscospark://us/PEOPLE/different_id\"}";
+            WebexHelper.Identity = JsonConvert.DeserializeObject<Person>(serializedPerson);
+
+            var message =
+                JsonConvert.DeserializeObject<Message>(
+                    File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\MessageHtml.json"));
+
+            var activity = WebexHelper.DecryptedMessageToActivity(message);
+
+            Assert.Equal(message.Id, activity.Id);
+            Assert.Equal(message.Html, activity.Text);
+        }
+
+        [Fact]
         public void HandleMessageAttachments_Should_Fail_With_MoreThanOne_Attachment()
         {
             var message = JsonConvert.DeserializeObject<Message>(File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\MessageAttachments.json"));


### PR DESCRIPTION
## Proposed Changes

- Add an extra unit test to cover the regex evaluation in **DecryptedMessageToActivity**.
- Improve regex implementation in Helper class.
- Correct webhook name. 

**Modified Files**

- WebexAdapter.cs
- WebexHelper.cs
- Payload.json
- Payload2.json
- WebookList.json
- WebexHelperTests.cs
- WebexAdapterTests.cs