### PR TITLE
Add Slack Adapter project to CodeCoverage

### DIFF
--- a/CodeCoverage.runsettings
+++ b/CodeCoverage.runsettings
@@ -22,6 +22,7 @@
                 <ModulePath>.*\Microsoft.Bot.Builder.Integration.AspNet.Core.dll$</ModulePath>
                 <ModulePath>.*\Microsoft.Bot.Builder.TemplateManager.dll$</ModulePath>
                 <ModulePath>.*\Microsoft.Bot.Builder.Testing.dll$</ModulePath>
+                <ModulePath>.*\Microsoft.Bot.Builder.Adapters.Slack.dll$</ModulePath>                
                 <!-- <ModulePath>Microsoft.Bot.Builder.Schema.dll$</ModulePath> -->
               </Include>
             </ModulePaths>


### PR DESCRIPTION
## Description
Update the `CodeCoverage.runsettings` file for adding the Slack project to Code Coverage.

## More information
- [Customizing code coverage](https://docs.microsoft.com/en-us/visualstudio/test/customizing-code-coverage-analysis?view=vs-2019)