### PR TITLE
[Slack adapter] Add unit tests

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackClientWrapper.cs
@@ -687,6 +687,11 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// <returns>The result of the comparison between the signature in the request and hashed secret.</returns>
         public bool VerifySignature(HttpRequest request, string body)
         {
+            if (request == null || string.IsNullOrWhiteSpace(body))
+            {
+                return false;
+            }
+
             string baseString;
 
             var timestamp = request.Headers["X-Slack-Request-Timestamp"];

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
@@ -5,9 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Runtime.CompilerServices;
-using System.Security.Cryptography;
-using System.Text;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Bot.Schema;
 
 #if SIGNASSEMBLY
@@ -86,14 +83,20 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         }
 
         /// <summary>
-        /// Converts the 'Event' subobject of the Slack payload into a NewSlackMessage for assigning to ChannelData.
+        /// Converts the 'Event' subobject of the Slack payload into a NewSlackMessage.
         /// </summary>
         /// <param name="slackEvent">A dynamic payload from the request body sent by Slack.</param>
         /// <returns>A NewSlackMessage with the resulting properties.</returns>
-        public static NewSlackMessage GetChannelDataFromSlackEvent(dynamic slackEvent)
+        public static NewSlackMessage GetMessageFromSlackEvent(dynamic slackEvent)
         {
-            // Convert Slack timestamp format to DateTime
+            if (slackEvent == null)
+            {
+                return null;
+            }
+
             var eventProperty = slackEvent["event"];
+
+            // Convert Slack timestamp format to DateTime
             string[] splitString = eventProperty.ts.ToString().Split('.');
             var dateTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).ToLocalTime().AddSeconds(Convert.ToDouble(splitString[0], CultureInfo.InvariantCulture));
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/Files/MessageBody.json
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/Files/MessageBody.json
@@ -1,0 +1,22 @@
+{
+  "token": "testToken",
+  "team_id": "teamId",
+  "api_app_id": "apiAppId",
+  "event": {
+    "client_msg_id": "clientId",
+    "type": "message",
+    "text": "Hello",
+    "user": "userId",
+    "ts": "1568915625.001000",
+    "team": "teamId",
+    "channel": "channelId",
+    "event_ts": "1568915625.001000",
+    "channel_type": "im"
+  },
+  "type": "event_callback",
+  "event_id": "eventId",
+  "event_time": 1568915625,
+  "authed_users": [
+    "userId"
+  ]
+}

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/Microsoft.Bot.Builder.Adapters.Slack.Tests.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/Microsoft.Bot.Builder.Adapters.Slack.Tests.csproj
@@ -23,4 +23,10 @@
     <ProjectReference Include="..\..\..\libraries\Adapters\Microsoft.Bot.Builder.Adapters.Slack\Microsoft.Bot.Builder.Adapters.Slack.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="Files\MessageBody.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/SlackAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/SlackAdapterTests.cs
@@ -14,25 +14,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Tests
     public class SlackAdapterTests
     {
         [Fact]
-        public void ConstructorShouldFailWithNullOptions()
+        public void ConstructorShouldFailWithNullClient()
         {
-            var slackApi = new Mock<SlackClientWrapper>("BotToken");
-
-            Assert.Throws<ArgumentNullException>(() => new SlackAdapter(slackApi.Object, null));
-        }
-
-        [Fact]
-        public void ConstructorShouldFailWithNullSecurityMechanisms()
-        {
-            var slackAdapterOptions = new SlackAdapterOptions()
-            {
-                VerificationToken = null,
-                ClientSigningSecret = null,
-            };
-
-            var slackApi = new Mock<SlackClientWrapper>("BotToken");
-
-            Assert.Throws<Exception>(() => new SlackAdapter(slackApi.Object, slackAdapterOptions));
+            Assert.Throws<ArgumentNullException>(() => new SlackAdapter(null));
         }
 
         [Fact]
@@ -43,12 +27,12 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Tests
             options.Object.ClientSigningSecret = "ClientSigningSecret";
             options.Object.BotToken = "BotToken";
 
-            var slackApi = new Mock<SlackClientWrapper>(options.Object.BotToken);
+            var slackApi = new Mock<SlackClientWrapper>(options.Object);
 
             // TODO: delete when LoginWithSlack method gets removed from SlackAdapter.
             slackApi.Setup(x => x.TestAuthAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult("mockedUserId"));
 
-            Assert.NotNull(new SlackAdapter(slackApi.Object, options.Object));
+            Assert.NotNull(new SlackAdapter(slackApi.Object));
         }
 
         [Fact]
