### PR TITLE
[Slack Adapter] Move methods from SlackAdapter class

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapter.cs
@@ -33,24 +33,8 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         public SlackAdapter(SlackClientWrapper slackClient)
             : base()
         {
-            if (string.IsNullOrWhiteSpace(slackClient.Options.VerificationToken) && string.IsNullOrWhiteSpace(slackClient.Options.ClientSigningSecret))
-            {
-                var warning =
-                    "****************************************************************************************" +
-                    "* WARNING: Your bot is operating without recommended security mechanisms in place.     *" +
-                    "* Initialize your adapter with a clientSigningSecret parameter to enable               *" +
-                    "* verification that all incoming webhooks originate with Slack:                        *" +
-                    "*                                                                                      *" +
-                    "* var adapter = new SlackAdapter({clientSigningSecret: <my secret from slack>});       *" +
-                    "*                                                                                      *" +
-                    "****************************************************************************************" +
-                    ">> Slack docs: https://api.slack.com/docs/verifying-requests-from-slack";
-
-                throw new Exception(warning + Environment.NewLine + "Required: include a verificationToken or clientSigningSecret to verify incoming Events API webhooks");
-            }
-
             _slackClient = slackClient ?? throw new ArgumentNullException(nameof(slackClient));
-            _slackClient.LoginWithSlack(default(CancellationToken)).Wait();
+            _slackClient.LoginWithSlackAsync(default(CancellationToken)).Wait();
         }
 
         /// <summary>
@@ -216,7 +200,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                 return;
             }
 
-            if (!SlackHelper.VerifySignature(_slackClient.Options.ClientSigningSecret, request, body))
+            if (!_slackClient.VerifySignature(_slackClient.Options.ClientSigningSecret, request, body))
             {
                 response.StatusCode = (int)HttpStatusCode.Unauthorized;
             }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapter.cs
@@ -23,23 +23,17 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         private const string PostEphemeralMessageUrl = "https://slack.com/api/chat.postEphemeral";
         private const string SlackOAuthUrl = "https://slack.com/oauth/authorize?client_id=";
 
-        private readonly SlackAdapterOptions _options;
         private readonly SlackClientWrapper _slackClient;
-
-        private string _identity;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SlackAdapter"/> class.
         /// Create a Slack adapter.
         /// </summary>
         /// <param name="slackClient">An initialized instance of the SlackClientWrapper class.</param>
