### PR TITLE
[Slack Adapter] Remove most dynamic castings

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapter.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Text;
@@ -346,10 +345,6 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                         }
                         else
                         {
-                            // Convert Slack ts format to DateTime
-                            string[] splitString = slackEvent["event"].ts.ToString().Split('.');
-                            var dateTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).ToLocalTime().AddSeconds(Convert.ToDouble(splitString[0], CultureInfo.InvariantCulture));
-
                             Activity activity = new Activity()
                             {
                                 Id = slackEvent["event"].ts,
@@ -367,15 +362,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                                 {
                                     Id = null,
                                 },
-                                ChannelData = new NewSlackMessage()
-                                {
-                                    type = slackEvent["event"].type,
-                                    text = slackEvent["event"].text,
-                                    user = slackEvent["event"].user,
-                                    ts = dateTime,
-                                    team = slackEvent["event"].team,
-                                    channel = slackEvent["event"].channel,
-                                },
+                                ChannelData = SlackHelper.GetChannelDataFromSlackEvent(slackEvent),
                                 Text = null,
                                 Type = ActivityTypes.Event,
                             };
@@ -422,10 +409,6 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                         }
                         else
                         {
-                            // Convert Slack ts format to DateTime
-                            string[] splitString = slackEvent["event"].ts.ToString().Split('.');
-                            var dateTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).ToLocalTime().AddSeconds(Convert.ToDouble(splitString[0], CultureInfo.InvariantCulture));
-
                             // this is a slash command
                             Activity activity = new Activity()
                             {
@@ -444,15 +427,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                                 {
                                     Id = null,
                                 },
-                                ChannelData = new NewSlackMessage()
-                                {
-                                    type = slackEvent["event"].type,
-                                    text = slackEvent["event"].text,
-                                    user = slackEvent["event"].user,
-                                    ts = dateTime,
-                                    team = slackEvent["event"].team,
-                                    channel = slackEvent["event"].channel,
-                                },
+                                ChannelData = SlackHelper.GetChannelDataFromSlackEvent(slackEvent),
                                 Text = slackEvent.text,
                                 Type = ActivityTypes.Event,
                             };

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
@@ -93,20 +93,26 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
             }
         }
 
+        /// <summary>
+        /// Converts the 'Event' subobject of the Slack payload into a NewSlackMessage for assigning to ChannelData.
+        /// </summary>
+        /// <param name="slackEvent">A dynamic payload from the request body sent by Slack.</param>
+        /// <returns>A NewSlackMessage with the resulting properties.</returns>
         public static NewSlackMessage GetChannelDataFromSlackEvent(dynamic slackEvent)
         {
             // Convert Slack timestamp format to DateTime
-            string[] splitString = slackEvent["event"].ts.ToString().Split('.');
+            var eventProperty = slackEvent["event"];
+            string[] splitString = eventProperty.ts.ToString().Split('.');
             var dateTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).ToLocalTime().AddSeconds(Convert.ToDouble(splitString[0], CultureInfo.InvariantCulture));
 
             return new NewSlackMessage()
             {
-                type = slackEvent["event"].type ?? null,
-                text = slackEvent["event"].text ?? null,
-                user = slackEvent["event"].user ?? null,
+                type = eventProperty.type ?? null,
+                text = eventProperty.text ?? null,
+                user = eventProperty.user ?? null,
                 ts = dateTime,
-                team = slackEvent["event"].team ?? null,
-                channel = slackEvent["event"].channel ?? null,
+                team = eventProperty.team ?? null,
+                channel = eventProperty.channel ?? null,
             };
         }
     }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
@@ -47,23 +47,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
             // if channelData is specified, overwrite any fields in message object
             if (activity.ChannelData != null)
             {
-                try
-                {
-                    // Try a straight up cast
-                    message = activity.ChannelData as NewSlackMessage;
-                }
-                catch (InvalidCastException)
-                {
-                    foreach (var property in message.GetType().GetFields())
-                    {
-                        var name = property.Name;
-                        var value = (activity.ChannelData as dynamic)[name];
-                        if (value != null)
-                        {
-                            message.GetType().GetField(name).SetValue(message, value);
-                        }
-                    }
-                }
+                message = activity.GetChannelData<NewSlackMessage>();
             }
 
             // should this message be sent as an ephemeral message

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.AspNetCore.Http;
@@ -90,6 +91,23 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
 
                 return hash == retrievedSignature;
             }
+        }
+
+        public static NewSlackMessage GetChannelDataFromSlackEvent(dynamic slackEvent)
+        {
+            // Convert Slack timestamp format to DateTime
+            string[] splitString = slackEvent["event"].ts.ToString().Split('.');
+            var dateTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).ToLocalTime().AddSeconds(Convert.ToDouble(splitString[0], CultureInfo.InvariantCulture));
+
+            return new NewSlackMessage()
+            {
+                type = slackEvent["event"].type ?? null,
+                text = slackEvent["event"].text ?? null,
+                user = slackEvent["event"].user ?? null,
+                ts = dateTime,
+                team = slackEvent["event"].team ?? null,
+                channel = slackEvent["event"].channel ?? null,
+            };
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes
Remove _as dynamic_ castings for ChannelData by simply casting it to NewSlackMessage. Some conversions needed to be done to take into account Slack handling of timestamp.
A bigger refactor might come in handy in the future as well.

**Modified Files**
- SlackAdapter.cs
- SlackHelper.cs 