### PR TITLE
[SlackAdapter] Add unit tests for SendActivitiesAsync

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapter.cs
@@ -114,12 +114,12 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
 
             if (activity.Id == null)
             {
-                throw new ArgumentException(nameof(activity.Id));
+                throw new ArgumentException(nameof(activity.Timestamp));
             }
 
             if (activity.Conversation == null)
             {
-                throw new ArgumentException(nameof(activity.Conversation));
+                throw new ArgumentException(nameof(activity.ChannelId));
             }
 
             var message = SlackHelper.ActivityToSlack(activity);

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/SlackAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/SlackAdapterTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Tests
         }
 
         [Fact]
-        public async Task UpdateActivityAsyncShouldFailWithNullActivityId()
+        public async Task UpdateActivityAsyncShouldFailWithNullActivityTimestamp()
         {
             var options = new Mock<SlackAdapterOptions>();
             options.Object.VerificationToken = "VerificationToken";
@@ -52,7 +52,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Tests
 
             var activity = new Activity
             {
-                Id = null,
+                Timestamp = null,
             };
 
             var turnContext = new TurnContext(slackAdapter, activity);
@@ -78,11 +78,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Tests
 
             var slackAdapter = new SlackAdapter(slackApi.Object);
 
-            var activity = new Activity
-            {
-                Id = "testId",
-                Conversation = null,
-            };
+            var activity = new Activity();
 
             await Assert.ThrowsAsync<ArgumentNullException>(async () =>
             {

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/SlackAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/SlackAdapterTests.cs
@@ -303,5 +303,99 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Tests
 
             Assert.Equal(1, deletedMessages);
         }
+
+        [Fact]
+        public async Task SendActivitiesAsyncShouldThrowExceptionWithNullContext()
+        {
+            var options = new Mock<SlackAdapterOptions>();
+            options.Object.VerificationToken = "VerificationToken";
+            options.Object.ClientSigningSecret = "ClientSigningSecret";
+            options.Object.BotToken = "BotToken";
+
+            var slackApi = new SlackClientWrapper(options.Object);
+
+            var slackAdapter = new SlackAdapter(slackApi);
+
+            var activity = new Activity
+            {
+                Id = "testId",
+                Type = ActivityTypes.Message,
+                Text = "text",
+                Conversation = new ConversationAccount()
+                {
+                    Id = "testConversationId",
+                },
+            };
+
+            Activity[] activities = { activity };
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => { await slackAdapter.SendActivitiesAsync(null, activities, default); });
+        }
+
+        [Fact]
+        public async Task SendActivitiesAsyncShouldThrowExceptionWithNullActivity()
+        {
+            var options = new Mock<SlackAdapterOptions>();
+            options.Object.VerificationToken = "VerificationToken";
+            options.Object.ClientSigningSecret = "ClientSigningSecret";
+            options.Object.BotToken = "BotToken";
+
+            var slackApi = new SlackClientWrapper(options.Object);
+
+            var slackAdapter = new SlackAdapter(slackApi);
+
+            var activity = new Activity
+            {
+                Id = "testId",
+                Type = ActivityTypes.Message,
+                Text = "text",
+                Conversation = new ConversationAccount()
+                {
+                    Id = "testConversationId",
+                },
+            };
+
+            var turnContext = new TurnContext(slackAdapter, activity);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => { await slackAdapter.SendActivitiesAsync(turnContext, null, default); });
+        }
+
+        [Fact]
+        public async Task SendActivitiesAsyncShouldSucceed()
+        {
+            var options = new Mock<SlackAdapterOptions>();
+            options.Object.VerificationToken = "VerificationToken";
+            options.Object.ClientSigningSecret = "ClientSigningSecret";
+            options.Object.BotToken = "BotToken";
+
+            var slackResponse = new SlackResponse
+            {
+                Ok = true,
+                TS = "mockedTS",
+            };
+
+            var slackApi = new Mock<SlackClientWrapper>(options.Object);
+            slackApi.Setup(x => x.PostMessageAsync(It.IsAny<NewSlackMessage>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(slackResponse));
+
+            var slackAdapter = new SlackAdapter(slackApi.Object);
+
+            var activity = new Activity
+            {
+                Type = ActivityTypes.Message,
+                Text = "text",
+                Conversation = new ConversationAccount()
+                {
+                    Id = "testConversationId",
+                },
+            };
+
+            Activity[] activities = { activity };
+
+            var turnContext = new TurnContext(slackAdapter, activity);
+
+            var responses = await slackAdapter.SendActivitiesAsync(turnContext, activities, default);
+
+            Assert.Equal(slackResponse.TS, responses[0].Id);
+        }
     }
 }


### PR DESCRIPTION
## Proposed Changes
- Added unit tests for SendActivitiesAsync method
- Moved PostMessage code to SlackClientWrapper class.
- Added null parameter validations.
- Fixed parameter validations in UpdateActivityAsync and its tests.