-        /// <param name="options">An object containing API credentials, a webhook verification token and other options.</param>
-        public SlackAdapter(SlackClientWrapper slackClient, SlackAdapterOptions options)
+        public SlackAdapter(SlackClientWrapper slackClient)
             : base()
         {
-            _options = options ?? throw new ArgumentNullException(nameof(options));
-
-            if (string.IsNullOrWhiteSpace(_options.VerificationToken) && string.IsNullOrWhiteSpace(_options.ClientSigningSecret))
+            if (string.IsNullOrWhiteSpace(slackClient.Options.VerificationToken) && string.IsNullOrWhiteSpace(slackClient.Options.ClientSigningSecret))
             {
                 string warning =
                     "****************************************************************************************" +
@@ -56,76 +50,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
             }
 
             _slackClient = slackClient;
-            LoginWithSlack().Wait();
-        }
-
-        /// <summary>
-        /// Get a Slack API client with the correct credentials based on the team identified in the incoming activity.
-        /// This is used by many internal functions to get access to the Slack API, and is exposed as `bot.api` on any bot worker instances.
-        /// </summary>
-        /// <param name="activity">An Activity object.</param>
-        /// <returns>Returns an instance of the Slack API.</returns>
-        public async Task<SlackClientWrapper> GetAPIAsync(Activity activity)
-        {
-            if (_slackClient != null)
-            {
-                return _slackClient;
-            }
-
-            if (activity.Conversation.Properties["team"] == null)
-            {
-                throw new Exception($"Unable to create API based on activity:{activity}");
-            }
-
-            var token = await _options.GetTokenForTeam(activity.Conversation.Properties["team"].ToString()).ConfigureAwait(false);
-            return string.IsNullOrWhiteSpace(token) ? new SlackClientWrapper(token) : throw new Exception("Missing credentials for team.");
-        }
-
-        /// <summary>
-        /// Get the bot user id associated with the team on which an incoming activity originated. This is used internally by the SlackMessageTypeMiddleware to identify direct_mention and mention events.
-        /// In single-team mode, this will pull the information from the Slack API at launch.
-        /// In multi-team mode, this will use the `getBotUserByTeam` method passed to the constructor to pull the information from a developer-defined source.
-        /// </summary>
-        /// <param name="activity">An Activity.</param>
-        /// <returns>The identity of the bot's user.</returns>
-        public async Task<string> GetBotUserByTeamAsync(Activity activity)
-        {
-            if (!string.IsNullOrWhiteSpace(_identity))
-            {
-                return _identity;
-            }
-
-            if (activity.Conversation.Properties["team"] == null)
-            {
-                return null;
-            }
-
-            // multi-team mode
-            var userId = await _options.GetBotUserByTeam(activity.Conversation.Properties["team"].ToString()).ConfigureAwait(false);
-            return !string.IsNullOrWhiteSpace(userId) ? userId : throw new Exception("Missing credentials for team.");
-        }
-
-        /// <summary>
-        /// Get the oauth link for this bot, based on the clientId and scopes passed in to the constructor.
-        /// </summary>
-        /// <returns>A url pointing to the first step in Slack's oauth flow.</returns>
-        public string GetInstallLink()
-        {
-            return (!string.IsNullOrWhiteSpace(_options.ClientId) && _options.GetScopes().Length > 0)
-                ? SlackOAuthUrl + _options.ClientId + "&scope=" + string.Join(",", _options.GetScopes())
-                : throw new Exception("getInstallLink() cannot be called without clientId and scopes in adapter options.");
-        }
-
-        /// <summary>
-        /// Validates an oauth code sent by Slack during the install process.
-        /// </summary>
-        /// <param name="code">The value found in `req.query.code` as part of Slack's response to the oauth flow.</param>
-        /// <returns>The access token.</returns>
-        public async Task<AccessTokenResponse> ValidateOauthCodeAsync(string code)
-        {
-            var helpers = new SlackClientHelpers();
-            var results = await helpers.GetAccessTokenAsync(_options.ClientId, _options.ClientSecret, _options.RedirectUri.AbsolutePath, code).ConfigureAwait(false);
-            return results.ok ? results : throw new Exception(results.error);
+            _slackClient.LoginWithSlack(default(CancellationToken)).Wait();
         }
 
         /// <summary>
@@ -148,7 +73,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                     SlackResponse responseInString;
 
                     var data = new NameValueCollection();
-                    data["token"] = _options.BotToken;
+                    data["token"] = _slackClient.Options.BotToken;
                     data["channel"] = message.channel;
                     data["text"] = message.text;
                     data["thread_ts"] = message.ThreadTS;