@@ -59,12 +43,12 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Tests
             options.Object.ClientSigningSecret = "ClientSigningSecret";
             options.Object.BotToken = "BotToken";
 
-            var slackApi = new Mock<SlackClientWrapper>(options.Object.BotToken);
+            var slackApi = new Mock<SlackClientWrapper>(options.Object);
 
             // TODO: delete when LoginWithSlack method gets removed from SlackAdapter.
             slackApi.Setup(x => x.TestAuthAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult("mockedUserId"));
 
-            var slackAdapter = new SlackAdapter(slackApi.Object, options.Object);
+            var slackAdapter = new SlackAdapter(slackApi.Object);
 
             var activity = new Activity
             {
@@ -87,12 +71,12 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Tests
             options.Object.ClientSigningSecret = "ClientSigningSecret";
             options.Object.BotToken = "BotToken";
 
-            var slackApi = new Mock<SlackClientWrapper>(options.Object.BotToken);
+            var slackApi = new Mock<SlackClientWrapper>(options.Object);
 
             // TODO: delete when LoginWithSlack method gets removed from SlackAdapter.
             slackApi.Setup(x => x.TestAuthAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult("mockedUserId"));
 
-            var slackAdapter = new SlackAdapter(slackApi.Object, options.Object);
+            var slackAdapter = new SlackAdapter(slackApi.Object);
 
             var activity = new Activity
             {
@@ -116,13 +100,13 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Tests
             options.Object.ClientSigningSecret = "ClientSigningSecret";
             options.Object.BotToken = "BotToken";
 
-            var slackApi = new Mock<SlackClientWrapper>(options.Object.BotToken);
+            var slackApi = new Mock<SlackClientWrapper>(options.Object);
 
             // TODO: delete when LoginWithSlack method gets removed from SlackAdapter.
             slackApi.Setup(x => x.TestAuthAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult("mockedUserId"));
             slackApi.Setup(x => x.UpdateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), null, It.IsAny<bool>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(new UpdateResponse { ok = true }));
 
-            var slackAdapter = new SlackAdapter(slackApi.Object, options.Object);
+            var slackAdapter = new SlackAdapter(slackApi.Object);
 
             var activity = new Mock<Activity>().SetupAllProperties();
             activity.Object.Id = "MockActivityId";
@@ -147,12 +131,12 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Tests
             options.Object.ClientSigningSecret = "ClientSigningSecret";
             options.Object.BotToken = "BotToken";
 
-            var slackApi = new Mock<SlackClientWrapper>(options.Object.BotToken);
+            var slackApi = new Mock<SlackClientWrapper>(options.Object);
 
             // TODO: delete when LoginWithSlack method gets removed from SlackAdapter.
             slackApi.Setup(x => x.TestAuthAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult("mockedUserId"));
 
-            var slackAdapter = new SlackAdapter(slackApi.Object, options.Object);
+            var slackAdapter = new SlackAdapter(slackApi.Object);
 
             var context = new TurnContext(slackAdapter, new Activity());
 
@@ -170,12 +154,12 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Tests
             options.Object.ClientSigningSecret = "ClientSigningSecret";
             options.Object.BotToken = "BotToken";
 
-            var slackApi = new Mock<SlackClientWrapper>(options.Object.BotToken);
+            var slackApi = new Mock<SlackClientWrapper>(options.Object);
 
             // TODO: delete when LoginWithSlack method gets removed from SlackAdapter.
             slackApi.Setup(x => x.TestAuthAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult("mockedUserId"));
 
-            var slackAdapter = new SlackAdapter(slackApi.Object, options.Object);
+            var slackAdapter = new SlackAdapter(slackApi.Object);
 
             var reference = new ConversationReference();
 
@@ -193,12 +177,12 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Tests
             options.Object.ClientSigningSecret = "ClientSigningSecret";
             options.Object.BotToken = "BotToken";
 
-            var slackApi = new Mock<SlackClientWrapper>(options.Object.BotToken);
+            var slackApi = new Mock<SlackClientWrapper>(options.Object);
 
             // TODO: delete when LoginWithSlack method gets removed from SlackAdapter.
             slackApi.Setup(x => x.TestAuthAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult("mockedUserId"));
 
-            var slackAdapter = new SlackAdapter(slackApi.Object, options.Object);
+            var slackAdapter = new SlackAdapter(slackApi.Object);
 
             var context = new TurnContext(slackAdapter, new Activity());
 
@@ -221,12 +205,12 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Tests
             options.Object.ClientSigningSecret = "ClientSigningSecret";
             options.Object.BotToken = "BotToken";
 
-            var slackApi = new Mock<SlackClientWrapper>(options.Object.BotToken);
+            var slackApi = new Mock<SlackClientWrapper>(options.Object);
 
             // TODO: delete when LoginWithSlack method gets removed from SlackAdapter.
             slackApi.Setup(x => x.TestAuthAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult("mockedUserId"));
 
-            var slackAdapter = new SlackAdapter(slackApi.Object, options.Object);
+            var slackAdapter = new SlackAdapter(slackApi.Object);
 
             var context = new TurnContext(slackAdapter, new Activity());
 
@@ -251,13 +235,13 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Tests
             options.Object.ClientSigningSecret = "ClientSigningSecret";
             options.Object.BotToken = "BotToken";
 
-            var slackApi = new Mock<SlackClientWrapper>(options.Object.BotToken);
+            var slackApi = new Mock<SlackClientWrapper>(options.Object);
 
             // TODO: delete when LoginWithSlack method gets removed from SlackAdapter.
             slackApi.Setup(x => x.TestAuthAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult("mockedUserId"));
             slackApi.Setup(x => x.DeleteMessageAsync(It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>())).Callback(() => { deletedMessages++; });
 
-            var slackAdapter = new SlackAdapter(slackApi.Object, options.Object);
+            var slackAdapter = new SlackAdapter(slackApi.Object);
 
             var activity = new Mock<Activity>();
             activity.Object.Timestamp = new DateTimeOffset();

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/SlackAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/SlackAdapterTests.cs
@@ -64,6 +64,56 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Tests
         }
 
         [Fact]
