### PR TITLE
[Slack Adapter] Turn ISlackAdapter interface into a class

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapter.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
 {
     public class SlackAdapter : BotAdapter, IBotFrameworkHttpAdapter
     {
-        private readonly ISlackAdapterOptions _options;
+        private readonly SlackAdapterOptions _options;
         private readonly SlackClientWrapper _slackClient;
         private readonly string _slackOAuthUrl = "https://slack.com/oauth/authorize?client_id=";
         private string _identity;
@@ -29,7 +29,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// Create a Slack adapter.
         /// </summary>
         /// <param name="options">An object containing API credentials, a webhook verification token and other options.</param>
-        public SlackAdapter(ISlackAdapterOptions options)
+        public SlackAdapter(SlackAdapterOptions options)
             : base()
         {
             _options = options ?? throw new ArgumentNullException(nameof(options));

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapterOptions.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapterOptions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright(c) Microsoft Corporation.All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Builder.Adapters.Slack
@@ -8,62 +9,68 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
     /// <summary>
     /// Interface for defining implementation of the SlackAdapter Options.
     /// </summary>
-    public interface ISlackAdapterOptions
+    public class SlackAdapterOptions
     {
         /// <summary>
         /// Gets or Sets the token for validating the origin of incoming webhooks.
         /// </summary>
         /// <value>The verification token.</value>
-        string VerificationToken { get; set; }
+        public string VerificationToken { get; set; }
 
         /// <summary>
         /// Gets or Sets a token used to validate that incoming webhooks originated with Slack.
         /// </summary>
         /// <value>The Client Signing Secret.</value>
-        string ClientSigningSecret { get; set; }
+        public string ClientSigningSecret { get; set; }
 
         /// <summary>
         /// Gets or Sets a token (provided by Slack) for a bot to work on a single workspace.
         /// </summary>
         /// <value>The Bot token.</value>
-        string BotToken { get; set; }
+        public string BotToken { get; set; }
 
         /// <summary>
         /// Gets or Sets the oauth client id provided by Slack for multi-team apps.
         /// </summary>
         /// <value>The Client Id.</value>
-        string ClientId { get; set; }
+        public string ClientId { get; set; }
 
         /// <summary>
         /// Gets or Sets the oauth client secret provided by Slack for multi-team apps.
         /// </summary>
         /// <value>The Client Secret.</value>
-        string ClientSecret { get; set; }
+        public string ClientSecret { get; set; }
 
         /// <summary>
         /// Gets or Sets an array of scope names that are being requested during the oauth process. Must match the scopes defined at api.slack.com.
         /// </summary>
         /// <value>The Scopes array.</value>
-        string[] Scopes { get; set; }
+        public string[] Scopes { get; set; }
 
         /// <summary>
         /// Gets or Sets the URI users will be redirected to after an oauth flow. In most cases, should be `https://mydomain.com/install/auth`.
         /// </summary>
         /// <value>The Redirect URI.</value>
-        string RedirectUri { get; set; }
+        public string RedirectUri { get; set; }
 
         /// <summary>
         /// A method that receives a Slack team id and returns the bot token associated with that team. Required for multi-team apps.
         /// </summary>
         /// <param name="teamId">Team ID.</param>
         /// <returns>The bot token associated with the team.</returns>
-        Task<string> GetTokenForTeam(string teamId);
+        public Task<string> GetTokenForTeam(string teamId)
+        {
+            throw new NotImplementedException();
+        }
 
         /// <summary>
         /// A method that receives a Slack team id and returns the bot user id associated with that team. Required for multi-team apps.
         /// </summary>
         /// <param name="teamId">Team ID.</param>
         /// <returns>The bot user id associated with that team.</returns>
-        Task<string> GetBotUserByTeam(string teamId);
+        public virtual Task<string> GetBotUserByTeam(string teamId)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.TestBot/SimpleSlackAdapterOptions.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.TestBot/SimpleSlackAdapterOptions.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.Bot.Builder.Adapters.Slack.TestBot
 {
-    public class SimpleSlackAdapterOptions : ISlackAdapterOptions
+    public class SimpleSlackAdapterOptions : SlackAdapterOptions
     {
         public SimpleSlackAdapterOptions()
         {
@@ -13,30 +13,6 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.TestBot
             this.VerificationToken = verificationToken;
             this.BotToken = botToken;
             this.ClientSigningSecret = signingSecret;
-        }
-
-        public string VerificationToken { get; set; }
-
-        public string ClientSigningSecret { get; set; }
-
-        public string BotToken { get; set; }
-
-        public string ClientId { get; set; }
-
-        public string ClientSecret { get; set; }
-
-        public string[] Scopes { get; set; }
-
-        public string RedirectUri { get; set; }
-
-        public Task<string> GetBotUserByTeam(string teamId)
-        {
-            throw new System.NotImplementedException();
-        }
-
-        public Task<string> GetTokenForTeam(string teamId)
-        {
-            throw new System.NotImplementedException();
         }
     }
 }

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.TestBot/Startup.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.TestBot/Startup.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.TestBot
             services.AddSingleton<ICredentialProvider, ConfigurationCredentialProvider>();
 
             // Create the options for the SlackAdapter
-            services.AddSingleton<ISlackAdapterOptions, ConfigurationSlackAdapterOptions>();
+            services.AddSingleton<SlackAdapterOptions, ConfigurationSlackAdapterOptions>();
 
             // services.AddSingleton<IBotFrameworkHttpAdapter, BotFrameworkHttpAdapter>();
 


### PR DESCRIPTION
## Description
As part of the feedback given for other adapters, we turned the ISlackAdapter interface into the SlackAdapter class. With the corresponding changes in the project.

**Modified files:**
- SlackAdapter.cs (renamed from ISlackAdapter.cs)
- DialogElement.cs
- SlackAdapterOptions.cs
- SimpleSlackAdapterOptions.cs
- Startup.cs