@@ -195,9 +120,8 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         {
             if (activity.Id != null && activity.Conversation != null)
             {
-                NewSlackMessage message = SlackHelper.ActivityToSlack(activity);
-                SlackClientWrapper slack = await GetAPIAsync(activity).ConfigureAwait(false);
-                var results = await slack.UpdateAsync(activity.Timestamp.ToString(), activity.ChannelId, message.text, null, null, false, null, false, cancellationToken).ConfigureAwait(false);
+                var message = SlackHelper.ActivityToSlack(activity);
+                var results = await _slackClient.UpdateAsync(activity.Timestamp.ToString(), activity.ChannelId, message.text, null, null, false, null, false, cancellationToken).ConfigureAwait(false);
                 if (!results.ok)
                 {
                     throw new Exception($"Error updating activity on Slack:{results}");
@@ -225,8 +149,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         {
             if (reference.ActivityId != null && reference.Conversation != null)
             {
-                SlackClientWrapper slack = await GetAPIAsync(turnContext.Activity).ConfigureAwait(false);
-                var results = await slack.DeleteMessageAsync(reference.ChannelId, turnContext.Activity.Timestamp.Value.DateTime, cancellationToken).ConfigureAwait(false);
+                var results = await _slackClient.DeleteMessageAsync(reference.ChannelId, turnContext.Activity.Timestamp.Value.DateTime, cancellationToken).ConfigureAwait(false);
             }
             else
             {
@@ -280,7 +203,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                 return;
             }
 
-            if (!SlackHelper.VerifySignature(_options.ClientSigningSecret, request, body))
+            if (!SlackHelper.VerifySignature(_slackClient.Options.ClientSigningSecret, request, body))
             {
                 response.StatusCode = (int)HttpStatusCode.Unauthorized;
             }
@@ -290,7 +213,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                 {
                     // handle interactive_message callbacks and block_actions
                     slackEvent = JsonConvert.ToString(slackEvent.payload);
-                    if (!string.IsNullOrWhiteSpace(_options.VerificationToken) && slackEvent.token != _options.VerificationToken)
+                    if (!string.IsNullOrWhiteSpace(_slackClient.Options.VerificationToken) && slackEvent.token != _slackClient.Options.VerificationToken)
                     {
                         response.StatusCode = (int)HttpStatusCode.Forbidden;
                         response.ContentType = "text/plain";
@@ -324,7 +247,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                         activity.Conversation.Properties["team"] = slackEvent.team.id;
 
                         // this complains because of extra fields in conversation
-                        activity.Recipient.Id = await GetBotUserByTeamAsync(activity).ConfigureAwait(false);
+                        activity.Recipient.Id = await _slackClient.GetBotUserByTeamAsync(activity, default(CancellationToken)).ConfigureAwait(false);
 
                         // create a conversation reference
                         using (var context = new TurnContext(this, activity))
@@ -344,7 +267,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                 else if (slackEvent.type == "event_callback")
                 {
                     // this is an event api post
-                    if (!string.IsNullOrWhiteSpace(_options.VerificationToken) && slackEvent.token != _options.VerificationToken)
+                    if (!string.IsNullOrWhiteSpace(_slackClient.Options.VerificationToken) && slackEvent.token != _slackClient.Options.VerificationToken)
                     {
                         response.StatusCode = (int)HttpStatusCode.Forbidden;
                         response.ContentType = "text/plain";
@@ -379,7 +302,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                         activity.Conversation.Properties["thread_ts"] = slackEvent["event"].thread_ts;
 
                         // this complains because of extra fields in conversation
-                        activity.Recipient.Id = await GetBotUserByTeamAsync(activity).ConfigureAwait(false);
+                        activity.Recipient.Id = await _slackClient.GetBotUserByTeamAsync(activity, default(CancellationToken)).ConfigureAwait(false);
 
                         // Normalize the location of the team id
                         activity.GetChannelData<NewSlackMessage>().team = slackEvent.team_id;
@@ -411,7 +334,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                 }
                 else if (slackEvent.Command != null)
                 {
-                    if (!string.IsNullOrWhiteSpace(_options.VerificationToken) && slackEvent.Token != _options.VerificationToken)
+                    if (!string.IsNullOrWhiteSpace(_slackClient.Options.VerificationToken) && slackEvent.Token != _slackClient.Options.VerificationToken)
                     {
                         response.StatusCode = (int)HttpStatusCode.Forbidden;
                         response.ContentType = "text/plain";
@@ -443,7 +366,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                             Type = ActivityTypes.Event,
                         };
 
-                        activity.Recipient.Id = await GetBotUserByTeamAsync(activity).ConfigureAwait(false);
+                        activity.Recipient.Id = await _slackClient.GetBotUserByTeamAsync(activity, default(CancellationToken)).ConfigureAwait(false);
 
                         // Normalize the location of the team id
                         activity.GetChannelData<NewSlackMessage>().team = slackEvent.TeamId;
@@ -469,23 +392,6 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                 else
                 {
                     throw new Exception($"Unknown Slack event type {slackEvent}");
-                }
-            }
-        }
-
-        private async Task LoginWithSlack()
-        {
-            if (_options.BotToken != null)
-            {
-                AuthTestResponse response = await _slackClient.TestAuthAsync(default(CancellationToken)).ConfigureAwait(false);
-                _identity = response.user_id;
-            }
-            else
-            {
-                if (string.IsNullOrWhiteSpace(_options.ClientId) || string.IsNullOrWhiteSpace(_options.ClientSecret) ||
-                _options.RedirectUri != null || _options.GetScopes().Length > 0)
-                {
-                    throw new Exception("Missing Slack API credentials! Provide clientId, clientSecret, scopes and redirectUri as part of the SlackAdapter options.");
                 }
             }
         }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapter.cs
@@ -200,9 +200,12 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                 return;
             }
 
-            if (!_slackClient.VerifySignature(_slackClient.Options.ClientSigningSecret, request, body))
+            if (!_slackClient.VerifySignature(request, body))
             {
                 response.StatusCode = (int)HttpStatusCode.Unauthorized;
+                response.ContentType = "text/plain";
+                string text = $"Rejected due to mismatched header signature";
+                await response.WriteAsync(text, cancellationToken).ConfigureAwait(false);
             }
             else
             {

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackClientWrapper.cs
@@ -682,11 +682,10 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// <summary>
         /// Validates the local secret against the one obtained from the request header.
         /// </summary>
-        /// <param name="secret">The local stored secret.</param>
         /// <param name="request">The <see cref="HttpRequest"/> with the signature.</param>
         /// <param name="body">The raw body of the request.</param>
         /// <returns>The result of the comparison between the signature in the request and hashed secret.</returns>
-        public bool VerifySignature(string secret, HttpRequest request, string body)
+        public bool VerifySignature(HttpRequest request, string body)
         {
             string baseString;
 
@@ -695,7 +694,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
             object[] signature = { "v0", timestamp.ToString(), body };
             baseString = string.Join(":", signature);
 
-            using (var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret)))
+            using (var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(Options.ClientSigningSecret)))
             {
                 var hashArray = hmac.ComputeHash(Encoding.UTF8.GetBytes(baseString));
 

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
@@ -86,34 +86,6 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         }
 
         /// <summary>
-        /// Validates the local secret against the one obtained from the request header.
-        /// </summary>
-        /// <param name="secret">The local stored secret.</param>
-        /// <param name="request">The <see cref="HttpRequest"/> with the signature.</param>
-        /// <param name="body">The raw body of the request.</param>
-        /// <returns>The result of the comparison between the signature in the request and hashed secret.</returns>
-        public static bool VerifySignature(string secret, HttpRequest request, string body)
-        {
-            string baseString;
-
-            var timestamp = request.Headers["X-Slack-Request-Timestamp"];
-
-            object[] signature = { "v0", timestamp.ToString(), body };
-            baseString = string.Join(":", signature);
-
-            using (var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret)))
-            {
-                var hashArray = hmac.ComputeHash(Encoding.UTF8.GetBytes(baseString));
-
-                var hash = string.Concat("v0=", BitConverter.ToString(hashArray).Replace("-", string.Empty)).ToUpperInvariant();
-
-                var retrievedSignature = request.Headers["X-Slack-Signature"].ToString().ToUpperInvariant();
-
-                return hash == retrievedSignature;
-            }
-        }
-
-        /// <summary>
         /// Converts the 'Event' subobject of the Slack payload into a NewSlackMessage for assigning to ChannelData.
         /// </summary>
         /// <param name="slackEvent">A dynamic payload from the request body sent by Slack.</param>

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.TestBot/Startup.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.TestBot/Startup.cs
@@ -22,9 +22,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.TestBot
             this.Configuration = configuration;
 
             var options = new SimpleSlackAdapterOptions(configuration["VerificationToken"], configuration["BotToken"], configuration["SigningSecret"]);
-            var wrapper = new SlackClientWrapper(options.BotToken);
+            var wrapper = new SlackClientWrapper(options);
 
-            _adapter = new SlackAdapter(wrapper, options);
+            _adapter = new SlackAdapter(wrapper);
         }
 
         public IConfiguration Configuration { get; }


### PR DESCRIPTION
## Description
Moved methods that don't belong to the Slack Adapter class into either the API Wrapper or the Helper class, leaving the Adapter to deal with only the BotAdapter responsibilities.

**Methods moved from SlackAdapter:**

- LoginWithSlack
- GetBotUserByTeamAsync

**Properties moved from SlackAdapter:**

- Options 
- Identity

 

**Methods deleted:**

- GetInstallLink (not used)
- ValidateOauthCodeAsync (not used)
- GetAPIAsync (deprecated)