### PR TITLE
[SlackAdapter] Add slack adapter unit tests

### DIFF
--- a/Microsoft.Bot.Builder.sln
+++ b/Microsoft.Bot.Builder.sln
@@ -114,6 +114,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Adapt
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Adapters.Slack.TestBot", "tests\Adapters\Microsoft.Bot.Builder.Adapters.Slack.TestBot\Microsoft.Bot.Builder.Adapters.Slack.TestBot.csproj", "{170EA6A3-26A6-4A1A-A6F9-44BE5208FA06}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Bot.Builder.Adapters.Slack.Tests", "tests\Adapters\Microsoft.Bot.Builder.Adapters.Slack.Tests\Microsoft.Bot.Builder.Adapters.Slack.Tests.csproj", "{195FC24B-C4DA-4055-918D-5ABF50FD805B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug - NuGet Packages|Any CPU = Debug - NuGet Packages|Any CPU
@@ -391,6 +393,12 @@ Global
 		{D9C6FA68-340F-4338-8158-3BCBF10F320D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D9C6FA68-340F-4338-8158-3BCBF10F320D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D9C6FA68-340F-4338-8158-3BCBF10F320D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{195FC24B-C4DA-4055-918D-5ABF50FD805B}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{195FC24B-C4DA-4055-918D-5ABF50FD805B}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{195FC24B-C4DA-4055-918D-5ABF50FD805B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{195FC24B-C4DA-4055-918D-5ABF50FD805B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{195FC24B-C4DA-4055-918D-5ABF50FD805B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{195FC24B-C4DA-4055-918D-5ABF50FD805B}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A67CCC9B-3B0D-4E3D-A111-6D8A85FAA35B}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
 		{A67CCC9B-3B0D-4E3D-A111-6D8A85FAA35B}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
 		{A67CCC9B-3B0D-4E3D-A111-6D8A85FAA35B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -465,6 +473,7 @@ Global
 		{6EB0FEBB-DB84-44C8-9C5B-FD3D3D187A4F} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
 		{D9C6FA68-340F-4338-8158-3BCBF10F320D} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
 		{A67CCC9B-3B0D-4E3D-A111-6D8A85FAA35B} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{195FC24B-C4DA-4055-918D-5ABF50FD805B} = {A6539B8D-3806-4E21-9DFE-11AEC075D2E3}
 		{D2D9931A-EBFC-4923-A7BC-EF8BBD76D079} = {6230B915-B238-4E57-AAC4-06B4498F540F}
 		{170EA6A3-26A6-4A1A-A6F9-44BE5208FA06} = {E8CD434A-306F-41D9-B67D-BFFF3287354D}
 	EndGlobalSection

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/Microsoft.Bot.Builder.Adapters.Slack.Tests.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/Microsoft.Bot.Builder.Adapters.Slack.Tests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Moq" Version="4.13.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/Microsoft.Bot.Builder.Adapters.Slack.Tests.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/Microsoft.Bot.Builder.Adapters.Slack.Tests.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\libraries\Adapters\Microsoft.Bot.Builder.Adapters.Slack\Microsoft.Bot.Builder.Adapters.Slack.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/SlackAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/SlackAdapterTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using Moq;
 using Xunit;
 
 namespace Microsoft.Bot.Builder.Adapters.Slack.Tests
@@ -12,6 +13,29 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Tests
         public void Constructor_Should_Fail_With_Null_Options()
         {
             Assert.Throws<ArgumentNullException>(() => new SlackAdapter(null));
+        }
+
+        [Fact]
+        public void Constructor_Should_Fail_With_Null_Security_Mechanisms()
+        {
+            var slackAdapterOptions = new SlackAdapterOptions()
+            {
+                VerificationToken = null,
+                ClientSigningSecret = null,
+            };
+
+            Assert.Throws<Exception>(() => new SlackAdapter(slackAdapterOptions));
+        }
+
+        [Fact]
+        public void Constructor_Succeeds()
+        {
+            var options = new Mock<SlackAdapterOptions>();
+            options.Object.VerificationToken = "VerificationToken";
+            options.Object.ClientSigningSecret = "ClientSigningSecret";
+            options.Object.BotToken = "BotToken";
+
+            Assert.NotNull(new SlackAdapter(options.Object));
         }
     }
 }

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/SlackAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/SlackAdapterTests.cs
@@ -1,0 +1,17 @@
+﻿// Copyright(c) Microsoft Corporation.All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Adapters.Slack.Tests
+{
+    public class SlackAdapterTests
+    {
+        [Fact]
+        public void Constructor_Should_Fail_With_Null_Options()
+        {
+            Assert.Throws<ArgumentNullException>(() => new SlackAdapter(null));
+        }
+    }
+}


### PR DESCRIPTION
### Description
- Create the `Microsoft.Bot.Builder.Adapters.Slack.Tests` project for testing the Slack Adapter
- Create the `SlackAdapterTests` file for testing the SlackAdapter class. Until now, it only tests the Constructor.