+        public async Task UpdateActivityAsyncShouldFailWithNullContext()
+        {
+            var options = new Mock<SlackAdapterOptions>();
+            options.Object.VerificationToken = "VerificationToken";
+            options.Object.ClientSigningSecret = "ClientSigningSecret";
+            options.Object.BotToken = "BotToken";
+
+            var slackApi = new Mock<SlackClientWrapper>(options.Object);
+
+            // TODO: delete when LoginWithSlack method gets removed from SlackAdapter.
+            slackApi.Setup(x => x.TestAuthAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult("mockedUserId"));
+
+            var slackAdapter = new SlackAdapter(slackApi.Object);
+
+            var activity = new Activity
+            {
+                Id = "testId",
+                Conversation = null,
+            };
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await slackAdapter.UpdateActivityAsync(null, activity, default);
+            });
+        }
+
+        [Fact]
+        public async Task UpdateActivityAsyncShouldFailWithNullActivity()
+        {
+            var options = new Mock<SlackAdapterOptions>();
+            options.Object.VerificationToken = "VerificationToken";
+            options.Object.ClientSigningSecret = "ClientSigningSecret";
+            options.Object.BotToken = "BotToken";
+
+            var slackApi = new Mock<SlackClientWrapper>(options.Object);
+
+            // TODO: delete when LoginWithSlack method gets removed from SlackAdapter.
+            slackApi.Setup(x => x.TestAuthAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult("mockedUserId"));
+
+            var slackAdapter = new SlackAdapter(slackApi.Object);
+
+            var turnContext = new TurnContext(slackAdapter, new Activity());
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await slackAdapter.UpdateActivityAsync(turnContext, null, default);
+            });
+        }
+
+        [Fact]
         public async Task UpdateActivityAsyncShouldFailWithNullActivityConversation()
         {
             var options = new Mock<SlackAdapterOptions>();

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/SlackAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/SlackAdapterTests.cs
@@ -138,5 +138,140 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Tests
 
             Assert.Equal(activity.Object.Id, response.Id);
         }
