### PR TITLE
[Botbuilder] Attachments on Facebook TestBot in .Net

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookAdapter.cs
@@ -70,14 +70,36 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
 
                 var api = await _facebookClient.GetApiAsync(context.Activity).ConfigureAwait(false);
 
-                var res = await api.SendMessageAsync("/me/messages", message, null, cancellationToken).ConfigureAwait(false);
-
-                var response = new ResourceResponse()
+                if (message.Message.Attachments != null)
                 {
-                    Id = res,
-                };
+                    var attachmentsList = message.Message.Attachments;
+                    message.Message.Attachments = null;
+                    message.Message.Text = null;
 
-                responses.Add(response);
+                    foreach (var item in attachmentsList)
+                    {
+                        message.Message.Attachment = item;
+                        var res = await api.SendMessageAsync("/me/messages", message, null, cancellationToken).ConfigureAwait(false);
+
+                        var response = new ResourceResponse()
+                        {
+                            Id = res,
+                        };
+
+                        responses.Add(response);
+                    }
+                }
+                else
+                {
+                    var res = await api.SendMessageAsync("/me/messages", message, null, cancellationToken).ConfigureAwait(false);
+
+                    var response = new ResourceResponse()
+                    {
+                        Id = res,
+                    };
+
+                    responses.Add(response);
+                }
             }
 
             return responses.ToArray();

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/FacebookAttachment.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/FacebookAttachment.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Newtonsoft.Json;
+
 namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents
 {
     public class FacebookAttachment
@@ -9,12 +11,14 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents
         /// Gets or sets the type of the attachment.
         /// </summary>
         /// <value>Type of attachment, may be image, audio, video, file or template.</value>
+        [JsonProperty(PropertyName = "type")]
         public string Type { get; set; }
 
         /// <summary>
         /// Gets or sets the payload of the attachment.
         /// </summary>
         /// <value>Payload of the attachment.</value>
-        public object Payload { get; set; }
+        [JsonProperty(PropertyName = "payload")]
+        public MessagePayload Payload { get; set; }
     }
 }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/MessagePayload.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/MessagePayload.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents
         /// </summary>
         /// <value>The Id of the sticker.</value>
         [JsonProperty(PropertyName = "sticker_id")]
-        public long StickerId { get; set; }
+        public long? StickerId { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the attachment is reusable or not. Default false.

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/MessagePayload.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/MessagePayload.cs
@@ -14,5 +14,19 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents
         /// <value>Url of the attachment.</value>
         [JsonProperty(PropertyName = "url")]
         public Uri Url { get; set; }
+
+        /// <summary>
+        /// Gets or sets the id of the sticker attached.
+        /// </summary>
+        /// <value>The Id of the sticker.</value>
+        [JsonProperty(PropertyName = "sticker_id")]
+        public long StickerId { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the attachment is reusable or not. Default false.
+        /// </summary>
+        /// <value>Indicates the reusable condition.</value>
+        [JsonProperty(PropertyName = "is_reusable")]
+        public bool IsReusable { get; set; }
     }
 }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/MessagePayload.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/MessagePayload.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents
+{
+    public class MessagePayload
+    {
+        /// <summary>
+        /// Gets or sets the url of the attachment.
+        /// </summary>
+        /// <value>Url of the attachment.</value>
+        [JsonProperty(PropertyName = "url")]
+        public Uri Url { get; set; }
+    }
+}

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/MessagePayload.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/MessagePayload.cs
@@ -28,5 +28,12 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents
         /// <value>Indicates the reusable condition.</value>
         [JsonProperty(PropertyName = "is_reusable")]
         public bool IsReusable { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Id of the attachment (for reusable attachments).
+        /// </summary>
+        /// <value>The id of the saved attachment.</value>
+        [JsonProperty(PropertyName = "attachment_id")]
+        public string AttachmentId { get; set; }
     }
 }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/Message.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/Message.cs
@@ -27,8 +27,8 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
         /// Gets or sets the attachment.
         /// </summary>
         /// <value>Attachment.</value>
-        [JsonProperty(PropertyName = "attachment")]
-        public FacebookAttachment Attachment { get; set; }
+        [JsonProperty(PropertyName = "attachments")]
+        public List<FacebookAttachment> Attachments { get; set; }
 
         /// <summary>
         /// Gets or sets the metadata.

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/Message.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/Message.cs
@@ -31,6 +31,13 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
         public List<FacebookAttachment> Attachments { get; set; }
 
         /// <summary>
+        /// Gets or sets the attachment.
+        /// </summary>
+        /// <value>Attachment.</value>
+        [JsonProperty(PropertyName = "attachment")]
+        public FacebookAttachment Attachment { get; set; }
+
+        /// <summary>
         /// Gets or sets the metadata.
         /// </summary>
         /// <value>Custom string that is delivered as a message echo. 1000 character limit.</value>

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.TestBot/Bots/EchoBot.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.TestBot/Bots/EchoBot.cs
@@ -27,8 +27,8 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.TestBot.Bots
                 foreach (var attachment in turnContext.Activity.Attachments)
                 {
                     var image = new Attachment(
-                        "image/png",
-                        "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQtB3AwMUeNoq4gUBGe6Ocj8kyh3bXa9ZbV7u1fVKQoyKFHdkqU");
+                       attachment.ContentType,
+                       attachment.ContentUrl);
 
                     activity.Attachments.Add(image);
                 }


### PR DESCRIPTION
### Description

The attachments functionality from Facebook is added to the TestBot in .Net

### Changes made

- The classes to deserealize the Facebook's responses were created 
- The response from the bot was setup to send attachments

### Testing

![image](https://user-images.githubusercontent.com/37625424/66338308-42751600-e917-11e9-88b2-c7776651f777.png)


