### PR TITLE
[WebexAdapter] Exclude from CC POCO and Wrapper classes

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexClientWrapper.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Net;
 using System.Security.Cryptography;
@@ -18,6 +19,7 @@ using Thrzn41.WebexTeams.Version1;
 
 namespace Microsoft.Bot.Builder.Adapters.Webex
 {
+    [ExcludeFromCodeCoverage]
     public class WebexClientWrapper
     {
         private const string WebhookUrl = "https://api.ciscospark.com/v1/webhooks";

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexMessageRequest.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexMessageRequest.cs
@@ -3,10 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Adapters.Webex
 {
+    [ExcludeFromCodeCoverage]
     public class WebexMessageRequest
     {
         /// <summary>


### PR DESCRIPTION
## Proposed Changes
Add `ExcludeFromCodeCoverage` attribute to WebexClientWrapper and WebexMessageRequest classes to exclude them from Code Coverage.