### PR TITLE
[Slack Adapter] Fix Roslyn warnings and adapters feedback

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/NewSlackMessage.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/NewSlackMessage.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright(c) Microsoft Corporation.All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using SlackAPI.WebSocketMessages;
 
 namespace Microsoft.Bot.Builder.Adapters.Slack
@@ -26,7 +27,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// Gets or Sets the URL for an icon.
         /// </summary>
         /// <value>The URL for an icon.</value>
-        public string IconUrl { get; set; }
+        public Uri IconUrl { get; set; }
 
         /// <summary>
         /// Gets or Sets an emoji icon.

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapter.cs
@@ -227,7 +227,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         {
             if (reference.ActivityId != null && reference.Conversation != null)
             {
-                SlackClientWrapper slack = await this.GetAPIAsync(turnContext.Activity).ConfigureAwait(false);
+                SlackClientWrapper slack = await GetAPIAsync(turnContext.Activity).ConfigureAwait(false);
                 var results = await slack.DeleteMessageAsync(reference.ChannelId, turnContext.Activity.Timestamp.Value.DateTime, cancellationToken).ConfigureAwait(false);
             }
             else
@@ -248,7 +248,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
 
             using (TurnContext context = new TurnContext(this, request))
             {
-                await this.RunPipelineAsync(context, logic, default(CancellationToken)).ConfigureAwait(false);
+                await RunPipelineAsync(context, logic, default(CancellationToken)).ConfigureAwait(false);
             }
         }
 
@@ -325,14 +325,14 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                         activity.Conversation.Properties["team"] = slackEvent.team.id;
 
                         // this complains because of extra fields in conversation
