### PR TITLE
[WebexAdapter] Apply new feedback

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
@@ -15,8 +15,6 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
 {
     public class WebexAdapter : BotAdapter
     {
-        private readonly WebexAdapterOptions _config;
-
         private readonly WebexClientWrapper _webexClient;
 
         /// <summary>
@@ -25,153 +23,11 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// </summary>
         /// <param name="config">An object containing API credentials, a webhook verification token and other options.</param>
         /// <param name="webexClient">A Webex API interface.</param>
-        public WebexAdapter(WebexAdapterOptions config, WebexClientWrapper webexClient)
+        public WebexAdapter(WebexClientWrapper webexClient)
         {
-            _config = config ?? throw new ArgumentNullException(nameof(config));
-
-            if (string.IsNullOrWhiteSpace(_config.AccessToken))
-            {
-                throw new Exception("AccessToken required to create controller");
-            }
-
-            if (_config.PublicAddress == null)
-            {
-                throw new Exception("PublicAddress parameter required to receive webhooks");
-            }
-
             _webexClient = webexClient ?? throw new Exception("Could not create the Webex Teams API client");
 
-            _webexClient.CreateClient(_config.AccessToken);
-        }
-
-        /// <summary>
-        /// Gets the identity of the bot.
-        /// </summary>
-        /// <value>
-        /// The identity of the bot.
-        /// </value>
-        public Person Identity { get; private set; }
-
-        /// <summary>
-        /// Load the bot's identity via the WebEx API.
-        /// MUST be called by BotBuilder bots in order to filter messages sent by the bot.
-        /// </summary>
-        /// <param name="cancellationToken">A cancellation token for the task.</param>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task GetIdentityAsync(CancellationToken cancellationToken)
-        {
-            await _webexClient.GetMeAsync(cancellationToken).ContinueWith(
-                task => { Identity = task.Result; }, TaskScheduler.Current).ConfigureAwait(false);
-
-            var id = Identity.Id;
-        }
-
-        /// <summary>
-        /// Lists all webhook subscriptions currently associated with this application.
-        /// </summary>
-        /// <param name="cancellationToken">A cancellation token for the task.</param>
-        /// <returns>A list of webhook subscriptions.</returns>
-        public async Task<WebhookList> ListWebhookSubscriptionsAsync(CancellationToken cancellationToken)
-        {
-            return await _webexClient.ListWebhooksAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Clears out and resets the list of webhook subscriptions.
-        /// </summary>
-        /// <param name="webhookList">List of webhook subscriptions to be deleted.</param>
-        /// <param name="cancellationToken">A cancellation token for the task.</param>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task ResetWebhookSubscriptionsAsync(WebhookList webhookList, CancellationToken cancellationToken)
-        {
-            for (var i = 0; i < webhookList.ItemCount; i++)
-            {
-                await _webexClient.DeleteWebhookAsync(webhookList.Items[i], cancellationToken).ConfigureAwait(false);
-            }
-        }
-
-        /// <summary>
-        /// Register webhook subscriptions to start receiving message events and adaptive cards events.
-        /// </summary>
-        /// <param name="webhookPath">The path of the webhook endpoint like '/api/messages'.</param>
-        /// <param name="cancellationToken">A cancellation token for the task.</param>
-        /// <returns>An array of registered <see cref="Webhook"/>.</returns>
-        public async Task<Webhook[]> RegisterWebhookSubscriptionsAsync(string webhookPath = "api/messages", CancellationToken cancellationToken = default)
-        {
-            var webHookName = string.IsNullOrWhiteSpace(_config.WebhookName) ? "Webex Firehose" : _config.WebhookName;
-            var webHookCardsName = string.IsNullOrWhiteSpace(_config.WebhookName) ? "Webex AttachmentActions" : $"{_config.WebhookName}_AttachmentActions)";
-
-            var webhookList = await ListWebhookSubscriptionsAsync(cancellationToken).ConfigureAwait(false);
-
-            string webhookId = null;
-            string webhookCardsId = null;
-
-            for (var i = 0; i < webhookList.ItemCount; i++)
-            {
-                if (webhookList.Items[i].Name == webHookName)
-                {
-                    webhookId = webhookList.Items[i].Id;
-                }
-                else if (webhookList.Items[i].Name == webHookCardsName)
-                {
-                    webhookCardsId = webhookList.Items[i].Id;
-                }
-            }
-
-            var webhookUrl = new Uri(_config.PublicAddress + webhookPath);
-
-            var webhook = await RegisterWebhookSubscriptionAsync(webhookId, webHookName, webhookUrl, cancellationToken).ConfigureAwait(false);
-            var cardsWebhook = await RegisterAdaptiveCardsWebhookSubscriptionAsync(webhookCardsId, webHookCardsName, webhookUrl, cancellationToken).ConfigureAwait(false);
-
-            return new[] { webhook, cardsWebhook };
-        }
-
-        /// <summary>
-        /// Register a webhook subscription with Webex Teams to start receiving message events.
-        /// </summary>
-        /// <param name="hookId">The id of the webhook to be registered.</param>
-        /// <param name="webHookName">The name of the webhook to be registered.</param>
-        /// <param name="webhookUrl">The Uri of the webhook.</param>
-        /// <param name="cancellationToken">A cancellation token for the task.</param>
-        /// <returns>The registered <see cref="Webhook"/>.</returns>
-        public async Task<Webhook> RegisterWebhookSubscriptionAsync(string hookId, string webHookName, Uri webhookUrl, CancellationToken cancellationToken)
-        {
-            Webhook webhook;
-
-            if (hookId != null)
-            {
-                webhook = await _webexClient.UpdateWebhookAsync(hookId, webHookName, webhookUrl, _config.Secret, cancellationToken).ConfigureAwait(false);
-            }
-            else
-            {
-                webhook = await _webexClient.CreateWebhookAsync(webHookName, webhookUrl, EventResource.All, EventType.All, null, _config.Secret, cancellationToken).ConfigureAwait(false);
-            }
-
-            return webhook;
-        }
-
-        /// <summary>
-        /// Register a webhook subscription with Webex Teams to start receiving events related to adaptive cards.
-        /// </summary>
-        /// <param name="hookId">The id of the webhook to be registered.</param>
-        /// <param name="webHookName">The name of the webhook to be registered.</param>
-        /// <param name="webhookUrl">The Uri of the webhook.</param>
-        /// <param name="cancellationToken">A cancellation token for the task.</param>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<Webhook> RegisterAdaptiveCardsWebhookSubscriptionAsync(string hookId, string webHookName, Uri webhookUrl, CancellationToken cancellationToken)
-        {
-            Webhook webhook;
-
-            if (hookId != null)
-            {
-                webhook = await _webexClient.UpdateAdaptiveCardsWebhookAsync(hookId, webHookName, webhookUrl, _config.Secret, _config.AccessToken, cancellationToken).ConfigureAwait(false);
-            }
-            else
-            {
-                webhook = await _webexClient.CreateAdaptiveCardsWebhookAsync(webHookName, webhookUrl, EventType.All, _config.Secret, _config.AccessToken, cancellationToken).ConfigureAwait(false);
-            }
-
-            return webhook;
+            _webexClient.InitAsync().ConfigureAwait(false);
         }
 
         /// <summary>
@@ -216,7 +72,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
                 {
                     if (activity.Attachments[0].ContentType == "application/vnd.microsoft.card.adaptive")
                     {
-                        responseId = await _webexClient.CreateMessageWithAttachmentsAsync(personIdOrEmail, activity.Text, activity.Attachments, _config.AccessToken, cancellationToken).ConfigureAwait(false);
+                        responseId = await _webexClient.CreateMessageWithAttachmentsAsync(personIdOrEmail, activity.Text, activity.Attachments, cancellationToken).ConfigureAwait(false);
                     }
                     else
                     {
@@ -322,7 +178,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
                 throw new ArgumentNullException(nameof(bot));
             }
 
-            await GetIdentityAsync(cancellationToken).ConfigureAwait(false);
+            await _webexClient.GetIdentityAsync(cancellationToken).ConfigureAwait(false);
 
             WebhookEventData payload;
             string json;
@@ -333,12 +189,9 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
                 payload = JsonConvert.DeserializeObject<WebhookEventData>(json);
             }
 
-            if (!string.IsNullOrWhiteSpace(_config.Secret))
+            if (!_webexClient.ValidateSignature(request, json))
             {
-                if (!WebexHelper.ValidateSignature(_config.Secret, request, json))
-                {
-                    throw new Exception("WARNING: Webhook received message with invalid signature. Potential malicious behavior!");
-                }
+                throw new Exception("WARNING: Webhook received message with invalid signature. Potential malicious behavior!");
             }
 
             Activity activity;
@@ -347,7 +200,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
             {
                 var decryptedMessage = await WebexHelper.GetDecryptedMessageAsync(payload, _webexClient.GetMessageAsync, cancellationToken).ConfigureAwait(false);
 
-                activity = WebexHelper.DecryptedMessageToActivity(decryptedMessage, Identity);
+                activity = WebexHelper.DecryptedMessageToActivity(decryptedMessage, _webexClient.Identity);
             }
             else if (payload.Resource.Name == "attachmentActions" && payload.EventType == EventType.Created)
             {
@@ -357,13 +210,13 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
 
                 var jsongData = JsonConvert.DeserializeObject<AttachmentActionData>(data);
 
-                var decryptedMessage = await _webexClient.GetAttachmentActionAsync(jsongData.Id, _config.AccessToken, cancellationToken).ConfigureAwait(false);
+                var decryptedMessage = await _webexClient.GetAttachmentActionAsync(jsongData.Id, cancellationToken).ConfigureAwait(false);
 
-                activity = WebexHelper.AttachmentActionToActivity(decryptedMessage, Identity);
+                activity = WebexHelper.AttachmentActionToActivity(decryptedMessage, _webexClient.Identity);
             }
             else
             {
-                activity = WebexHelper.PayloadToActivity(payload, Identity);
+                activity = WebexHelper.PayloadToActivity(payload, _webexClient.Identity);
             }
 
             using (var context = new TurnContext(this, activity))

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
@@ -34,12 +34,10 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
                 throw new Exception("AccessToken required to create controller");
             }
 
-            if (string.IsNullOrWhiteSpace(_config.PublicAddress))
+            if (_config.PublicAddress == null)
             {
                 throw new Exception("PublicAddress parameter required to receive webhooks");
             }
-
-            _config.PublicAddress = new Uri(_config.PublicAddress).Host;
 
             _webexClient = webexClient ?? throw new Exception("Could not create the Webex Teams API client");
 
@@ -109,7 +107,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
                 }
             }
 