+
+        [Fact]
+        public async Task DeleteActivityAsyncShouldFailWithNullReference()
+        {
+            var options = new Mock<SlackAdapterOptions>();
+            options.Object.VerificationToken = "VerificationToken";
+            options.Object.ClientSigningSecret = "ClientSigningSecret";
+            options.Object.BotToken = "BotToken";
+
+            var slackApi = new Mock<SlackClientWrapper>(options.Object.BotToken);
+
+            // TODO: delete when LoginWithSlack method gets removed from SlackAdapter.
+            slackApi.Setup(x => x.TestAuthAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult("mockedUserId"));
+
+            var slackAdapter = new SlackAdapter(slackApi.Object, options.Object);
+
+            var context = new TurnContext(slackAdapter, new Activity());
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await slackAdapter.DeleteActivityAsync(context, null, default);
+            });
+        }
+
+        [Fact]
+        public async Task DeleteActivityAsyncShouldFailWithNullTurnContext()
+        {
+            var options = new Mock<SlackAdapterOptions>();
+            options.Object.VerificationToken = "VerificationToken";
+            options.Object.ClientSigningSecret = "ClientSigningSecret";
+            options.Object.BotToken = "BotToken";
+
+            var slackApi = new Mock<SlackClientWrapper>(options.Object.BotToken);
+
+            // TODO: delete when LoginWithSlack method gets removed from SlackAdapter.
+            slackApi.Setup(x => x.TestAuthAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult("mockedUserId"));
+
+            var slackAdapter = new SlackAdapter(slackApi.Object, options.Object);
+
+            var reference = new ConversationReference();
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await slackAdapter.DeleteActivityAsync(null, reference, default);
+            });
+        }
+
+        [Fact]
+        public async Task DeleteActivityAsyncShouldFailWithNullChannelId()
+        {
+            var options = new Mock<SlackAdapterOptions>();
+            options.Object.VerificationToken = "VerificationToken";
+            options.Object.ClientSigningSecret = "ClientSigningSecret";
+            options.Object.BotToken = "BotToken";
+
+            var slackApi = new Mock<SlackClientWrapper>(options.Object.BotToken);
+
+            // TODO: delete when LoginWithSlack method gets removed from SlackAdapter.
+            slackApi.Setup(x => x.TestAuthAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult("mockedUserId"));
+
+            var slackAdapter = new SlackAdapter(slackApi.Object, options.Object);
+
+            var context = new TurnContext(slackAdapter, new Activity());
+
+            var reference = new ConversationReference
+            {
+                ChannelId = null,
+            };
+
+            await Assert.ThrowsAsync<ArgumentException>(async () =>
+            {
+                await slackAdapter.DeleteActivityAsync(context, reference, default);
+            });
+        }
+
+        [Fact]
+        public async Task DeleteActivityAsyncShouldFailWithNullTimestamp()
+        {
+            var options = new Mock<SlackAdapterOptions>();
+            options.Object.VerificationToken = "VerificationToken";
+            options.Object.ClientSigningSecret = "ClientSigningSecret";
+            options.Object.BotToken = "BotToken";
+
+            var slackApi = new Mock<SlackClientWrapper>(options.Object.BotToken);
+
+            // TODO: delete when LoginWithSlack method gets removed from SlackAdapter.
+            slackApi.Setup(x => x.TestAuthAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult("mockedUserId"));
+
+            var slackAdapter = new SlackAdapter(slackApi.Object, options.Object);
+
+            var context = new TurnContext(slackAdapter, new Activity());
+
+            var reference = new ConversationReference
+            {
+                ChannelId = "testChannelId",
+            };
+
+            await Assert.ThrowsAsync<ArgumentException>(async () =>
+            {
+                await slackAdapter.DeleteActivityAsync(context, reference, default);
+            });
+        }
+
+        [Fact]
+        public async Task DeleteActivityAsyncShouldSucceed()
+        {
+            var deletedMessages = 0;
+
+            var options = new Mock<SlackAdapterOptions>();
+            options.Object.VerificationToken = "VerificationToken";
+            options.Object.ClientSigningSecret = "ClientSigningSecret";
+            options.Object.BotToken = "BotToken";
+
+            var slackApi = new Mock<SlackClientWrapper>(options.Object.BotToken);
+
+            // TODO: delete when LoginWithSlack method gets removed from SlackAdapter.
+            slackApi.Setup(x => x.TestAuthAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult("mockedUserId"));
+            slackApi.Setup(x => x.DeleteMessageAsync(It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>())).Callback(() => { deletedMessages++; });
+
+            var slackAdapter = new SlackAdapter(slackApi.Object, options.Object);
+
+            var activity = new Mock<Activity>();
+            activity.Object.Timestamp = new DateTimeOffset();
+
+            var context = new TurnContext(slackAdapter, activity.Object);
+
+            var reference = new ConversationReference
+            {
+                ChannelId = "channelId",
+            };
+
+            await slackAdapter.DeleteActivityAsync(context, reference, default);
+
+            Assert.Equal(1, deletedMessages);
+        }
     }
 }

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/SlackClientWrapperTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/SlackClientWrapperTests.cs
@@ -1,0 +1,46 @@
+﻿// Copyright(c) Microsoft Corporation.All rights reserved.
+// Licensed under the MIT License.
+
+using System.IO;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Adapters.Slack.Tests
+{
+    public class SlackClientWrapperTests
+    {
+        [Fact]
+        public void VerifySignatureShouldReturnFalseWithNullParameters()
+        {
+            var options = new Mock<SlackAdapterOptions>();
+            options.Object.VerificationToken = "VerificationToken";
+            options.Object.ClientSigningSecret = "ClientSigningSecret";
+            options.Object.BotToken = "BotToken";
+
+            var slackApi = new SlackClientWrapper(options.Object);
+
+            Assert.False(slackApi.VerifySignature(null, null));
+        }
+
+        [Fact]
+        public void VerifySignatureShouldReturnTrue()
+        {
+            var options = new Mock<SlackAdapterOptions>();
+            options.Object.VerificationToken = "VerificationToken";
+            options.Object.ClientSigningSecret = "ClientSigningSecret";
+            options.Object.BotToken = "BotToken";
+
+            var slackApi = new SlackClientWrapper(options.Object);
+
+            var body = File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\MessageBody.json");
+
+            var httpRequest = new Mock<HttpRequest>();
+            httpRequest.Setup(req => req.Headers.ContainsKey(It.IsAny<string>())).Returns(true);
+            httpRequest.SetupGet(req => req.Headers["X-Slack-Request-Timestamp"]).Returns("0001-01-01T00:00:00+00:00");
+            httpRequest.SetupGet(req => req.Headers["X-Slack-Signature"]).Returns("V0=B53049CFD9F1DD2818B6DD952C905A2D38055BCB55958DF560B8E5E5AE4D62E0");
+
+            Assert.True(slackApi.VerifySignature(httpRequest.Object, body));
+        }
+    }
+}

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/SlackHelperTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/SlackHelperTests.cs
@@ -4,9 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Bot.Schema;
-using Moq;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -83,25 +81,6 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Tests
 
             Assert.Equal(activity.Conversation.Id, message.channel);
             Assert.Equal(activity.Conversation.Properties["thread_ts"], message.thread_ts);