-                        activity.Recipient.Id = await this.GetBotUserByTeamAsync(activity).ConfigureAwait(false);
+                        activity.Recipient.Id = await GetBotUserByTeamAsync(activity).ConfigureAwait(false);
 
                         // create a conversation reference
                         using (var context = new TurnContext(this, activity))
                         {
                             context.TurnState.Add("httpStatus", ((int)HttpStatusCode.OK).ToString(System.Globalization.CultureInfo.InvariantCulture));
 
-                            await this.RunPipelineAsync(context, bot.OnTurnAsync, cancellationToken).ConfigureAwait(false);
+                            await RunPipelineAsync(context, bot.OnTurnAsync, cancellationToken).ConfigureAwait(false);
 
                             // send http response back
                             response.StatusCode = Convert.ToInt32(context.TurnState.Get<string>("httpStatus"), System.Globalization.CultureInfo.InvariantCulture);
@@ -380,7 +380,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                         activity.Conversation.Properties["thread_ts"] = slackEvent["event"].thread_ts;
 
                         // this complains because of extra fields in conversation
-                        activity.Recipient.Id = await this.GetBotUserByTeamAsync(activity).ConfigureAwait(false);
+                        activity.Recipient.Id = await GetBotUserByTeamAsync(activity).ConfigureAwait(false);
 
                         // Normalize the location of the team id
                         activity.GetChannelData<NewSlackMessage>().team = slackEvent.team_id;
@@ -400,7 +400,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                         {
                             context.TurnState.Add("httpStatus", ((int)HttpStatusCode.OK).ToString(System.Globalization.CultureInfo.InvariantCulture));
 
-                            await this.RunPipelineAsync(context, bot.OnTurnAsync, cancellationToken).ConfigureAwait(false);
+                            await RunPipelineAsync(context, bot.OnTurnAsync, cancellationToken).ConfigureAwait(false);
 
                             // send http response back
                             response.StatusCode = Convert.ToInt32(context.TurnState.Get<string>("httpStatus"), System.Globalization.CultureInfo.InvariantCulture);
@@ -457,7 +457,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                         {
                             context.TurnState.Add("httpStatus", ((int)HttpStatusCode.OK).ToString(System.Globalization.CultureInfo.InvariantCulture));
 
-                            await this.RunPipelineAsync(context, bot.OnTurnAsync, cancellationToken).ConfigureAwait(false);
+                            await RunPipelineAsync(context, bot.OnTurnAsync, cancellationToken).ConfigureAwait(false);
 
                             // send http response back
                             response.StatusCode = Convert.ToInt32(context.TurnState.Get<string>("httpStatus"), System.Globalization.CultureInfo.InvariantCulture);

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapterOptions.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapterOptions.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// Gets or Sets the URI users will be redirected to after an oauth flow. In most cases, should be `https://mydomain.com/install/auth`.
         /// </summary>
         /// <value>The Redirect URI.</value>
-        public string RedirectUri { get; set; }
+        public Uri RedirectUri { get; set; }
 
         /// <summary>
         /// A method that returns an array of scope names that are being requested during the oauth process. Must match the scopes defined at api.slack.com.

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapterOptions.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapterOptions.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace Microsoft.Bot.Builder.Adapters.Slack
 {
     /// <summary>
-    /// Interface for defining implementation of the SlackAdapter Options.
+    /// Class for defining implementation of the SlackAdapter Options.
     /// </summary>
     public class SlackAdapterOptions
     {
@@ -42,16 +42,19 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         public string ClientSecret { get; set; }
 
         /// <summary>
-        /// Gets or Sets an array of scope names that are being requested during the oauth process. Must match the scopes defined at api.slack.com.
-        /// </summary>
-        /// <value>The Scopes array.</value>
-        public string[] Scopes { get; set; }
-
-        /// <summary>
         /// Gets or Sets the URI users will be redirected to after an oauth flow. In most cases, should be `https://mydomain.com/install/auth`.
         /// </summary>
         /// <value>The Redirect URI.</value>
         public string RedirectUri { get; set; }
+
+        /// <summary>
+        /// A method that returns an array of scope names that are being requested during the oauth process. Must match the scopes defined at api.slack.com.
+        /// </summary>
+        /// <returns>The scopes array.</returns>
+        public string[] GetScopes()
+        {
+            throw new NotImplementedException();
+        }
 
         /// <summary>
         /// A method that receives a Slack team id and returns the bot token associated with that team. Required for multi-team apps.

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackClientWrapper.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using SlackAPI;
 using SlackAPI.RPCMessages;
@@ -94,8 +95,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// </summary>
         /// <param name="channelId">The channel to delete the message from.</param>
         /// <param name="ts">The timestamp of the message.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="DeletedResponse"/> representing the response to deleting the message.</returns>
-        public virtual async Task<DeletedResponse> DeleteMessageAsync(string channelId, DateTime ts)
+        public virtual async Task<DeletedResponse> DeleteMessageAsync(string channelId, DateTime ts, CancellationToken cancellationToken)
         {
             return await _api.DeleteMessageAsync(channelId, ts).ConfigureAwait(false);
         }
@@ -519,13 +521,14 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// <param name="ts">The timestamp of the message.</param>
         /// <param name="channelId">The channel to delete the message from.</param>
         /// <param name="text">The text to update with.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <param name="botName">The optional bot name.</param>
         /// <param name="parse">Change how messages are treated.Defaults to 'none'. See https://api.slack.com/methods/chat.postMessage#formatting. </param>
         /// <param name="linkNames">If to find and link channel names and username.</param>
         /// <param name="attachments">The attachments, if any.</param>
         /// <param name="asUser">If the message is being sent as user instead of as a bot.</param>
         /// <returns>A <see cref="UpdateResponse"/> representing the response to the operation.</returns>
-        public virtual async Task<UpdateResponse> UpdateAsync(string ts, string channelId, string text, string botName = null, string parse = null, bool linkNames = false, Attachment[] attachments = null, bool asUser = false)
+        public virtual async Task<UpdateResponse> UpdateAsync(string ts, string channelId, string text, CancellationToken cancellationToken, string botName = null, string parse = null, bool linkNames = false, Attachment[] attachments = null, bool asUser = false)
         {
             return await _api.UpdateAsync(ts, channelId, text, botName, parse, linkNames, attachments, asUser).ConfigureAwait(false);
         }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackClientWrapper.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// <param name="ts">The timestamp of the message.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="DeletedResponse"/> representing the response to deleting the message.</returns>
-        public virtual async Task<DeletedResponse> DeleteMessageAsync(string channelId, DateTime ts, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<DeletedResponse> DeleteMessageAsync(string channelId, DateTime ts, CancellationToken cancellationToken)
         {
             return await _api.DeleteMessageAsync(channelId, ts).ConfigureAwait(false);
         }
@@ -521,14 +521,14 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// <param name="ts">The timestamp of the message.</param>
         /// <param name="channelId">The channel to delete the message from.</param>
         /// <param name="text">The text to update with.</param>
-        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <param name="botName">The optional bot name.</param>
         /// <param name="parse">Change how messages are treated.Defaults to 'none'. See https://api.slack.com/methods/chat.postMessage#formatting. </param>
         /// <param name="linkNames">If to find and link channel names and username.</param>
         /// <param name="attachments">The attachments, if any.</param>
         /// <param name="asUser">If the message is being sent as user instead of as a bot.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="UpdateResponse"/> representing the response to the operation.</returns>
-        public virtual async Task<UpdateResponse> UpdateAsync(string ts, string channelId, string text, CancellationToken cancellationToken = default(CancellationToken), string botName = null, string parse = null, bool linkNames = false, Attachment[] attachments = null, bool asUser = false)
+        public virtual async Task<UpdateResponse> UpdateAsync(string ts, string channelId, string text, string botName = null, string parse = null, bool linkNames = false, Attachment[] attachments = null, bool asUser = false, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await _api.UpdateAsync(ts, channelId, text, botName, parse, linkNames, attachments, asUser).ConfigureAwait(false);
         }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackClientWrapper.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// <param name="ts">The timestamp of the message.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="DeletedResponse"/> representing the response to deleting the message.</returns>
-        public virtual async Task<DeletedResponse> DeleteMessageAsync(string channelId, DateTime ts, CancellationToken cancellationToken)
+        public virtual async Task<DeletedResponse> DeleteMessageAsync(string channelId, DateTime ts, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await _api.DeleteMessageAsync(channelId, ts).ConfigureAwait(false);
         }
@@ -528,7 +528,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// <param name="attachments">The attachments, if any.</param>
         /// <param name="asUser">If the message is being sent as user instead of as a bot.</param>
         /// <returns>A <see cref="UpdateResponse"/> representing the response to the operation.</returns>
-        public virtual async Task<UpdateResponse> UpdateAsync(string ts, string channelId, string text, CancellationToken cancellationToken, string botName = null, string parse = null, bool linkNames = false, Attachment[] attachments = null, bool asUser = false)
+        public virtual async Task<UpdateResponse> UpdateAsync(string ts, string channelId, string text, CancellationToken cancellationToken = default(CancellationToken), string botName = null, string parse = null, bool linkNames = false, Attachment[] attachments = null, bool asUser = false)
         {
             return await _api.UpdateAsync(ts, channelId, text, botName, parse, linkNames, attachments, asUser).ConfigureAwait(false);
         }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackClientWrapper.cs
@@ -29,8 +29,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// <param name="name">The optional name.</param>
         /// <param name="channel">The optional channel.</param>
         /// <param name="timestamp">The optional timestamp.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>The <see cref="ReactionAddedResponse"/> representing the response to the reaction added.</returns>
-        public virtual async Task<ReactionAddedResponse> AddReactionAsync(string name = null, string channel = null, string timestamp = null)
+        public virtual async Task<ReactionAddedResponse> AddReactionAsync(string name = null, string channel = null, string timestamp = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await _api.AddReactionAsync(name, channel, timestamp).ConfigureAwait(false);
         }
@@ -38,10 +39,11 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// <summary>
         /// Wraps Slack API's APIRequestWithTokenAsync method.
         /// </summary>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <param name="postParameters">The parameters to the POST request.</param>
         /// <typeparam name="TResult">The generic type for the return. Must be of type Response.</param>
         /// <returns>A <see cref="Task"/> of type T representing the asynchronous operation.</returns>
-        public virtual async Task<TResult> APIRequestWithTokenAsync<TResult>(params Tuple<string, string>[] postParameters)
+        public virtual async Task<TResult> APIRequestWithTokenAsync<TResult>(CancellationToken cancellationToken, params Tuple<string, string>[] postParameters)
              where TResult : Response
         {
             return (postParameters != null) ?
@@ -53,8 +55,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// Wraps Slack API's ChannelsCreateAsync method.
         /// </summary>
         /// <param name="name">Name of the channel to be created.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="ChannelCreateResponse"/> representing the response from creating a channel.</returns>
-        public virtual async Task<ChannelCreateResponse> ChannelsCreateAsync(string name)
+        public virtual async Task<ChannelCreateResponse> ChannelsCreateAsync(string name, CancellationToken cancellationToken)
         {
             return await _api.ChannelsCreateAsync(name).ConfigureAwait(false);
         }
@@ -64,8 +67,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// </summary>
         /// <param name="channelId">The channel to set the topic to.</param>
         /// <param name="newTopic">The new topic.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="ChannelSetTopicResponse"/> representing the response of setting the channel's topic.</returns>
-        public virtual async Task<ChannelSetTopicResponse> ChannelSetTopicAsync(string channelId, string newTopic)
+        public virtual async Task<ChannelSetTopicResponse> ChannelSetTopicAsync(string channelId, string newTopic, CancellationToken cancellationToken)
         {
             return await _api.ChannelSetTopicAsync(channelId, newTopic).ConfigureAwait(false);
         }
@@ -75,8 +79,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// </summary>
         /// <param name="userId">The user to invite.</param>
         /// <param name="channelId">The channel to invite the user to.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="ChannelInviteResponse"/> representing the response to the invite.</returns>
-        public virtual async Task<ChannelInviteResponse> ChannelsInviteAsync(string userId, string channelId)
+        public virtual async Task<ChannelInviteResponse> ChannelsInviteAsync(string userId, string channelId, CancellationToken cancellationToken)
         {
             return await _api.ChannelsInviteAsync(userId, channelId).ConfigureAwait(false);
         }
@@ -84,8 +89,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// <summary>
         /// Wraps Slack API's ConnectAsync method.
         /// </summary>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="LoginResponse"/> representing the login response.</returns>
-        public virtual async Task<LoginResponse> ConnectAsync()
+        public virtual async Task<LoginResponse> ConnectAsync(CancellationToken cancellationToken)
         {
             return await _api.ConnectAsync().ConfigureAwait(false);
         }
@@ -107,8 +113,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// </summary>
         /// <param name="triggerId">.</param>
         /// <param name="dialog">The dialog to open.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="DialogOpenResponse"/> representing the response to the operation.</returns>
-        public virtual async Task<DialogOpenResponse> DialogOpenAsync(string triggerId, Dialog dialog)
+        public virtual async Task<DialogOpenResponse> DialogOpenAsync(string triggerId, Dialog dialog, CancellationToken cancellationToken)
         {
             return await _api.DialogOpenAsync(triggerId, dialog).ConfigureAwait(false);
         }
@@ -117,8 +124,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// Wraps Slack API's EmitLoginAsync method.
         /// </summary>
         /// <param name="agent">The agent name.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="LoginResponse"/> representing the response to the login operation.</returns>
-        public virtual async Task<LoginResponse> EmitLoginAsync(string agent = "Inumedia.SlackAPI")
+        public virtual async Task<LoginResponse> EmitLoginAsync(string agent = "Inumedia.SlackAPI", CancellationToken cancellationToken = default(CancellationToken))
         {
             return await _api.EmitLoginAsync(agent).ConfigureAwait(false);
         }
@@ -127,8 +135,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// Wraps Slack API's EmitPresence method.
         /// </summary>
         /// <param name="status">The presence status.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="PresenceResponse"/> representing the response of the operation.</returns>
-        public virtual async Task<PresenceResponse> EmitPresence(Presence status)
+        public virtual async Task<PresenceResponse> EmitPresence(Presence status, CancellationToken cancellationToken)
         {
             return await _api.EmitPresence(status).ConfigureAwait(false);
         }
@@ -140,8 +149,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// <param name="latest">The date of the latest.</param>
         /// <param name="oldest">The date of the oldest.</param>
         /// <param name="count">The requested count.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="ChannelMessageHistory"/> representing the response.</returns>
-        public virtual async Task<ChannelMessageHistory> GetChannelHistoryAsync(Channel channelInfo, DateTime? latest = null, DateTime? oldest = null, int? count = null)
+        public virtual async Task<ChannelMessageHistory> GetChannelHistoryAsync(Channel channelInfo, DateTime? latest = null, DateTime? oldest = null, int? count = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await _api.GetChannelHistoryAsync(channelInfo, latest, oldest, count).ConfigureAwait(false);
         }
@@ -150,8 +160,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// Wraps Slack API's GetChannelListAsync method.
         /// </summary>
         /// <param name="excludeArchived">Flag to set if archived channels are to be listed.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="ChannelListResponse"/> representing the response of listing the channel.</returns>
-        public virtual async Task<ChannelListResponse> GetChannelListAsync(bool excludeArchived = true)
+        public virtual async Task<ChannelListResponse> GetChannelListAsync(bool excludeArchived = true, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await _api.GetChannelListAsync(excludeArchived).ConfigureAwait(false);
         }
@@ -159,6 +170,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// <summary>
         /// Wraps Slack API's GetCountsAsync method.
         /// </summary>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="UserCountsResponse"/> representing the response.</returns>
         public virtual async Task<UserCountsResponse> GetCountsAsync()
         {
@@ -172,8 +184,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// <param name="latest">The date of the latest.</param>
         /// <param name="oldest">The date of the oldest.</param>
         /// <param name="count">The requested count.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="MessageHistory"/> representing the retrieved message history.</returns>
-        public virtual async Task<MessageHistory> GetDirectMessageHistoryAsync(DirectMessageConversation conversationInfo, DateTime? latest = null, DateTime? oldest = null, int? count = null)
+        public virtual async Task<MessageHistory> GetDirectMessageHistoryAsync(DirectMessageConversation conversationInfo, DateTime? latest = null, DateTime? oldest = null, int? count = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await _api.GetDirectMessageHistoryAsync(conversationInfo, latest, oldest, count).ConfigureAwait(false);
         }
@@ -181,8 +194,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// <summary>
         /// Wraps Slack API's GetDirectMessageListAsync method.
         /// </summary>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="DirectMessageConversationListResponse"/> representing the response to listing the messages.</returns>
-        public virtual async Task<DirectMessageConversationListResponse> GetDirectMessageListAsync()
+        public virtual async Task<DirectMessageConversationListResponse> GetDirectMessageListAsync(CancellationToken cancellationToken)
         {
             return await _api.GetDirectMessageListAsync().ConfigureAwait(false);
         }
@@ -193,8 +207,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// <param name="fileId">The id of the file to retrieve the info from.</param>
         /// <param name="page">The page number.</param>
         /// <param name="count">The requested count.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="FileInfoResponse"/> representing the response.</returns>
-        public virtual async Task<FileInfoResponse> GetFileInfoAsync(string fileId, int? page = null, int? count = null)
+        public virtual async Task<FileInfoResponse> GetFileInfoAsync(string fileId, int? page = null, int? count = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await _api.GetFileInfoAsync(fileId, page, count).ConfigureAwait(false);
         }
@@ -208,8 +223,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// <param name="count">The requested count.</param>
         /// <param name="page">The page number.</param>
         /// <param name="types">The type of files to retrieve.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="FileListResponse"/> representing the response.</returns>
-        public virtual async Task<FileListResponse> GetFilesAsync(string userId = null, DateTime? dateFrom = null, DateTime? dateTo = null, int? count = null, int? page = null, FileTypes types = FileTypes.all)
+        public virtual async Task<FileListResponse> GetFilesAsync(string userId = null, DateTime? dateFrom = null, DateTime? dateTo = null, int? count = null, int? page = null, FileTypes types = FileTypes.all, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await _api.GetFilesAsync(userId, dateFrom, dateTo, count, page, types).ConfigureAwait(false);
         }
@@ -221,8 +237,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// <param name="latest">The date of the latest.</param>
         /// <param name="oldest">The date of the oldest.</param>
         /// <param name="count">The requested count.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="GroupMessageHistory"/> representing the asynchronous operation.</returns>
-        public virtual async Task<GroupMessageHistory> GetGroupHistoryAsync(Channel groupInfo, DateTime? latest = null, DateTime? oldest = null, int? count = null)
+        public virtual async Task<GroupMessageHistory> GetGroupHistoryAsync(Channel groupInfo, DateTime? latest = null, DateTime? oldest = null, int? count = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await _api.GetGroupHistoryAsync(groupInfo, latest, oldest, count).ConfigureAwait(false);
         }
@@ -231,8 +248,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// Wraps Slack API's GetGroupsListAsync method.
         /// </summary>
         /// <param name="excludeArchived">Flag setting if archived groups are to be excluded.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="GroupListResponse"/> with the list of groups.</returns>
-        public virtual async Task<GroupListResponse> GetGroupsListAsync(bool excludeArchived = true)
+        public virtual async Task<GroupListResponse> GetGroupsListAsync(bool excludeArchived = true, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await _api.GetGroupsListAsync(excludeArchived).ConfigureAwait(false);
         }
@@ -240,8 +258,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// <summary>
         /// Wraps Slack API's GetPreferencesAsync method.
         /// </summary>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="UserPreferencesResponse"/> representing the asynchronous operation.</returns>
-        public virtual async Task<UserPreferencesResponse> GetPreferencesAsync()
+        public virtual async Task<UserPreferencesResponse> GetPreferencesAsync(CancellationToken cancellationToken)
         {
             return await _api.GetPreferencesAsync().ConfigureAwait(false);
         }
@@ -252,8 +271,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// <param name="userId">The user id.</param>
         /// <param name="count">The count to retrieve.</param>
         /// <param name="page">The page to retrieve from.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="StarListResponse"/> representing the asynchronous operation.</returns>
-        public virtual async Task<StarListResponse> GetStarsAsync(string userId = null, int? count = null, int? page = null)
+        public virtual async Task<StarListResponse> GetStarsAsync(string userId = null, int? count = null, int? page = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await _api.GetStarsAsync(userId, count, page).ConfigureAwait(false);
         }
@@ -261,6 +281,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// <summary>
         /// Wraps Slack API's GetUserListAsync method.
         /// </summary>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="UserListResponse"/> representing the response.</returns>
         public virtual async Task<UserListResponse> GetUserListAsync()
         {
@@ -271,8 +292,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// Wraps Slack API's GroupsArchiveAsync method.
         /// </summary>
         /// <param name="channelId">The channel id.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="GroupArchiveResponse"/> representing the response to the operation.</returns>
-        public virtual async Task<GroupArchiveResponse> GroupsArchiveAsync(string channelId)
+        public virtual async Task<GroupArchiveResponse> GroupsArchiveAsync(string channelId, CancellationToken cancellationToken)
         {
             return await _api.GroupsArchiveAsync(channelId).ConfigureAwait(false);
         }
@@ -281,8 +303,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// Wraps Slack API's GroupsCloseAsync method.
         /// </summary>
         /// <param name="channelId">The channel id.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="GroupCloseResponse"/> representing the response.</returns>
-        public virtual async Task<GroupCloseResponse> GroupsCloseAsync(string channelId)
+        public virtual async Task<GroupCloseResponse> GroupsCloseAsync(string channelId, CancellationToken cancellationToken)
         {
             return await _api.GroupsCloseAsync(channelId).ConfigureAwait(false);
         }
@@ -291,8 +314,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// Wraps Slack API's GroupsCreateAsync method.
         /// </summary>
         /// <param name="name">The name of the group to create.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="GroupCreateResponse"/> representing the response to the group creation.</returns>
-        public virtual async Task<GroupCreateResponse> GroupsCreateAsync(string name)
+        public virtual async Task<GroupCreateResponse> GroupsCreateAsync(string name, CancellationToken cancellationToken)
         {
             return await _api.GroupsCreateAsync(name).ConfigureAwait(false);
         }
@@ -301,8 +325,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// Wraps Slack API's GroupsCreateChildAsync method.
         /// </summary>
         /// <param name="channelId">The channel id.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="GroupCreateChildResponse"/> representing the asynchronous operation.</returns>
-        public virtual async Task<GroupCreateChildResponse> GroupsCreateChildAsync(string channelId)
+        public virtual async Task<GroupCreateChildResponse> GroupsCreateChildAsync(string channelId, CancellationToken cancellationToken)
         {
             return await _api.GroupsCreateChildAsync(channelId).ConfigureAwait(false);
         }
@@ -312,8 +337,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// </summary>
         /// <param name="userId">The id of the user to invite.</param>
         /// <param name="channelId">The channel to invite the user to.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="GroupInviteResponse"/> representing the response.</returns>
-        public virtual async Task<GroupInviteResponse> GroupsInviteAsync(string userId, string channelId)
+        public virtual async Task<GroupInviteResponse> GroupsInviteAsync(string userId, string channelId, CancellationToken cancellationToken)
         {
             return await _api.GroupsInviteAsync(userId, channelId).ConfigureAwait(false);
         }
@@ -323,8 +349,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// </summary>
         /// <param name="userId">The id of the user to kick.</param>
         /// <param name="channelId">The channel to kick the user from.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="GroupKickResponse"/> representing the response.</returns>
-        public virtual async Task<GroupKickResponse> GroupsKickAsync(string userId, string channelId)
+        public virtual async Task<GroupKickResponse> GroupsKickAsync(string userId, string channelId, CancellationToken cancellationToken)
         {
             return await _api.GroupsKickAsync(userId, channelId).ConfigureAwait(false);
         }
@@ -333,8 +360,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// Wraps Slack API's GroupsLeaveAsync method.
         /// </summary>
         /// <param name="channelId">The channel id.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="GroupLeaveResponse"/> representing the response.</returns>
-        public virtual async Task<GroupLeaveResponse> GroupsLeaveAsync(string channelId)
+        public virtual async Task<GroupLeaveResponse> GroupsLeaveAsync(string channelId, CancellationToken cancellationToken)
         {
             return await _api.GroupsLeaveAsync(channelId).ConfigureAwait(false);
         }
@@ -344,8 +372,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// </summary>
         /// <param name="channelId">The channel id.</param>
         /// <param name="ts">The timestamp.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="GroupMarkResponse"/> representing the response.</returns>
-        public virtual async Task<GroupMarkResponse> GroupsMarkAsync(string channelId, DateTime ts)
+        public virtual async Task<GroupMarkResponse> GroupsMarkAsync(string channelId, DateTime ts, CancellationToken cancellationToken)
         {
             return await _api.GroupsMarkAsync(channelId, ts).ConfigureAwait(false);
         }
@@ -354,8 +383,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// Wraps Slack API's GroupsOpenAsync method.
         /// </summary>
         /// <param name="channelId">The channel id.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="GroupOpenResponse"/> representing the response.</returns>
-        public virtual async Task<GroupOpenResponse> GroupsOpenAsync(string channelId)
+        public virtual async Task<GroupOpenResponse> GroupsOpenAsync(string channelId, CancellationToken cancellationToken)
         {
             return await _api.GroupsOpenAsync(channelId).ConfigureAwait(false);
         }
@@ -365,8 +395,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// </summary>
         /// <param name="channelId">The channel id.</param>
         /// <param name="name">The new name to set to the group.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="GroupRenameResponse"/> representing the response to the group renaming.</returns>
-        public virtual async Task<GroupRenameResponse> GroupsRenameAsync(string channelId, string name)
+        public virtual async Task<GroupRenameResponse> GroupsRenameAsync(string channelId, string name, CancellationToken cancellationToken)
         {
             return await _api.GroupsRenameAsync(channelId, name).ConfigureAwait(false);
         }
@@ -376,8 +407,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// </summary>
         /// <param name="channelId">The channel id.</param>
         /// <param name="purpose">The new purpose.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="GroupSetPurposeResponse"/> representing the asynchronous operation.</returns>
-        public virtual async Task<GroupSetPurposeResponse> GroupsSetPurposeAsync(string channelId, string purpose)
+        public virtual async Task<GroupSetPurposeResponse> GroupsSetPurposeAsync(string channelId, string purpose, CancellationToken cancellationToken)
         {
             return await _api.GroupsSetPurposeAsync(channelId, purpose).ConfigureAwait(false);
         }
@@ -387,8 +419,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// </summary>
         /// <param name="channelId">The channel id.</param>
         /// <param name="topic">The new topic.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="GroupSetTopicResponse"/> representing the response to setting the topic.</returns>
-        public virtual async Task<GroupSetTopicResponse> GroupsSetTopicAsync(string channelId, string topic)
+        public virtual async Task<GroupSetTopicResponse> GroupsSetTopicAsync(string channelId, string topic, CancellationToken cancellationToken)
         {
             return await _api.GroupsSetTopicAsync(channelId, topic).ConfigureAwait(false);
         }
@@ -397,8 +430,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// Wraps Slack API's GroupsUnarchiveAsync method.
         /// </summary>
         /// <param name="channelId">The channel id.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="GroupUnarchiveResponse"/> representing the response.</returns>
-        public virtual async Task<GroupUnarchiveResponse> GroupsUnarchiveAsync(string channelId)
+        public virtual async Task<GroupUnarchiveResponse> GroupsUnarchiveAsync(string channelId, CancellationToken cancellationToken)
         {
             return await _api.GroupsUnarchiveAsync(channelId).ConfigureAwait(false);
         }
@@ -407,8 +441,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// Wraps Slack API's JoinDirectMessageChannelAsync method.
         /// </summary>
         /// <param name="user">The user to join in.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="JoinDirectMessageChannelResponse"/> representing the response.</returns>
-        public virtual async Task<JoinDirectMessageChannelResponse> JoinDirectMessageChannelAsync(string user)
+        public virtual async Task<JoinDirectMessageChannelResponse> JoinDirectMessageChannelAsync(string user, CancellationToken cancellationToken)
         {
             return await _api.JoinDirectMessageChannelAsync(user).ConfigureAwait(false);
         }
@@ -418,8 +453,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// </summary>
         /// <param name="channelId">The channel id.</param>
         /// <param name="ts">The timestamp.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="MarkResponse"/> representing the response.</returns>
-        public virtual async Task<MarkResponse> MarkChannelAsync(string channelId, DateTime ts)
+        public virtual async Task<MarkResponse> MarkChannelAsync(string channelId, DateTime ts, CancellationToken cancellationToken)
         {
             return await _api.MarkChannelAsync(channelId, ts).ConfigureAwait(false);
         }
@@ -435,8 +471,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// <param name="attachments">The attachments, if any.</param>
         /// <param name="asUser">If the message is being sent as user instead of as a bot.</param>
         /// <param name="threadTs">Info about the message coming from a thread. CURRENTLY NOT USED.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="PostEphemeralResponse"/> representing the response to the message posting.</returns>
-        public virtual async Task<PostEphemeralResponse> PostEphemeralMessageAsync(string channelId, string text, string targetUser, string parse = null, bool linkNames = false, Attachment[] attachments = null, bool asUser = false, string threadTs = null)
+        public virtual async Task<PostEphemeralResponse> PostEphemeralMessageAsync(string channelId, string text, string targetUser, string parse = null, bool linkNames = false, Attachment[] attachments = null, bool asUser = false, string threadTs = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await _api.PostEphemeralMessageAsync(channelId, text, targetUser, parse, linkNames, attachments, asUser, threadTs).ConfigureAwait(false);
         }
@@ -455,8 +492,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// <param name="iconUrl">The url of the icon with the message, if any.</param>
         /// <param name="iconEmoji">The emoji icon, if any.</param>
         /// <param name="asUser">If the message is being sent as user instead of as a bot.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="PostMessageResponse"/> representing the response to the message posting.</returns>
-        public virtual async Task<PostMessageResponse> PostMessageAsync(string channelId, string text, string botName = null, string parse = null, bool linkNames = false, IBlock[] blocks = null, Attachment[] attachments = null, bool unfurlLinks = false, string iconUrl = null, string iconEmoji = null, bool asUser = false)
+        public virtual async Task<PostMessageResponse> PostMessageAsync(string channelId, string text, string botName = null, string parse = null, bool linkNames = false, IBlock[] blocks = null, Attachment[] attachments = null, bool unfurlLinks = false, string iconUrl = null, string iconEmoji = null, bool asUser = false, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await _api.PostMessageAsync(channelId, text, botName, parse, linkNames, blocks, attachments, unfurlLinks, iconUrl, iconEmoji, asUser).ConfigureAwait(false);
         }
@@ -470,8 +508,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// <param name="enableHighlights">Set if highlights are enabled.</param>
         /// <param name="count">The count to return.</param>
         /// <param name="page">The page to search from.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="SearchResponseAll"/> representing the response for the operation.</returns>
-        public virtual async Task<SearchResponseAll> SearchAllAsync(string query, string sorting = null, SearchSortDirection? direction = null, bool enableHighlights = false, int? count = null, int? page = null)
+        public virtual async Task<SearchResponseAll> SearchAllAsync(string query, string sorting = null, SearchSortDirection? direction = null, bool enableHighlights = false, int? count = null, int? page = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await _api.SearchAllAsync(query, sorting, direction, enableHighlights, count, page).ConfigureAwait(false);
         }
@@ -485,8 +524,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// <param name="enableHighlights">Set if highlights are enabled.</param>
         /// <param name="count">The count to return.</param>
         /// <param name="page">The page to search from.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="SearchResponseFiles"/> representing the response of the search operation.</returns>
-        public virtual async Task<SearchResponseFiles> SearchFilesAsync(string query, string sorting = null, SearchSortDirection? direction = null, bool enableHighlights = false, int? count = null, int? page = null)
+        public virtual async Task<SearchResponseFiles> SearchFilesAsync(string query, string sorting = null, SearchSortDirection? direction = null, bool enableHighlights = false, int? count = null, int? page = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await _api.SearchFilesAsync(query, sorting, direction, enableHighlights, count, page).ConfigureAwait(false);
         }
@@ -500,8 +540,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// <param name="enableHighlights">Set if highlights are enabled.</param>
         /// <param name="count">The count to return.</param>
         /// <param name="page">The page to search from.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="SearchResponseMessages"/> representing the response of the search operation.</returns>
-        public virtual async Task<SearchResponseMessages> SearchMessagesAsync(string query, string sorting = null, SearchSortDirection? direction = null, bool enableHighlights = false, int? count = null, int? page = null)
+        public virtual async Task<SearchResponseMessages> SearchMessagesAsync(string query, string sorting = null, SearchSortDirection? direction = null, bool enableHighlights = false, int? count = null, int? page = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await _api.SearchMessagesAsync(query, sorting, direction, enableHighlights, count).ConfigureAwait(false);
         }
@@ -509,8 +550,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// <summary>
         /// Wraps Slack API's TestAuthAsync method.
         /// </summary>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="AuthTestResponse"/> representing the authentication operation.</returns>
-        public virtual async Task<AuthTestResponse> TestAuthAsync()
+        public virtual async Task<AuthTestResponse> TestAuthAsync(CancellationToken cancellationToken)
         {
             return await _api.TestAuthAsync().ConfigureAwait(false);
         }
@@ -543,8 +585,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// <param name="initialComment">The optional message text introducing the file in specified channels.</param>
         /// <param name="useAsync">Whether to use the async version of the upload.</param>
         /// <param name="fileType">A file type identifier. See https://api.slack.com/types/file#file_types for the available types.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="FileUploadResponse"/> representing the response.</returns>
-        public virtual async Task<FileUploadResponse> UploadFileAsync(byte[] fileData, string fileName, string[] channelIds, string title = null, string initialComment = null, bool useAsync = false, string fileType = null)
+        public virtual async Task<FileUploadResponse> UploadFileAsync(byte[] fileData, string fileName, string[] channelIds, string title = null, string initialComment = null, bool useAsync = false, string fileType = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await _api.UploadFileAsync(fileData, fileName, channelIds, title, initialComment, useAsync, fileType).ConfigureAwait(false);
         }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
@@ -52,12 +52,12 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
             }
 
             // should this message be sent as an ephemeral message
-            if (!string.IsNullOrEmpty(message.Ephemeral))
+            if (!string.IsNullOrWhiteSpace(message.Ephemeral))
             {
                 message.user = activity.Recipient.Id;
             }
 
-            if (!string.IsNullOrEmpty(message.IconUrl) || !string.IsNullOrEmpty(message.icons?.status_emoji) || !string.IsNullOrEmpty(message.username))
+            if (!string.IsNullOrWhiteSpace(message.IconUrl) || !string.IsNullOrWhiteSpace(message.icons?.status_emoji) || !string.IsNullOrWhiteSpace(message.username))
             {
                 message.AsUser = false;
             }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
@@ -52,12 +52,12 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
             }
 
             // should this message be sent as an ephemeral message
-            if (message.Ephemeral != null)
+            if (!string.IsNullOrEmpty(message.Ephemeral))
             {
                 message.user = activity.Recipient.Id;
             }
 
-            if (message.IconUrl != null || message.icons?.status_emoji != null || message.username != null)
+            if (!string.IsNullOrEmpty(message.IconUrl) || !string.IsNullOrEmpty(message.icons?.status_emoji) || !string.IsNullOrEmpty(message.username))
             {
                 message.AsUser = false;
             }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
 
             message.channel = activity.Conversation.Id;
 
-            if (!string.IsNullOrEmpty(activity.Conversation.Properties["thread_ts"].ToString()))
+            if (!string.IsNullOrWhiteSpace(activity.Conversation.Properties["thread_ts"].ToString()))
             {
                 message.ThreadTS = activity.Conversation.Properties["thread_ts"].ToString();
             }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                 message.user = activity.Recipient.Id;
             }
 
-            if (!string.IsNullOrWhiteSpace(message.IconUrl) || !string.IsNullOrWhiteSpace(message.icons?.status_emoji) || !string.IsNullOrWhiteSpace(message.username))
+            if (message.IconUrl != null || !string.IsNullOrWhiteSpace(message.icons?.status_emoji) || !string.IsNullOrWhiteSpace(message.username))
             {
                 message.AsUser = false;
             }

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.TestBot/Startup.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.TestBot/Startup.cs
@@ -15,9 +15,16 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.TestBot
 {
     public class Startup
     {
+        private readonly SlackAdapter _adapter;
+
         public Startup(IConfiguration configuration)
         {
             this.Configuration = configuration;
+
+            var options = new SimpleSlackAdapterOptions(configuration["VerificationToken"], configuration["BotToken"], configuration["SigningSecret"]);
+            var wrapper = new SlackClientWrapper(options.BotToken);
+
+            _adapter = new SlackAdapter(wrapper, options);
         }
 
         public IConfiguration Configuration { get; }
@@ -36,7 +43,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.TestBot
             // services.AddSingleton<IBotFrameworkHttpAdapter, BotFrameworkHttpAdapter>();
 
             // Create the Bot Framework Adapter.
-            services.AddSingleton<SlackAdapter>();
+            services.AddSingleton<SlackAdapter>(_adapter);
 
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
             services.AddTransient<IBot, EchoBot>();


### PR DESCRIPTION
## Description
Fixed warnings by Roslyn as well as applied the feedback added by Gabo in previous adapters, 
consisting of:
- Adding ConfigureAwait(false) to the async calls since this is a library.
- Passing on cancellation tokens inside async methods when available.
- Correctly using string.NotNullOrEmpty and similar when working with strings.
- Using status codes from HttpStatusCode enum.

**Modified files**
- SlackAdapter.cs
- SlackAdapterOptions.cs
- SlackClientWrapper.cs
- SlackHelper.cs