### PR TITLE
[SlackAdapter] Add helper class

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapter.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         {
             this.options = options;
 
-            if (this.options.VerificationToken != null && this.options.ClientSigningSecret != null)
+            if (string.IsNullOrEmpty(this.options.VerificationToken) && string.IsNullOrEmpty(this.options.ClientSigningSecret))
             {
                 string warning =
                     "****************************************************************************************" +
@@ -265,7 +265,8 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                 // Create an Activity based on the incoming message from Slack.
                 // There are a few different types of event that Slack might send.
                 StreamReader sr = new StreamReader(request.Body);
-                dynamic slackEvent = JsonConvert.DeserializeObject(sr.ReadToEnd());
+                var body = sr.ReadToEnd();
+                dynamic slackEvent = JsonConvert.DeserializeObject(body);
 
                 if (slackEvent.type == "url_verification")
                 {
@@ -275,7 +276,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                     await response.WriteAsync(text);
                 }
 
-                if (!SlackHelper.VerifySignature(options.ClientSigningSecret, request))
+                if (!SlackHelper.VerifySignature(options.ClientSigningSecret, request, body))
                 {
                     response.StatusCode = 401;
                 }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
@@ -1,0 +1,108 @@
+﻿// Copyright(c) Microsoft Corporation.All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Bot.Schema;
+
+namespace Microsoft.Bot.Builder.Adapters.Slack
+{
+    internal static class SlackHelper
+    {
+        /// <summary>
+        /// Formats a BotBuilder activity into an outgoing Slack message.
+        /// </summary>
+        /// <param name="activity">A BotBuilder Activity object.</param>
+        /// <returns>A Slack message object with {text, attachments, channel, thread ts} as well as any fields found in activity.channelData.</returns>
+        public static NewSlackMessage ActivityToSlack(Activity activity)
+        {
+            var message = new NewSlackMessage();
+
+            if (activity.Timestamp != null)
+            {
+                message.ts = activity.Timestamp.Value.DateTime;
+            }
+
+            message.text = activity.Text;
+
+            foreach (var att in activity.Attachments)
+            {
+                var newAttachment = new SlackAPI.Attachment()
+                {
+                    author_name = att.Name,
+                    thumb_url = att.ThumbnailUrl,
+                };
+                message.attachments.Add(newAttachment);
+            }
+
+            message.channel = activity.Conversation.Id;
+
+            if (!string.IsNullOrEmpty(activity.Conversation.Properties["thread_ts"].ToString()))
+            {
+                message.ThreadTS = activity.Conversation.Properties["thread_ts"].ToString();
+            }
+
+            // if channelData is specified, overwrite any fields in message object
+            if (activity.ChannelData != null)
+            {
+                try
+                {
+                    // Try a straight up cast
+                    message = activity.ChannelData as NewSlackMessage;
+                }
+                catch (InvalidCastException)
+                {
+                    foreach (var property in message.GetType().GetFields())
+                    {
+                        var name = property.Name;
+                        var value = (activity.ChannelData as dynamic)[name];
+                        if (value != null)
+                        {
+                            message.GetType().GetField(name).SetValue(message, value);
+                        }
+                    }
+                }
+            }
+
+            // should this message be sent as an ephemeral message
+            if (message.Ephemeral != null)
+            {
+                message.user = activity.Recipient.Id;
+            }
+
+            if (message.IconUrl != null || message.icons?.status_emoji != null || message.username != null)
+            {
+                message.AsUser = false;
+            }
+
+            return message;
+        }
+
+        /// <summary>
+        /// Validates the local secret against the one obtained from the request header.
+        /// </summary>
+        /// <param name="secret">The local stored secret.</param>
+        /// <param name="request">The <see cref="HttpRequest"/> with the signature.</param>
+        /// <returns>The result of the comparison between the signature in the request and hashed secret.</returns>
+        public static bool VerifySignature(string secret, HttpRequest request)
+        {
+            var timestamp = request.Headers;
+            var body = request.Body;
+
+            object[] signature = { "v0", timestamp.ToString(), body.ToString() };
+
+            var baseString = string.Join(":", signature);
+
+            using (var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret)))
+            {
+                var hash = "v0=" + hmac.ComputeHash(Encoding.UTF8.GetBytes(baseString));
+
+                var retrievedSignature = request.Headers["X-Slack-Signature"];
+
+                return hash == retrievedSignature;
+            }
+        }
+    }
+}

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.TestBot/ConfigurationSlackAdapterOptions.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.TestBot/ConfigurationSlackAdapterOptions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.TestBot
     public class ConfigurationSlackAdapterOptions : SimpleSlackAdapterOptions
     {
         public ConfigurationSlackAdapterOptions(IConfiguration configuration)
-             : base(configuration["VerificationToken"], configuration["BotToken"])
+             : base(configuration["VerificationToken"], configuration["BotToken"], configuration["SigningSecret"])
         {
         }
     }

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.TestBot/SimpleSlackAdapterOptions.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.TestBot/SimpleSlackAdapterOptions.cs
@@ -8,10 +8,11 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.TestBot
         {
         }
 
-        public SimpleSlackAdapterOptions(string verificationToken, string botToken)
+        public SimpleSlackAdapterOptions(string verificationToken, string botToken, string signingSecret)
         {
             this.VerificationToken = verificationToken;
             this.BotToken = botToken;
+            this.ClientSigningSecret = signingSecret;
         }
 
         public string VerificationToken { get; set; }

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.TestBot/appsettings.json
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.TestBot/appsettings.json
@@ -2,5 +2,6 @@
   "MicrosoftAppId": "",
   "MicrosoftAppPassword": "",
   "VerificationToken": "",
-  "BotToken": ""
+  "BotToken": "",
+  "SigningSecret": ""
 }

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.TestBot/appsettings.json
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.TestBot/appsettings.json
@@ -1,0 +1,6 @@
+{
+  "MicrosoftAppId": "",
+  "MicrosoftAppPassword": "",
+  "VerificationToken": "",
+  "BotToken": ""
+}


### PR DESCRIPTION
## Proposed Changes
- Add SlackHelper class to gather all auxiliary methods.

## Detailed Changes
- Create SlackHelper class and move ActivityToSlack and VerifySignature methods in it.
- Remove ActivityToSlack and VerifySignature methods from SlackAdapter class
- Refactor VerifySignature method to adjust it to use the SigningSecret instead of the deprecated [VerificationToken](https://api.slack.com/docs/verifying-requests-from-slack)
- Adjust the setting of TestBot credentials to use the Signing Secret.