-        }
-
-        [Fact]
-        public void VerifySignatureShouldReturnFalseWithNullParameters()
-        {
-            Assert.False(SlackHelper.VerifySignature(null, null, null));
-        }
-
-        [Fact]
-        public void VerifySignatureShouldReturnTrue()
-        {
-            var body = File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\MessageBody.json");
-
-            var httpRequest = new Mock<HttpRequest>();
-            httpRequest.Setup(req => req.Headers.ContainsKey(It.IsAny<string>())).Returns(true);
-            httpRequest.SetupGet(req => req.Headers["X-Slack-Request-Timestamp"]).Returns("0001-01-01T00:00:00+00:00");
-            httpRequest.SetupGet(req => req.Headers["X-Slack-Signature"]).Returns("V0=389808EE538C31F2030C00A0A172BC75C349A39F84B86DBCE695706575FDA19B");
-
-            Assert.True(SlackHelper.VerifySignature("secret", httpRequest.Object, body));
         }
 
         [Fact]

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/SlackHelperTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/SlackHelperTests.cs
@@ -1,0 +1,125 @@
+﻿// Copyright(c) Microsoft Corporation.All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Bot.Schema;
+using Moq;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Adapters.Slack.Tests
+{
+    public class SlackHelperTests
+    {
+        public const string ImageUrl = "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQtB3AwMUeNoq4gUBGe6Ocj8kyh3bXa9ZbV7u1fVKQoyKFHdkqU";
+
+        [Fact]
+        public void ActivityToSlackShouldReturnNullWithNullActivity()
+        {
+            Assert.Null(SlackHelper.ActivityToSlack(null));
+        }
+
+        [Fact]
+        public void ActivityToSlackShouldReturnMessage()
+        {
+            var activity = new Activity
+            {
+                Timestamp = new DateTimeOffset(),
+                Text = "Hello!",
+                Attachments = new List<Attachment>
+                {
+                    new Attachment(name: "image", thumbnailUrl: ImageUrl),
+                },
+                Conversation = new ConversationAccount(id: "testId"),
+            };
+
+            var message = SlackHelper.ActivityToSlack(activity);
+
+            Assert.Equal(activity.Conversation.Id, message.channel);
+            Assert.Equal(activity.Attachments[0].Name, message.attachments[0].author_name);
+        }
+
+        [Fact]
+        public void ActivityToSlackShouldReturnMessageFromChannelData()
+        {
+            var messageText = "Hello from message";
+
+            var activity = new Activity
+            {
+                Timestamp = new DateTimeOffset(),
+                Text = "Hello!",
+                Recipient = new ChannelAccount("testRecipientId"),
+                ChannelData = new NewSlackMessage
+                {
+                    text = messageText,
+                    Ephemeral = "testEphimeral",
+                    IconUrl = new Uri(ImageUrl),
+                },
+                Conversation = new ConversationAccount(id: "testId"),
+            };
+
+            var message = SlackHelper.ActivityToSlack(activity);
+
+            Assert.Equal(messageText, message.text);
+            Assert.False(message.AsUser);
+        }
+
+        [Fact]
+        public void ActivityToSlackShouldReturnMessageWithThreadTS()
+        {
+            var serializeConversation = "{\"id\":\"testId\",\"thread_ts\":\"0001-01-01T00:00:00+00:00\"}";
+
+            var activity = new Activity
+            {
+                Timestamp = new DateTimeOffset(),
+                Text = "Hello!",
+                Conversation = JsonConvert.DeserializeObject<ConversationAccount>(serializeConversation),
+            };
+
+            var message = SlackHelper.ActivityToSlack(activity);
+
+            Assert.Equal(activity.Conversation.Id, message.channel);
+            Assert.Equal(activity.Conversation.Properties["thread_ts"], message.thread_ts);
+        }
+
+        [Fact]
+        public void VerifySignatureShouldReturnFalseWithNullParameters()
+        {
+            Assert.False(SlackHelper.VerifySignature(null, null, null));
+        }
+
+        [Fact]
+        public void VerifySignatureShouldReturnTrue()
+        {
+            var body = File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\MessageBody.json");
+
+            var httpRequest = new Mock<HttpRequest>();
+            httpRequest.Setup(req => req.Headers.ContainsKey(It.IsAny<string>())).Returns(true);
+            httpRequest.SetupGet(req => req.Headers["X-Slack-Request-Timestamp"]).Returns("0001-01-01T00:00:00+00:00");
+            httpRequest.SetupGet(req => req.Headers["X-Slack-Signature"]).Returns("V0=389808EE538C31F2030C00A0A172BC75C349A39F84B86DBCE695706575FDA19B");
+
+            Assert.True(SlackHelper.VerifySignature("secret", httpRequest.Object, body));
+        }
+
+        [Fact]
+        public void GetMessageFromSlackEventShouldReturnNull()
+        {
+            Assert.Null(SlackHelper.GetMessageFromSlackEvent(null));
+        }
+
+        [Fact]
+        public void GetMessageFromSlackEventShouldReturnMessage()
+        {
+            var json = File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\MessageBody.json");
+            dynamic slackEvent = JsonConvert.DeserializeObject(json);
+
+            var message = SlackHelper.GetMessageFromSlackEvent(slackEvent);
+
+            Assert.Equal(slackEvent["event"].text.Value, message.text);
+            Assert.Equal(slackEvent["event"].user.Value, message.user);
+        }
+    }
+}


### PR DESCRIPTION
## Proposed Changes
- Add unit tests for the following methods:
  - DeleteActivityAsync
  - UpdateActivityAsync
  - VerifySignature
  - ActivityToSlack
  - GetMessageFromSlackEvent