-            var hookUrl = "https://" + _config.PublicAddress + webhookPath;
+            var hookUrl = _config.PublicAddress + webhookPath;
 
             Webhook webhook;
             Webhook cardsWebhook;

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// </summary>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A list of webhook subscriptions.</returns>
-        public async Task<WebhookList> ListWebhookSubscriptionsAsync(CancellationToken cancellationToken = default)
+        public async Task<WebhookList> ListWebhookSubscriptionsAsync(CancellationToken cancellationToken)
         {
             return await _webexClient.ListWebhooksAsync(cancellationToken).ConfigureAwait(false);
         }
@@ -82,7 +82,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="webhookList">List of webhook subscriptions to be deleted.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task ResetWebhookSubscriptionsAsync(WebhookList webhookList, CancellationToken? cancellationToken = null)
+        public async Task ResetWebhookSubscriptionsAsync(WebhookList webhookList, CancellationToken cancellationToken)
         {
             for (var i = 0; i < webhookList.ItemCount; i++)
             {
@@ -101,7 +101,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
             var webHookName = string.IsNullOrWhiteSpace(_config.WebhookName) ? "Webex Firehose" : _config.WebhookName;
             var webHookCardsName = string.IsNullOrWhiteSpace(_config.WebhookName) ? "Webex AttachmentActions" : $"{_config.WebhookName}_AttachmentActions)";
 
-            var webhookList = await ListWebhookSubscriptionsAsync().ConfigureAwait(false);
+            var webhookList = await ListWebhookSubscriptionsAsync(cancellationToken).ConfigureAwait(false);
 
             string webhookId = null;
             string webhookCardsId = null;
@@ -305,7 +305,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="bot">A bot with logic function in the form.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task ProcessAsync(HttpRequest request, HttpResponse response, IBot bot, CancellationToken cancellationToken = default)
+        public async Task ProcessAsync(HttpRequest request, HttpResponse response, IBot bot, CancellationToken cancellationToken)
         {
             if (request == null)
             {

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapterOptions.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapterOptions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright(c) Microsoft Corporation.All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+
 namespace Microsoft.Bot.Builder.Adapters.Webex
 {
     /// <summary>
@@ -15,7 +17,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="publicAddress">The root URL of the bot application.</param>
         /// <param name="secret">The secret used to validate incoming webhooks.</param>
         /// <param name="webhookName">A name for the webhook subscription.</param>
-        public WebexAdapterOptions(string accessToken, string publicAddress, string secret, string webhookName = null)
+        public WebexAdapterOptions(string accessToken, Uri publicAddress, string secret, string webhookName = null)
         {
             AccessToken = accessToken;
             PublicAddress = publicAddress;
@@ -36,10 +38,10 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         public string Secret { get; set; }
 
         /// <summary>
-        /// Gets or sets the root URL of your bot application. Something like 'https://mybot.com/'.
+        /// Gets or sets the root URI of your bot application. Something like 'https://mybot.com/'.
         /// </summary>
-        /// <value>the root URL of your bot application.</value>
-        public string PublicAddress { get; set; }
+        /// <value>the root URI of your bot application.</value>
+        public Uri PublicAddress { get; set; }
 
         /// <summary>
         /// Gets or sets a name for the webhook subscription that will be created to tell WebEx to send your bot webhooks.

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexClientWrapper.cs
@@ -290,35 +290,17 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
             newStream.Write(bytes, 0, bytes.Length);
             newStream.Close();
 
-            using (cancellationToken.Register(() => http.Abort(), useSynchronizationContext: false))
+            var response = await http.GetResponseAsync().ConfigureAwait(false);
+
+            var stream = response.GetResponseStream();
+
+            using (var sr = new StreamReader(stream))
             {
-                try
-                {
-                    var response = await http.GetResponseAsync().ConfigureAwait(false);
-
-                    var stream = response.GetResponseStream();
-
-                    using (var sr = new StreamReader(stream))
-                    {
-                        var content = sr.ReadToEnd();
-                        result = JsonConvert.DeserializeObject<Message>(content);
-                    }
-
-                    return result.Id;
-                }
-                catch (WebException ex)
-                {
-                    // WebException is thrown when request.Abort() is called,
-                    // but there may be many other reasons
-                    if (cancellationToken.IsCancellationRequested)
-                    {
-                        throw new OperationCanceledException(ex.Message, ex, cancellationToken);
-                    }
-
-                    // cancellation hasn't been requested, rethrow the original WebException
-                    throw;
-                }
+                var content = sr.ReadToEnd();
+                result = JsonConvert.DeserializeObject<Message>(content);
             }
+
+            return result.Id;
         }
 
         /// <summary>
@@ -338,35 +320,17 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
             http.Headers.Add("Authorization", "Bearer " + _config.AccessToken);
             http.Method = "GET";
 
-            using (cancellationToken.Register(() => http.Abort(), useSynchronizationContext: false))
+            var response = await http.GetResponseAsync().ConfigureAwait(false);
+
+            var stream = response.GetResponseStream();
+
+            using (var sr = new StreamReader(stream))
             {
-                try
-                {
-                    var response = await http.GetResponseAsync().ConfigureAwait(false);
-
-                    var stream = response.GetResponseStream();
-
-                    using (var sr = new StreamReader(stream))
-                    {
-                        var content = sr.ReadToEnd();
-                        result = JsonConvert.DeserializeObject<Message>(content);
-                    }
-
-                    return result;
-                }
-                catch (WebException ex)
-                {
-                    // WebException is thrown when request.Abort() is called,
-                    // but there may be many other reasons
-                    if (cancellationToken.IsCancellationRequested)
-                    {
-                        throw new OperationCanceledException(ex.Message, ex, cancellationToken);
-                    }
-
-                    // cancellation hasn't been requested, rethrow the original WebException
-                    throw;
-                }
+                var content = sr.ReadToEnd();
+                result = JsonConvert.DeserializeObject<Message>(content);
             }
+
+            return result;
         }
 
         /// <summary>
@@ -477,29 +441,11 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
             {
                 client.Headers[HttpRequestHeader.Authorization] = "Bearer " + token;
 
-                using (cancellationToken.Register(() => client.CancelAsync(), useSynchronizationContext: false))
-                {
-                    try
-                    {
-                        var response = await client.UploadValuesTaskAsync(new Uri(url), "POST", data).ConfigureAwait(false);
+                var response = await client.UploadValuesTaskAsync(new Uri(url), "POST", data).ConfigureAwait(false);
 
-                        result = JsonConvert.DeserializeObject<Webhook>(Encoding.ASCII.GetString(response));
+                result = JsonConvert.DeserializeObject<Webhook>(Encoding.ASCII.GetString(response));
 
-                        return result;
-                    }
-                    catch (WebException ex)
-                    {
-                        // WebException is thrown when request.Abort() is called,
-                        // but there may be many other reasons
-                        if (cancellationToken.IsCancellationRequested)
-                        {
-                            throw new OperationCanceledException(ex.Message, ex, cancellationToken);
-                        }
-
-                        // cancellation hasn't been requested, rethrow the original WebException
-                        throw;
-                    }
-                }
+                return result;
             }
         }
 
@@ -531,29 +477,11 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
             {
                 client.Headers[HttpRequestHeader.Authorization] = "Bearer " + token;
 
-                using (cancellationToken.Register(() => client.CancelAsync(), useSynchronizationContext: false))
-                {
-                    try
-                    {
-                        var response = await client.UploadValuesTaskAsync(new Uri(url), "PUT", data).ConfigureAwait(false);
+                var response = await client.UploadValuesTaskAsync(new Uri(url), "PUT", data).ConfigureAwait(false);
 
-                        result = JsonConvert.DeserializeObject<Webhook>(Encoding.ASCII.GetString(response));
+                result = JsonConvert.DeserializeObject<Webhook>(Encoding.ASCII.GetString(response));
 
-                        return result;
-                    }
-                    catch (WebException ex)
-                    {
-                        // WebException is thrown when request.Abort() is called,
-                        // but there may be many other reasons
-                        if (cancellationToken.IsCancellationRequested)
-                        {
-                            throw new OperationCanceledException(ex.Message, ex, cancellationToken);
-                        }
-
-                        // cancellation hasn't been requested, rethrow the original WebException
-                        throw;
-                    }
-                }
+                return result;
             }
         }
 

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexClientWrapper.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="files">List of files attached to the message.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>The created message id.</returns>
-        public virtual async Task<string> CreateMessageAsync(string toPersonOrEmail, string text, IList<Uri> files = null, CancellationToken? cancellationToken = null)
+        public virtual async Task<string> CreateMessageAsync(string toPersonOrEmail, string text, IList<Uri> files = null, CancellationToken cancellationToken = default)
         {
             var webexResponse = await _api.CreateDirectMessageAsync(toPersonOrEmail, text, files, cancellationToken: cancellationToken).ConfigureAwait(false);
 
@@ -54,7 +54,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="messageId">The id of the message to be deleted.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public virtual async Task DeleteMessageAsync(string messageId, CancellationToken? cancellationToken = null)
+        public virtual async Task DeleteMessageAsync(string messageId, CancellationToken cancellationToken)
         {
             await _api.DeleteMessageAsync(messageId, cancellationToken).ConfigureAwait(false);
         }
@@ -187,7 +187,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// </summary>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>The <see cref="Person"/> object associated with the bot.</returns>
-        public virtual async Task<Person> GetMeAsync(CancellationToken? cancellationToken = null)
+        public virtual async Task<Person> GetMeAsync(CancellationToken cancellationToken)
         {
             var resultPerson = await _api.GetMeAsync(cancellationToken).ConfigureAwait(false);
 
@@ -199,7 +199,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// </summary>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>The <see cref="Person"/> object associated with the bot, from cache.</returns>
-        public virtual async Task<CachedPerson> GetMeFromCacheAsync(CancellationToken? cancellationToken = null)
+        public virtual async Task<CachedPerson> GetMeFromCacheAsync(CancellationToken cancellationToken)
         {
             var resultPerson = await _api.GetMeFromCacheAsync(cancellationToken).ConfigureAwait(false);
 
@@ -212,7 +212,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="messageId">Id of the message to be recovered.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>The message's data.</returns>
-        public virtual async Task<Message> GetMessageAsync(string messageId, CancellationToken? cancellationToken = null)
+        public virtual async Task<Message> GetMessageAsync(string messageId, CancellationToken cancellationToken)
         {
             var message = await _api.GetMessageAsync(messageId, cancellationToken).ConfigureAwait(false);
 
@@ -225,7 +225,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="webhook"><see cref="Webhook"/> to be activated.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>The Activated <see cref="Webhook"/>.</returns>
-        public virtual async Task<Webhook> ActivateWebhookAsync(Webhook webhook, CancellationToken? cancellationToken = null)
+        public virtual async Task<Webhook> ActivateWebhookAsync(Webhook webhook, CancellationToken cancellationToken)
         {
             var resultWebhook = await _api.ActivateWebhookAsync(webhook, cancellationToken).ConfigureAwait(false);
 
@@ -237,7 +237,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// </summary>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A list of Webhooks associated with the application.</returns>
-        public virtual async Task<WebhookList> ListWebhooksAsync(CancellationToken? cancellationToken = null)
+        public virtual async Task<WebhookList> ListWebhooksAsync(CancellationToken cancellationToken)
         {
             var webhookList = await _api.ListWebhooksAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
 
@@ -255,7 +255,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="secret">Secret used to validate the webhook.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>The created <see cref="Webhook"/>.</returns>
-        public virtual async Task<Webhook> CreateWebhookAsync(string name, Uri targetUri, EventResource resource, EventType type, IEnumerable<EventFilter> filters, string secret, CancellationToken? cancellationToken = null)
+        public virtual async Task<Webhook> CreateWebhookAsync(string name, Uri targetUri, EventResource resource, EventType type, IEnumerable<EventFilter> filters, string secret, CancellationToken cancellationToken)
         {
             var resultWebhook = await _api.CreateWebhookAsync(name, targetUri, resource, type, null, secret, cancellationToken: cancellationToken).ConfigureAwait(false);
 
@@ -376,7 +376,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="webhookId">The id of the Webhook to get.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>The requested Webhook.</returns>
-        public virtual async Task<Webhook> GetWebhookAsync(string webhookId, CancellationToken? cancellationToken = null)
+        public virtual async Task<Webhook> GetWebhookAsync(string webhookId, CancellationToken cancellationToken)
         {
             var resultWebhook = await _api.GetWebhookAsync(webhookId, cancellationToken).ConfigureAwait(false);
 
@@ -389,7 +389,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="id">Id of the webhook to be deleted.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public virtual async Task DeleteWebhookAsync(Webhook id, CancellationToken? cancellationToken = null)
+        public virtual async Task DeleteWebhookAsync(Webhook id, CancellationToken cancellationToken)
         {
             await _api.DeleteWebhookAsync(id, cancellationToken).ConfigureAwait(false);
         }
@@ -403,7 +403,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="secret">Secret used to validate the webhook.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>The updated <see cref="Webhook"/>.</returns>
-        public virtual async Task<Webhook> UpdateWebhookAsync(string webhookId, string name, Uri targetUri, string secret, CancellationToken? cancellationToken = null)
+        public virtual async Task<Webhook> UpdateWebhookAsync(string webhookId, string name, Uri targetUri, string secret, CancellationToken cancellationToken)
         {
             var resultWebhook = await _api.UpdateWebhookAsync(webhookId, name, targetUri, secret, cancellationToken: cancellationToken).ConfigureAwait(false);
 
@@ -417,7 +417,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="teamId">The ID for the team with which this room is associated.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>The space created.</returns>
-        public virtual async Task<Space> CreateSpaceAsync(string title, string teamId = null, CancellationToken? cancellationToken = null)
+        public virtual async Task<Space> CreateSpaceAsync(string title, string teamId = null, CancellationToken cancellationToken = default)
         {
             var resultSpace = await _api.CreateSpaceAsync(title, teamId, cancellationToken).ConfigureAwait(false);
 
@@ -433,7 +433,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="personIdType"><see cref="PersonIdType"/> for personIdOrEmail parameter.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>The resulting space membership.</returns>
-        public virtual async Task<SpaceMembership> CreateSpaceMembershipAsync(string spaceId, string personIdOrEmail, bool? isModerator = null, PersonIdType personIdType = PersonIdType.Detect, CancellationToken? cancellationToken = null)
+        public virtual async Task<SpaceMembership> CreateSpaceMembershipAsync(string spaceId, string personIdOrEmail, bool? isModerator = null, PersonIdType personIdType = PersonIdType.Detect, CancellationToken cancellationToken = default)
         {
             var resultSpaceMembership = await _api.CreateSpaceMembershipAsync(spaceId, personIdOrEmail, isModerator, personIdType, cancellationToken).ConfigureAwait(false);
 
@@ -446,7 +446,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="spaceId">The id of the space to be deleted.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public virtual async Task DeleteSpaceAsync(string spaceId, CancellationToken? cancellationToken = null)
+        public virtual async Task DeleteSpaceAsync(string spaceId, CancellationToken cancellationToken)
         {
             await _api.DeleteSpaceAsync(spaceId, cancellationToken).ConfigureAwait(false);
         }
@@ -457,7 +457,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="membershipId">The id of the membership to be deleted.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public virtual async Task DeleteSpaceMembershipAsync(string membershipId, CancellationToken? cancellationToken = null)
+        public virtual async Task DeleteSpaceMembershipAsync(string membershipId, CancellationToken cancellationToken)
         {
             await _api.DeleteSpaceMembershipAsync(membershipId, cancellationToken).ConfigureAwait(false);
         }
@@ -468,7 +468,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="spaceId">The id of the space to be gotten.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>The space requested.</returns>
-        public virtual async Task<Space> GetSpaceAsync(string spaceId, CancellationToken? cancellationToken = null)
+        public virtual async Task<Space> GetSpaceAsync(string spaceId, CancellationToken cancellationToken)
         {
             var resultSpace = await _api.GetSpaceAsync(spaceId, cancellationToken).ConfigureAwait(false);
             return resultSpace.GetData(false);
@@ -480,7 +480,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="membershipId">The id of the membership to get.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>The requested space membership.</returns>
-        public virtual async Task<SpaceMembership> GetSpaceMembershipAsync(string membershipId, CancellationToken? cancellationToken = null)
+        public virtual async Task<SpaceMembership> GetSpaceMembershipAsync(string membershipId, CancellationToken cancellationToken)
         {
             var resultSpaceMembership = await _api.GetSpaceMembershipAsync(membershipId, cancellationToken).ConfigureAwait(false);
 
@@ -496,7 +496,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="max">Limit the maximum number of messages in the response.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A list of the spaces.</returns>
-        public virtual async Task<SpaceList> ListSpacesAsync(string teamId = null, SpaceType type = null, SpaceSortBy sortBy = null, int? max = null, CancellationToken? cancellationToken = null)
+        public virtual async Task<SpaceList> ListSpacesAsync(string teamId = null, SpaceType type = null, SpaceSortBy sortBy = null, int? max = null, CancellationToken cancellationToken = default)
         {
             var resultSpaceList = await _api.ListSpacesAsync(teamId, type, sortBy, max, cancellationToken).ConfigureAwait(false);
 
@@ -512,7 +512,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="personIdType"><see cref="PersonIdType"/> for personIdOrEmail parameter.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>The space memberships list.</returns>
-        public virtual async Task<SpaceMembershipList> ListSpaceMembershipsAsync(string spaceId = null, string personIdOrEmail = null, int? max = null, PersonIdType personIdType = PersonIdType.Detect, CancellationToken? cancellationToken = null)
+        public virtual async Task<SpaceMembershipList> ListSpaceMembershipsAsync(string spaceId = null, string personIdOrEmail = null, int? max = null, PersonIdType personIdType = PersonIdType.Detect, CancellationToken cancellationToken = default)
         {
             var resultSpaceMembershipsList = await _api.ListSpaceMembershipsAsync(spaceId, personIdOrEmail, max, personIdType, cancellationToken).ConfigureAwait(false);
 
@@ -526,7 +526,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="title">A user-friendly name for the space.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>The updated space.</returns>
-        public virtual async Task<Space> UpdateSpaceAsync(string spaceId, string title, CancellationToken? cancellationToken = null)
+        public virtual async Task<Space> UpdateSpaceAsync(string spaceId, string title, CancellationToken cancellationToken)
         {
             var resultSpace = await _api.UpdateSpaceAsync(spaceId, title, cancellationToken).ConfigureAwait(false);
 
@@ -540,7 +540,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="isModerator">Set to true to make the person a space moderator.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>The updated space membership.</returns>
-        public virtual async Task<SpaceMembership> UpdateSpaceMembershipAsync(string membershipId, bool isModerator, CancellationToken? cancellationToken = null)
+        public virtual async Task<SpaceMembership> UpdateSpaceMembershipAsync(string membershipId, bool isModerator, CancellationToken cancellationToken)
         {
             var resultSpaceMembership = await _api.UpdateSpaceMembershipAsync(membershipId, isModerator, cancellationToken).ConfigureAwait(false);
 
@@ -553,7 +553,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="name">A user-friendly name for the team.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>The created team.</returns>
-        public virtual async Task<Team> CreateTeamAsync(string name, CancellationToken? cancellationToken = null)
+        public virtual async Task<Team> CreateTeamAsync(string name, CancellationToken cancellationToken)
         {
             var resultTeam = await _api.CreateTeamAsync(name, cancellationToken).ConfigureAwait(false);
 
@@ -569,7 +569,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="personIdType"><see cref="PersonIdType"/> for personIdOrEmail parameter.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>The team membership created.</returns>
-        public virtual async Task<TeamMembership> CreateTeamMembershipAsync(string teamId, string personIdOrEmail, bool? isModerator = null, PersonIdType personIdType = PersonIdType.Detect, CancellationToken? cancellationToken = null)
+        public virtual async Task<TeamMembership> CreateTeamMembershipAsync(string teamId, string personIdOrEmail, bool? isModerator = null, PersonIdType personIdType = PersonIdType.Detect, CancellationToken cancellationToken = default)
         {
             var resultTeamMembership = await _api.CreateTeamMembershipAsync(teamId, personIdOrEmail, isModerator, personIdType, cancellationToken).ConfigureAwait(false);
 
@@ -582,7 +582,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="teamId">Team id to be deleted.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public virtual async Task DeleteTeamAsync(string teamId, CancellationToken? cancellationToken = null)
+        public virtual async Task DeleteTeamAsync(string teamId, CancellationToken cancellationToken)
         {
             await _api.DeleteTeamAsync(teamId, cancellationToken).ConfigureAwait(false);
         }
@@ -593,7 +593,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="membershipId">Team Membership id to be deleted.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public virtual async Task DeleteTeamMembershipAsync(string membershipId, CancellationToken? cancellationToken = null)
+        public virtual async Task DeleteTeamMembershipAsync(string membershipId, CancellationToken cancellationToken)
         {
             await _api.DeleteTeamMembershipAsync(membershipId, cancellationToken).ConfigureAwait(false);
         }
@@ -604,7 +604,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="teamId">Team id that the detail info is gotten.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>The requested team.</returns>
-        public virtual async Task<Team> GetTeamAsync(string teamId, CancellationToken? cancellationToken = null)
+        public virtual async Task<Team> GetTeamAsync(string teamId, CancellationToken cancellationToken)
         {
             var resultTeam = await _api.GetTeamAsync(teamId, cancellationToken).ConfigureAwait(false);
 
@@ -617,7 +617,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="membershipId">Team Membership id that the detail info is gotten.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>The requested team membership.</returns>
-        public virtual async Task<TeamMembership> GetTeamMembershipAsync(string membershipId, CancellationToken? cancellationToken = null)
+        public virtual async Task<TeamMembership> GetTeamMembershipAsync(string membershipId, CancellationToken cancellationToken)
         {
             var resultTeamMembership = await _api.GetTeamMembershipAsync(membershipId, cancellationToken).ConfigureAwait(false);
 
@@ -631,7 +631,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="max">Limit the maximum number of items in the response.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A list of team memberships.</returns>
-        public virtual async Task<TeamMembershipList> ListTeamMembershipsAsync(string teamId, int? max = null, CancellationToken? cancellationToken = null)
+        public virtual async Task<TeamMembershipList> ListTeamMembershipsAsync(string teamId, int? max = null, CancellationToken cancellationToken = default)
         {
             var resultTeamMembershipList = await _api.ListTeamMembershipsAsync(teamId, max, cancellationToken).ConfigureAwait(false);
 
@@ -644,7 +644,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="max">Limit the maximum number of teams in the response.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A list of the teams.</returns>
-        public virtual async Task<TeamList> ListTeamsAsync(int? max = null, CancellationToken? cancellationToken = null)
+        public virtual async Task<TeamList> ListTeamsAsync(int? max = null, CancellationToken cancellationToken = default)
         {
             var resultTeamsList = await _api.ListTeamsAsync(max, cancellationToken).ConfigureAwait(false);
 
@@ -658,7 +658,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="name">A user-friendly name for the team.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>The updated team.</returns>
-        public virtual async Task<Team> UpdateTeamAsync(string teamId, string name, CancellationToken? cancellationToken = null)
+        public virtual async Task<Team> UpdateTeamAsync(string teamId, string name, CancellationToken cancellationToken)
         {
             var resultTeam = await _api.UpdateTeamAsync(teamId, name, cancellationToken).ConfigureAwait(false);
 
@@ -672,7 +672,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="isModerator">Set to true to make the person a team moderator.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>The updated team membership.</returns>
-        public virtual async Task<TeamMembership> UpdateTeamMembershipAsync(string membershipId, bool isModerator, CancellationToken? cancellationToken = null)
+        public virtual async Task<TeamMembership> UpdateTeamMembershipAsync(string membershipId, bool isModerator, CancellationToken cancellationToken)
         {
             var resultTeamMembership = await _api.UpdateTeamMembershipAsync(membershipId, isModerator, cancellationToken).ConfigureAwait(false);
 
@@ -685,7 +685,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="fileUri">Uri of the file.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>The teams file data.</returns>
-        public virtual async Task<TeamsFileData> GetFileDataAsync(Uri fileUri, CancellationToken? cancellationToken = null)
+        public virtual async Task<TeamsFileData> GetFileDataAsync(Uri fileUri, CancellationToken cancellationToken)
         {
             var resultTeamsFileData = await _api.GetFileDataAsync(fileUri, cancellationToken).ConfigureAwait(false);
 
@@ -698,7 +698,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="fileUri">Uri of the file.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>The teams file info.</returns>
-        public virtual async Task<TeamsFileInfo> GetFileInfoAsync(Uri fileUri, CancellationToken? cancellationToken = null)
+        public virtual async Task<TeamsFileInfo> GetFileInfoAsync(Uri fileUri, CancellationToken cancellationToken)
         {
             var resultTeamsFileInfo = await _api.GetFileInfoAsync(fileUri, cancellationToken).ConfigureAwait(false);
 
@@ -715,7 +715,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="max">Limit the maximum number of messages in the response.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A list of the messages.</returns>
-        public virtual async Task<MessageList> ListMessagesAsync(string spaceId, string mentionedPeople = null, DateTime? before = null, string beforeMessage = null, int? max = null, CancellationToken? cancellationToken = null)
+        public virtual async Task<MessageList> ListMessagesAsync(string spaceId, string mentionedPeople = null, DateTime? before = null, string beforeMessage = null, int? max = null, CancellationToken cancellationToken = default)
         {
             var resultMessageList = await _api.ListMessagesAsync(spaceId, mentionedPeople, before, beforeMessage, max, cancellationToken).ConfigureAwait(false);
 
@@ -731,7 +731,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="max">Limit the maximum number of people in the response.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A list with the requested people.</returns>
-        public virtual async Task<PersonList> ListPeopleAsync(string email = null, string displayName = null, IEnumerable<string> ids = null, int? max = null, CancellationToken? cancellationToken = null)
+        public virtual async Task<PersonList> ListPeopleAsync(string email = null, string displayName = null, IEnumerable<string> ids = null, int? max = null, CancellationToken cancellationToken = default)
         {
             var resultPersonList = await _api.ListPeopleAsync(email, displayName, ids, max, cancellationToken).ConfigureAwait(false);
 

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexClientWrapper.cs
@@ -39,12 +39,12 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
 
             if (string.IsNullOrWhiteSpace(_config.AccessToken))
             {
-                throw new Exception("AccessToken required to create controller");
+                throw new ArgumentException(nameof(config.AccessToken));
             }
 
             if (_config.PublicAddress == null)
             {
-                throw new Exception("PublicAddress parameter required to receive webhooks");
+                throw new ArgumentException(nameof(config.PublicAddress));
             }
         }
 

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexHelper.cs
@@ -25,14 +25,6 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
     internal static class WebexHelper
     {
         /// <summary>
-        /// Gets or sets the identity of the bot.
-        /// </summary>
-        /// <value>
-        /// The identity of the bot.
-        /// </value>
-        public static Person Identity { get; set; }
-
-        /// <summary>
         /// Validates the local secret against the one obtained from the request header.
         /// </summary>
         /// <param name="secret">The local stored secret.</param>
@@ -60,8 +52,9 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// Creates a <see cref="Activity"/> using the body of a request.
         /// </summary>
         /// <param name="payload">The payload obtained from the body of the request.</param>
+        /// <param name="identity">The identity of the bot.</param>
         /// <returns>An <see cref="Activity"/> object.</returns>
-        public static Activity PayloadToActivity(WebhookEventData payload)
+        public static Activity PayloadToActivity(WebhookEventData payload, Person identity)
         {
             if (payload == null)
             {
@@ -83,7 +76,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
                 },
                 Recipient = new ChannelAccount
                 {
-                    Id = Identity.Id,
+                    Id = identity.Id,
                 },
                 ChannelData = payload,
                 Type = ActivityTypes.Event,
@@ -118,8 +111,9 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// Converts a decrypted <see cref="Message"/> into an <see cref="Activity"/>.
         /// </summary>
         /// <param name="decryptedMessage">The decrypted message obtained from the body of the request.</param>
+        /// <param name="identity">The identity of the bot.</param>
         /// <returns>An <see cref="Activity"/> object.</returns>
-        public static Activity DecryptedMessageToActivity(Message decryptedMessage)
+        public static Activity DecryptedMessageToActivity(Message decryptedMessage, Person identity)
         {
             if (decryptedMessage == null)
             {
@@ -142,7 +136,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
                 },
                 Recipient = new ChannelAccount
                 {
-                    Id = Identity.Id,
+                    Id = identity.Id,
                 },
                 Text = !string.IsNullOrEmpty(decryptedMessage.Text) ? decryptedMessage.Text : string.Empty,
                 ChannelData = decryptedMessage,
@@ -150,7 +144,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
             };
 
             // this is the bot speaking
-            if (activity.From.Id == Identity.Id)
+            if (activity.From.Id == identity.Id)
             {
                 activity.Type = ActivityTypes.Event;
             }
@@ -158,11 +152,11 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
             if (decryptedMessage.HasHtml)
             {
                 // strip the mention & HTML from the message
-                var pattern = new Regex($"^(<p>)?<spark-mention .*?data-object-id=\"{Identity.Id}\".*?>.*?</spark-mention>", RegexOptions.IgnoreCase | RegexOptions.Multiline);
+                var pattern = new Regex($"^(<p>)?<spark-mention .*?data-object-id=\"{identity.Id}\".*?>.*?</spark-mention>", RegexOptions.IgnoreCase | RegexOptions.Multiline);
                 if (!decryptedMessage.Html.Equals(pattern))
                 {
                     // this should look like ciscospark://us/PEOPLE/<id string>
-                    var match = Regex.Match(Identity.Id, "/ciscospark://.*/(.*)", RegexOptions.IgnoreCase | RegexOptions.Multiline);
+                    var match = Regex.Match(identity.Id, "/ciscospark://.*/(.*)", RegexOptions.IgnoreCase | RegexOptions.Multiline);
                     if (match.Captures.Count > 0)
                     {
                         pattern = new Regex(
@@ -177,7 +171,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
             }
             else
             {
-                var pattern = new Regex("^" + Identity.DisplayName + "\\s+");
+                var pattern = new Regex("^" + identity.DisplayName + "\\s+");
                 activity.Text = activity.Text.Replace(pattern.ToString(), string.Empty);
             }
 
@@ -193,8 +187,9 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// Converts a decrypted related to an attachment action into an <see cref="Activity"/>.
         /// </summary>
         /// <param name="decryptedMessage">The decrypted message obtained from the body of the request.</param>
+        /// <param name="identity">The identity of the bot.</param>
         /// <returns>An <see cref="Activity"/> object.</returns>
-        public static Activity AttachmentActionToActivity(Message decryptedMessage)
+        public static Activity AttachmentActionToActivity(Message decryptedMessage, Person identity)
         {
             if (decryptedMessage == null)
             {
@@ -221,7 +216,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
                 },
                 Recipient = new ChannelAccount
                 {
-                    Id = Identity.Id,
+                    Id = identity.Id,
                 },
                 Text = !string.IsNullOrEmpty(decryptedMessage.Text) ? decryptedMessage.Text : string.Empty,
                 Value = messageExtraData.Inputs,

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexHelper.cs
@@ -25,30 +25,6 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
     internal static class WebexHelper
     {
         /// <summary>
-        /// Validates the local secret against the one obtained from the request header.
-        /// </summary>
-        /// <param name="secret">The local stored secret.</param>
-        /// <param name="request">The <see cref="HttpRequest"/> with the signature.</param>
-        /// <param name="json">The serialized payload to be use for comparison.</param>
-        /// <returns>The result of the comparison between the signature in the request and hashed json.</returns>
-        public static bool ValidateSignature(string secret, HttpRequest request, string json)
-        {
-            var signature = request.Headers.ContainsKey("x-spark-signature")
-                ? request.Headers["x-spark-signature"].ToString().ToUpperInvariant()
-                : throw new Exception("HttpRequest is missing \"x-spark-signature\"");
-
-            #pragma warning disable CA5350 // Webex API uses SHA1 as cryptographic algorithm.
-            using (var hmac = new HMACSHA1(Encoding.UTF8.GetBytes(secret)))
-            {
-                var hashArray = hmac.ComputeHash(Encoding.UTF8.GetBytes(json));
-                var hash = BitConverter.ToString(hashArray).Replace("-", string.Empty).ToUpperInvariant();
-
-                return signature == hash;
-            }
-            #pragma warning restore CA5350 // Webex API uses SHA1 as cryptographic algorithm.
-        }
-
-        /// <summary>
         /// Creates a <see cref="Activity"/> using the body of a request.
         /// </summary>
         /// <param name="payload">The payload obtained from the body of the request.</param>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexHelper.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="decrypterFunc">The function used to decrypt the message.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="Message"/> object.</returns>
-        public static async Task<Message> GetDecryptedMessageAsync(WebhookEventData payload, Func<string, CancellationToken?, Task<Message>> decrypterFunc, CancellationToken? cancellationToken = null)
+        public static async Task<Message> GetDecryptedMessageAsync(WebhookEventData payload, Func<string, CancellationToken, Task<Message>> decrypterFunc, CancellationToken cancellationToken)
         {
             if (payload == null)
             {

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.TestBot/ConfigurationWebexAdapterOptions.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.TestBot/ConfigurationWebexAdapterOptions.cs
@@ -3,6 +3,7 @@
 //
 // Generated with Bot Builder V4 SDK Template for Visual Studio EchoBot v4.3.0
 
+using System;
 using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Bot.Builder.Adapters.Webex.TestBot
@@ -10,7 +11,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.TestBot
     public class ConfigurationWebexAdapterOptions : WebexAdapterOptions
     {
         public ConfigurationWebexAdapterOptions(IConfiguration configuration)
-             : base(configuration["AccessToken"], configuration["PublicAddress"], configuration["Secret"], configuration["WebhookName"])
+             : base(configuration["AccessToken"], new Uri(configuration["PublicAddress"]), configuration["Secret"], configuration["WebhookName"])
         {
         }
     }

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.TestBot/Controllers/BotController.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.TestBot/Controllers/BotController.cs
@@ -3,6 +3,7 @@
 //
 // Generated with Bot Builder V4 SDK Template for Visual Studio EchoBot v4.3.0
 
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 
@@ -22,8 +23,6 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.TestBot.Controllers
         {
             _adapter = adapter;
             _bot = bot;
-
-            adapter.GetIdentityAsync().Wait();
         }
 
         [HttpPost]
@@ -31,7 +30,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.TestBot.Controllers
         {
             // Delegate the processing of the HTTP POST to the adapter.
             // The adapter will invoke the bot.
-            await _adapter.ProcessAsync(Request, Response, _bot);
+            await _adapter.ProcessAsync(Request, Response, _bot, new CancellationToken());
         }
     }
 }

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.TestBot/Startup.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.TestBot/Startup.cs
@@ -3,7 +3,7 @@
 //
 // Generated with Bot Builder V4 SDK Template for Visual Studio EchoBot v4.3.0
 
-using System.Threading;
+using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -23,7 +23,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.TestBot
         {
             Configuration = configuration;
 
-            var options = new WebexAdapterOptions(configuration["AccessToken"], configuration["PublicAddress"], configuration["Secret"], configuration["WebhookName"]);
+            var options = new WebexAdapterOptions(configuration["AccessToken"], new Uri(configuration["PublicAddress"]), configuration["Secret"], configuration["WebhookName"]);
             _adapter = new WebexAdapter(options, new WebexClientWrapper());
 
             RegisterWebhookAsync().Wait();
@@ -73,7 +73,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.TestBot
             var webhookList = await _adapter.ListWebhookSubscriptionsAsync();
 
             // await _adapter.ResetWebhookSubscriptionsAsync(webhookList);
-            await _adapter.RegisterWebhookSubscriptionsAsync("/api/messages", webhookList, default);
+            await _adapter.RegisterWebhookSubscriptionsAsync("api/messages", webhookList, default);
         }
     }
 }

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.TestBot/Startup.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.TestBot/Startup.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.TestBot
             var webhookList = await _adapter.ListWebhookSubscriptionsAsync();
 
             // await _adapter.ResetWebhookSubscriptionsAsync(webhookList);
-            await _adapter.RegisterWebhookSubscriptionsAsync("api/messages", webhookList, default);
+            await _adapter.RegisterWebhookSubscriptionsAsync();
         }
     }
 }

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.TestBot/Startup.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.TestBot/Startup.cs
@@ -70,8 +70,6 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.TestBot
 
         public async Task RegisterWebhookAsync()
         {
-            var webhookList = await _adapter.ListWebhookSubscriptionsAsync();
-
             // await _adapter.ResetWebhookSubscriptionsAsync(webhookList);
             await _adapter.RegisterWebhookSubscriptionsAsync();
         }

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.TestBot/Startup.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.TestBot/Startup.cs
@@ -4,7 +4,6 @@
 // Generated with Bot Builder V4 SDK Template for Visual Studio EchoBot v4.3.0
 
 using System;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
@@ -24,9 +23,9 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.TestBot
             Configuration = configuration;
 
             var options = new WebexAdapterOptions(configuration["AccessToken"], new Uri(configuration["PublicAddress"]), configuration["Secret"], configuration["WebhookName"]);
-            _adapter = new WebexAdapter(options, new WebexClientWrapper());
+            var wrapper = new WebexClientWrapper(options);
 
-            RegisterWebhookAsync().Wait();
+            _adapter = new WebexAdapter(wrapper);
         }
 
         public IConfiguration Configuration { get; }
@@ -66,12 +65,6 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.TestBot
 
             // app.UseHttpsRedirection();
             app.UseMvc();
-        }
-
-        public async Task RegisterWebhookAsync()
-        {
-            // await _adapter.ResetWebhookSubscriptionsAsync(webhookList);
-            await _adapter.RegisterWebhookSubscriptionsAsync();
         }
     }
 }

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/WebexAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/WebexAdapterTests.cs
@@ -18,6 +18,8 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
 {
     public class WebexAdapterTests
     {
+        private Uri _testPublicAddress = new Uri("http://contoso.com");
+
         [Fact]
         public void Constructor_Should_Fail_With_Null_Config()
         {
@@ -27,7 +29,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         [Fact]
         public void Constructor_Should_Fail_With_Null_AccessToken()
         {
-            var options = new WebexAdapterOptions(null, "Test", "Test");
+            var options = new WebexAdapterOptions(null, _testPublicAddress, "Test");
 
             Assert.Throws<Exception>(() => { new WebexAdapter(options, new Mock<WebexClientWrapper>().Object); });
         }
@@ -43,9 +45,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         [Fact]
         public void Constructor_WithArguments_Should_Succeed()
         {
-            var testPublicAddress = "http://contoso.com";
-
-            var options = new WebexAdapterOptions("Test", testPublicAddress, "Test");
+            var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
             Assert.NotNull(new WebexAdapter(options, new Mock<WebexClientWrapper>().Object));
         }
@@ -53,9 +53,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         [Fact]
         public async void ContinueConversationAsync_Should_Fail_With_Null_ConversationReference()
         {
-            var testPublicAddress = "http://contoso.com";
-
-            var options = new WebexAdapterOptions("Test", testPublicAddress, "Test");
+            var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
             var webexAdapter = new WebexAdapter(options, new Mock<WebexClientWrapper>().Object);
 
@@ -70,9 +68,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         [Fact]
         public async void ContinueConversationAsync_Should_Fail_With_Null_Logic()
         {
-            var testPublicAddress = "http://contoso.com";
-
-            var options = new WebexAdapterOptions("Test", testPublicAddress, "Test");
+            var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
             var webexAdapter = new WebexAdapter(options, new Mock<WebexClientWrapper>().Object);
             var conversationReference = new ConversationReference();
@@ -84,9 +80,8 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         public async void ContinueConversationAsync_Should_Succeed()
         {
             var callbackInvoked = false;
-            var testPublicAddress = "http://contoso.com";
 
-            var options = new WebexAdapterOptions("Test", testPublicAddress, "Test");
+            var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
             var webexAdapter = new WebexAdapter(options, new Mock<WebexClientWrapper>().Object);
             var conversationReference = new ConversationReference();
@@ -103,9 +98,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         [Fact]
         public async void GetIdentityAsync_Should_Succeed()
         {
-            var testPublicAddress = "http://contoso.com";
-
-            var options = new WebexAdapterOptions("Test", testPublicAddress, "Test");
+            var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
             var person = JsonConvert.DeserializeObject<Person>(File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\Person.json"));
 
@@ -122,9 +115,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         [Fact]
         public async void ProcessAsync_Should_Fail_With_Null_HttpRequest()
         {
-            var testPublicAddress = "http://contoso.com";
-
-            var options = new WebexAdapterOptions("Test", testPublicAddress, "Test");
+            var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
             var webexAdapter = new WebexAdapter(options, new Mock<WebexClientWrapper>().Object);
             var httpResponse = new Mock<HttpResponse>();
@@ -139,9 +130,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         [Fact]
         public async void ProcessAsync_Should_Fail_With_Null_HttpResponse()
         {
-            var testPublicAddress = "http://contoso.com";
-
-            var options = new WebexAdapterOptions("Test", testPublicAddress, "Test");
+            var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
             var webexAdapter = new WebexAdapter(options, new Mock<WebexClientWrapper>().Object);
             var httpRequest = new Mock<HttpRequest>();
@@ -156,9 +145,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         [Fact]
         public async void ProcessAsync_Should_Fail_With_Null_Bot()
         {
-            var testPublicAddress = "http://contoso.com";
-
-            var options = new WebexAdapterOptions("Test", testPublicAddress, "Test");
+            var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
             var webexAdapter = new WebexAdapter(options, new Mock<WebexClientWrapper>().Object);
             var httpRequest = new Mock<HttpRequest>();
@@ -173,9 +160,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         [Fact]
         public async void ProcessAsync_With_EvenType_Created_Should_Succeed()
         {
-            var testPublicAddress = "http://contoso.com";
-
-            var options = new WebexAdapterOptions("Test", testPublicAddress, "Test");
+            var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
             var message = JsonConvert.DeserializeObject<Message>(File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\Message.json"));
             var payload = File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\Payload.json");
@@ -210,9 +195,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         [Fact]
         public async void ProcessAsync_With_EvenType_Updated_Should_Succeed()
         {
-            var testPublicAddress = "http://contoso.com";
-
-            var options = new WebexAdapterOptions("Test", testPublicAddress, "Test");
+            var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
             var webexAdapter = new WebexAdapter(options, new Mock<WebexClientWrapper>().Object);
 
@@ -241,9 +224,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         [Fact]
         public async void ProcessAsync_Should_Fail_With_NonMatching_Signature()
         {
-            var testPublicAddress = "http://contoso.com";
-
-            var options = new WebexAdapterOptions("Test", testPublicAddress, "Test");
+            var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
             var webexAdapter = new WebexAdapter(options, new Mock<WebexClientWrapper>().Object);
 
@@ -268,9 +249,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         [Fact]
         public async void ProcessAsync_With_AttachmentActions_Should_Succeed()
         {
-            var testPublicAddress = "http://contoso.com";
-
-            var options = new WebexAdapterOptions("Test", testPublicAddress, "Test");
+            var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
             var message = JsonConvert.DeserializeObject<Message>(File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\MessageWithInputs.json"));
             var payload = File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\PayloadAttachmentActions.json");
@@ -305,9 +284,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         [Fact]
         public async void ListWebhookSubscriptionsAsync_Should_Succeed()
         {
-            var testPublicAddress = "http://contoso.com";
-
-            var options = new WebexAdapterOptions("Test", testPublicAddress, "Test");
+            var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
             var webhookList = JsonConvert.DeserializeObject<WebhookList>(File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\WebhookList.json"));
 
@@ -326,9 +303,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         [Fact]
         public async void ResetWebhookSubscriptionsAsync_Should_Succeed()
         {
-            var testPublicAddress = "http://contoso.com";
-
-            var options = new WebexAdapterOptions("Test", testPublicAddress, "Test");
+            var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
             var webhookList = JsonConvert.DeserializeObject<WebhookList>(File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\WebhookList.json"));
             var deletedItems = 0;
@@ -350,9 +325,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         [Fact]
         public async void RegisterWebhookSubscriptionsAsync_UpdateWebhook_Should_Succeed()
         {
-            var testPublicAddress = "http://contoso.com";
-
-            var options = new WebexAdapterOptions("Test", testPublicAddress, "Test");
+            var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
             var webhookList = JsonConvert.DeserializeObject<WebhookList>(File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\WebhookList.json"));
 
@@ -372,10 +345,9 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         [Fact]
         public async void RegisterWebhookSubscriptionAsync_CreateWebhook_Should_Succeed()
         {
-            var testPublicAddress = "http://contoso.com";
             var webhookName = "New_Webhook";
 
-            var options = new WebexAdapterOptions("Test", testPublicAddress, "Test", webhookName);
+            var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test", webhookName);
 
             var webhookList = JsonConvert.DeserializeObject<WebhookList>(File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\WebhookList.json"));
             var webhook = JsonConvert.DeserializeObject<Webhook>(File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\Webhook.json"));
@@ -399,9 +371,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         [Fact]
         public async void UpdateActivityAsync_Should_Throw_NotSupportedException()
         {
-            var testPublicAddress = "http://contoso.com";
-
-            var options = new WebexAdapterOptions("Test", testPublicAddress, "Test");
+            var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
             var webexAdapter = new WebexAdapter(options, new Mock<WebexClientWrapper>().Object);
 
@@ -418,9 +388,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         [Fact]
         public async void SendActivitiesAsync_Should_Fail_With_ActivityType_Not_Message()
         {
-            var testPublicAddress = "http://contoso.com";
-
-            var options = new WebexAdapterOptions("Test", testPublicAddress, "Test");
+            var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
             var webexAdapter = new WebexAdapter(options, new Mock<WebexClientWrapper>().Object);
             var activity = new Activity
@@ -441,9 +409,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         [Fact]
         public async void SendActivitiesAsync_NotNull_toPersonEmail_Should_Succeed()
         {
-            var testPublicAddress = "http://contoso.com";
-
-            var options = new WebexAdapterOptions("Test", testPublicAddress, "Test");
+            var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
             // Setup mocked Webex API client
             const string expectedResponseId = "Mocked Response Id";
@@ -469,9 +435,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         [Fact]
         public async void SendActivitiesAsync_Should_Fail_With_Null_toPersonEmail()
         {
-            var testPublicAddress = "http://contoso.com";
-
-            var options = new WebexAdapterOptions("Test", testPublicAddress, "Test");
+            var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
             // Setup mocked Webex API client
             const string expectedResponseId = "Mocked Response Id";
@@ -495,9 +459,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         [Fact]
         public async void SendActivitiesAsync_With_Attachment_Should_Succeed()
         {
-            var testPublicAddress = "http://contoso.com";
-
-            var options = new WebexAdapterOptions("Test", testPublicAddress, "Test");
+            var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
             // Setup mocked Webex API client
             const string expectedResponseId = "Mocked Response Id";
@@ -527,9 +489,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         [Fact]
         public async void SendActivitiesAsync_With_AttachmentActions_Should_Succeed()
         {
-            var testPublicAddress = "http://contoso.com";
-
-            var options = new WebexAdapterOptions("Test", testPublicAddress, "Test");
+            var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
             const string expectedResponseId = "Mocked Response Id";
             var webexApi = new Mock<WebexClientWrapper>();
@@ -556,9 +516,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         [Fact]
         public async void DeleteActivityAsync_With_ActivityId_Should_Succeed()
         {
-            var testPublicAddress = "http://contoso.com";
-
-            var options = new WebexAdapterOptions("Test", testPublicAddress, "Test");
+            var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
             var deletedMessages = 0;
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/WebexAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/WebexAdapterTests.cs
@@ -22,13 +22,13 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         private readonly Person _identity = JsonConvert.DeserializeObject<Person>(File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\Person.json"));
 
         [Fact]
-        public void Constructor_Should_Fail_With_Null_Config()
+        public void ConstructorShouldFailWithNullConfig()
         {
             Assert.Throws<ArgumentNullException>(() => { new WebexAdapter(null, new Mock<WebexClientWrapper>().Object); });
         }
 
         [Fact]
-        public void Constructor_Should_Fail_With_Null_AccessToken()
+        public void ConstructorShouldFailWithNullAccessToken()
         {
             var options = new WebexAdapterOptions(null, _testPublicAddress, "Test");
 
@@ -36,7 +36,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public void Constructor_Should_Fail_With_Null_PublicAddress()
+        public void ConstructorShouldFailWithNullPublicAddress()
         {
             var options = new WebexAdapterOptions("Test", null, "Test");
 
@@ -44,7 +44,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public void Constructor_WithArguments_Should_Succeed()
+        public void ConstructorWithArgumentsShouldSucceed()
         {
             var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
@@ -52,7 +52,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void ContinueConversationAsync_Should_Fail_With_Null_ConversationReference()
+        public async void ContinueConversationAsyncShouldFailWithNullConversationReference()
         {
             var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
@@ -67,7 +67,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void ContinueConversationAsync_Should_Fail_With_Null_Logic()
+        public async void ContinueConversationAsyncShouldFailWithNullLogic()
         {
             var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
@@ -78,7 +78,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void ContinueConversationAsync_Should_Succeed()
+        public async void ContinueConversationAsyncShouldSucceed()
         {
             var callbackInvoked = false;
 
@@ -97,7 +97,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void GetIdentityAsync_Should_Succeed()
+        public async void GetIdentityAsyncShouldSucceed()
         {
             var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
@@ -113,7 +113,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void ProcessAsync_Should_Fail_With_Null_HttpRequest()
+        public async void ProcessAsyncShouldFailWithNullHttpRequest()
         {
             var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
@@ -128,7 +128,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void ProcessAsync_Should_Fail_With_Null_HttpResponse()
+        public async void ProcessAsyncShouldFailWithNullHttpResponse()
         {
             var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
@@ -143,7 +143,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void ProcessAsync_Should_Fail_With_Null_Bot()
+        public async void ProcessAsyncShouldFailWithNullBot()
         {
             var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
@@ -158,7 +158,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void ProcessAsync_With_EvenType_Created_Should_Succeed()
+        public async void ProcessAsyncWithEvenTypeCreatedShouldSucceed()
         {
             var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
@@ -192,7 +192,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void ProcessAsync_With_EvenType_Updated_Should_Succeed()
+        public async void ProcessAsyncWithEvenTypeUpdatedShouldSucceed()
         {
             var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
@@ -224,7 +224,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void ProcessAsync_Should_Fail_With_NonMatching_Signature()
+        public async void ProcessAsyncShouldFailWithNonMatchingSignature()
         {
             var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
@@ -252,7 +252,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void ProcessAsync_With_AttachmentActions_Should_Succeed()
+        public async void ProcessAsyncWithAttachmentActionsShouldSucceed()
         {
             var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
@@ -286,7 +286,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void ListWebhookSubscriptionsAsync_Should_Succeed()
+        public async void ListWebhookSubscriptionsAsyncShouldSucceed()
         {
             var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
@@ -305,7 +305,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void ResetWebhookSubscriptionsAsync_Should_Succeed()
+        public async void ResetWebhookSubscriptionsAsyncShouldSucceed()
         {
             var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
@@ -327,7 +327,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void RegisterWebhookSubscriptionsAsync_UpdateWebhook_Should_Succeed()
+        public async void RegisterWebhookSubscriptionsAsyncUpdateWebhookShouldSucceed()
         {
             var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
@@ -348,7 +348,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void RegisterWebhookSubscriptionAsync_CreateWebhook_Should_Succeed()
+        public async void RegisterWebhookSubscriptionAsyncCreateWebhookShouldSucceed()
         {
             var webhookName = "New_Webhook";
 
@@ -375,7 +375,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void UpdateActivityAsync_Should_Throw_NotSupportedException()
+        public async void UpdateActivityAsyncShouldThrowNotSupportedException()
         {
             var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
@@ -392,7 +392,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void SendActivitiesAsync_Should_Fail_With_ActivityType_Not_Message()
+        public async void SendActivitiesAsyncShouldFailWithActivityTypeNotMessage()
         {
             var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
@@ -413,7 +413,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void SendActivitiesAsync_NotNull_toPersonEmail_Should_Succeed()
+        public async void SendActivitiesAsyncNotNulltoPersonEmailShouldSucceed()
         {
             var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
@@ -439,7 +439,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void SendActivitiesAsync_Should_Fail_With_Null_toPersonEmail()
+        public async void SendActivitiesAsyncShouldFailWithNulltoPersonEmail()
         {
             var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
@@ -463,7 +463,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void SendActivitiesAsync_With_Attachment_Should_Succeed()
+        public async void SendActivitiesAsyncWithAttachmentShouldSucceed()
         {
             var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
@@ -493,7 +493,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void SendActivitiesAsync_With_AttachmentActions_Should_Succeed()
+        public async void SendActivitiesAsyncWithAttachmentActionsShouldSucceed()
         {
             var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 
@@ -520,7 +520,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void DeleteActivityAsync_With_ActivityId_Should_Succeed()
+        public async void DeleteActivityAsyncWithActivityIdShouldSucceed()
         {
             var options = new WebexAdapterOptions("Test", _testPublicAddress, "Test");
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/WebexAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/WebexAdapterTests.cs
@@ -331,12 +331,13 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
 
             var webexApi = new Mock<WebexClientWrapper>();
             webexApi.SetupAllProperties();
+            webexApi.Setup(x => x.ListWebhooksAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult(webhookList));
             webexApi.Setup(x => x.UpdateWebhookAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(webhookList.Items[1]));
             webexApi.Setup(x => x.UpdateAdaptiveCardsWebhookAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(webhookList.Items[0]));
 
             var webexAdapter = new WebexAdapter(options, webexApi.Object);
 
-            var webhook = await webexAdapter.RegisterWebhookSubscriptionsAsync("/api/messages", webhookList, new CancellationToken());
+            var webhook = await webexAdapter.RegisterWebhookSubscriptionsAsync();
 
             Assert.Equal(webhookList.Items[0].Id, webhook[1].Id);
             Assert.Equal(webhookList.Items[1].Id, webhook[0].Id);
@@ -355,12 +356,13 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
 
             var webexApi = new Mock<WebexClientWrapper>();
             webexApi.SetupAllProperties();
+            webexApi.Setup(x => x.ListWebhooksAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult(webhookList));
             webexApi.Setup(x => x.CreateWebhookAsync(It.IsAny<string>(), It.IsAny<Uri>(), It.IsAny<EventResource>(), It.IsAny<EventType>(), It.IsAny<IEnumerable<EventFilter>>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(webhook));
             webexApi.Setup(x => x.CreateAdaptiveCardsWebhookAsync(It.IsAny<string>(), It.IsAny<Uri>(), It.IsAny<EventType>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(webhook));
 
             var webexAdapter = new WebexAdapter(options, webexApi.Object);
 
-            var actualWebhook = await webexAdapter.RegisterWebhookSubscriptionsAsync("/api/messages", webhookList, new CancellationToken());
+            var actualWebhook = await webexAdapter.RegisterWebhookSubscriptionsAsync();
 
             Assert.Equal(webhook.Id, actualWebhook[0].Id);
             Assert.Equal(webhook.Name, actualWebhook[0].Name);

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/WebexHelperTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/WebexHelperTests.cs
@@ -19,13 +19,13 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         private readonly Person _identity = JsonConvert.DeserializeObject<Person>(File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\Person.json"));
 
         [Fact]
-        public void PayloadToActivity_Should_Return_Null_With_Null_Payload()
+        public void PayloadToActivityShouldReturnNullWithNullPayload()
         {
             Assert.Null(WebexHelper.PayloadToActivity(null, _identity));
         }
 
         [Fact]
-        public void PayloadToActivity_Should_Return_Activity()
+        public void PayloadToActivityShouldReturnActivity()
         {
             var payload = JsonConvert.DeserializeObject<WebhookEventData>(File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\Payload.json"));
 
@@ -36,7 +36,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public void ValidateSignature_Should_Fail_With_Missing_Signature()
+        public void ValidateSignatureShouldFailWithMissingSignature()
         {
             var httpRequest = new Mock<HttpRequest>();
             httpRequest.SetupAllProperties();
@@ -49,7 +49,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public void ValidateSignature_Should_Return_False()
+        public void ValidateSignatureShouldReturnFalse()
         {
             var httpRequest = new Mock<HttpRequest>();
             httpRequest.SetupAllProperties();
@@ -61,13 +61,13 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void GetDecryptedMessageAsync_Should_Return_Null_With_Null_Payload()
+        public async void GetDecryptedMessageAsyncShouldReturnNullWithNullPayload()
         {
             Assert.Null(await WebexHelper.GetDecryptedMessageAsync(null, null, new CancellationToken()));
         }
 
         [Fact]
-        public async void GetDecryptedMessageAsync_Should_Succeed()
+        public async void GetDecryptedMessageAsyncShouldSucceed()
         {
             var payload = JsonConvert.DeserializeObject<WebhookEventData>(File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\Payload.json"));
 
@@ -83,13 +83,13 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public void DecryptedMessageToActivity_Should_Return_Null_With_Null_Message()
+        public void DecryptedMessageToActivityShouldReturnNullWithNullMessage()
         {
             Assert.Null(WebexHelper.DecryptedMessageToActivity(null, _identity));
         }
 
         [Fact]
-        public void DecryptedMessageToActivity_Should_Return_Activity_Type_SelfMessage()
+        public void DecryptedMessageToActivityShouldReturnActivityTypeSelfMessage()
         {
             var serializedPerson = "{\"id\":\"person_id\"}";
             var identity = JsonConvert.DeserializeObject<Person>(serializedPerson);
@@ -105,7 +105,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public void DecryptedMessageToActivity_With_Html_Should_Return_Activity()
+        public void DecryptedMessageToActivityWithHtmlShouldReturnActivity()
         {
             var serializedPerson = "{\"id\":\"different_id\"}";
             var identity = JsonConvert.DeserializeObject<Person>(serializedPerson);
@@ -121,7 +121,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public void DecryptedMessageToActivity_With_Html_Should_Return_Activity_When_Match()
+        public void DecryptedMessageToActivityWithHtmlShouldReturnActivityWhenMatch()
         {
             var serializedPerson = "{\"id\":\"/ciscospark://us/PEOPLE/different_id\"}";
             var identity = JsonConvert.DeserializeObject<Person>(serializedPerson);
@@ -137,7 +137,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public void HandleMessageAttachments_Should_Fail_With_MoreThanOne_Attachment()
+        public void HandleMessageAttachmentsShouldFailWithMoreThanOneAttachment()
         {
             var message = JsonConvert.DeserializeObject<Message>(File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\MessageAttachments.json"));
 
@@ -148,7 +148,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public void HandleMessageAttachments_Should_Succeed()
+        public void HandleMessageAttachmentsShouldSucceed()
         {
             var message = JsonConvert.DeserializeObject<Message>(File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\Message.json"));
 
@@ -158,13 +158,13 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public void AttachmentActionToActivity_With_Null_Message_Should_Fail()
+        public void AttachmentActionToActivityWithNullMessageShouldFail()
         {
             Assert.Null(WebexHelper.AttachmentActionToActivity(null, _identity));
         }
 
         [Fact]
-        public void AttachmentActionToActivity_Should_Return_Activity_With_Empty_Text()
+        public void AttachmentActionToActivityShouldReturnActivityWithEmptyText()
         {
             var message =
                 JsonConvert.DeserializeObject<Message>(
@@ -181,7 +181,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public void AttachmentActionToActivity_Should_Return_Activity_With_Text()
+        public void AttachmentActionToActivityShouldReturnActivityWithText()
         {
             var message =
                 JsonConvert.DeserializeObject<Message>(

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/WebexHelperTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/WebexHelperTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         [Fact]
         public async void GetDecryptedMessageAsync_Should_Return_Null_With_Null_Payload()
         {
-            Assert.Null(await WebexHelper.GetDecryptedMessageAsync(null, null));
+            Assert.Null(await WebexHelper.GetDecryptedMessageAsync(null, null, new CancellationToken()));
         }
 
         [Fact]

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/WebexHelperTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/WebexHelperTests.cs
@@ -16,19 +16,20 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
 {
     public class WebexHelperTests
     {
+        private readonly Person _identity = JsonConvert.DeserializeObject<Person>(File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\Person.json"));
+
         [Fact]
         public void PayloadToActivity_Should_Return_Null_With_Null_Payload()
         {
-            Assert.Null(WebexHelper.PayloadToActivity(null));
+            Assert.Null(WebexHelper.PayloadToActivity(null, _identity));
         }
 
         [Fact]
         public void PayloadToActivity_Should_Return_Activity()
         {
             var payload = JsonConvert.DeserializeObject<WebhookEventData>(File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\Payload.json"));
-            WebexHelper.Identity = JsonConvert.DeserializeObject<Person>(File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\Person.json"));
 
-            var activity = WebexHelper.PayloadToActivity(payload);
+            var activity = WebexHelper.PayloadToActivity(payload, _identity);
 
             Assert.Equal(payload.Id, activity.Id);
             Assert.Equal(payload.ActorId, activity.From.Id);
@@ -84,20 +85,20 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         [Fact]
         public void DecryptedMessageToActivity_Should_Return_Null_With_Null_Message()
         {
-            Assert.Null(WebexHelper.DecryptedMessageToActivity(null));
+            Assert.Null(WebexHelper.DecryptedMessageToActivity(null, _identity));
         }
 
         [Fact]
         public void DecryptedMessageToActivity_Should_Return_Activity_Type_SelfMessage()
         {
             var serializedPerson = "{\"id\":\"person_id\"}";
-            WebexHelper.Identity = JsonConvert.DeserializeObject<Person>(serializedPerson);
+            var identity = JsonConvert.DeserializeObject<Person>(serializedPerson);
 
             var message =
                 JsonConvert.DeserializeObject<Message>(
                     File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\Message.json"));
 
-            var activity = WebexHelper.DecryptedMessageToActivity(message);
+            var activity = WebexHelper.DecryptedMessageToActivity(message, identity);
 
             Assert.Equal(message.Id, activity.Id);
             Assert.Equal(ActivityTypes.Event, activity.Type);
@@ -107,13 +108,13 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         public void DecryptedMessageToActivity_With_Html_Should_Return_Activity()
         {
             var serializedPerson = "{\"id\":\"different_id\"}";
-            WebexHelper.Identity = JsonConvert.DeserializeObject<Person>(serializedPerson);
+            var identity = JsonConvert.DeserializeObject<Person>(serializedPerson);
 
             var message =
                 JsonConvert.DeserializeObject<Message>(
                     File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\MessageHtml.json"));
 
-            var activity = WebexHelper.DecryptedMessageToActivity(message);
+            var activity = WebexHelper.DecryptedMessageToActivity(message, identity);
 
             Assert.Equal(message.Id, activity.Id);
             Assert.Equal(message.Html, activity.Text);
@@ -123,13 +124,13 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         public void DecryptedMessageToActivity_With_Html_Should_Return_Activity_When_Match()
         {
             var serializedPerson = "{\"id\":\"/ciscospark://us/PEOPLE/different_id\"}";
-            WebexHelper.Identity = JsonConvert.DeserializeObject<Person>(serializedPerson);
+            var identity = JsonConvert.DeserializeObject<Person>(serializedPerson);
 
             var message =
                 JsonConvert.DeserializeObject<Message>(
                     File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\MessageHtml.json"));
 
-            var activity = WebexHelper.DecryptedMessageToActivity(message);
+            var activity = WebexHelper.DecryptedMessageToActivity(message, identity);
 
             Assert.Equal(message.Id, activity.Id);
             Assert.Equal(message.Html, activity.Text);
@@ -159,13 +160,12 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         [Fact]
         public void AttachmentActionToActivity_With_Null_Message_Should_Fail()
         {
-            Assert.Null(WebexHelper.AttachmentActionToActivity(null));
+            Assert.Null(WebexHelper.AttachmentActionToActivity(null, _identity));
         }
 
         [Fact]
         public void AttachmentActionToActivity_Should_Return_Activity_With_Empty_Text()
         {
-            WebexHelper.Identity = JsonConvert.DeserializeObject<Person>(File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\Person.json"));
             var message =
                 JsonConvert.DeserializeObject<Message>(
                     File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\MessageWithInputs.json"));
@@ -173,7 +173,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
             var data = JsonConvert.SerializeObject(message);
             var messageExtraData = JsonConvert.DeserializeObject<AttachmentActionData>(data);
 
-            var activity = WebexHelper.AttachmentActionToActivity(message);
+            var activity = WebexHelper.AttachmentActionToActivity(message, _identity);
 
             Assert.Equal(message.Id, activity.Id);
             Assert.Equal(messageExtraData.Inputs, activity.Value);
@@ -183,7 +183,6 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         [Fact]
         public void AttachmentActionToActivity_Should_Return_Activity_With_Text()
         {
-            WebexHelper.Identity = JsonConvert.DeserializeObject<Person>(File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\Person.json"));
             var message =
                 JsonConvert.DeserializeObject<Message>(
                     File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\MessageWithText.json"));
@@ -191,7 +190,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
             var data = JsonConvert.SerializeObject(message);
             var messageExtraData = JsonConvert.DeserializeObject<AttachmentActionData>(data);
 
-            var activity = WebexHelper.AttachmentActionToActivity(message);
+            var activity = WebexHelper.AttachmentActionToActivity(message, _identity);
 
             Assert.Equal(message.Id, activity.Id);
             Assert.Equal(messageExtraData.Inputs, activity.Value);


### PR DESCRIPTION
## Proposed Changes
- Change property PublicAddress type from string to Uri
- Refactor RegisterWebhooksAsync method
- Move GetIdentityAsync call inside the adapter
- Make CancellationToken parameter mandatory
- Remove underscores from tests names
- Move methods related to the API to WebexClientWrapper class
- Move _config parámeter to WebexClientWrapper constructor
- Update Unit tests