### PR TITLE
[Facebook Adapter] Add most of adapters tests

### DIFF
--- a/Microsoft.Bot.Builder.sln
+++ b/Microsoft.Bot.Builder.sln
@@ -104,6 +104,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Adapt
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Adapters.Facebook.TestBot", "tests\Adapters\Microsoft.Bot.Builder.Adapters.Facebook.TestBot\Microsoft.Bot.Builder.Adapters.Facebook.TestBot.csproj", "{06630974-4F8C-49B1-93A9-B5B298049778}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Adapters.Facebook.Tests", "tests\Adapters\Microsoft.Bot.Builder.Adapters.Facebook.Tests\Microsoft.Bot.Builder.Adapters.Facebook.Tests.csproj", "{B3D15932-6E65-4C57-BCF6-78E7166A8CCB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug - NuGet Packages|Any CPU = Debug - NuGet Packages|Any CPU
@@ -369,6 +371,12 @@ Global
 		{06630974-4F8C-49B1-93A9-B5B298049778}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{06630974-4F8C-49B1-93A9-B5B298049778}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{06630974-4F8C-49B1-93A9-B5B298049778}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B3D15932-6E65-4C57-BCF6-78E7166A8CCB}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{B3D15932-6E65-4C57-BCF6-78E7166A8CCB}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{B3D15932-6E65-4C57-BCF6-78E7166A8CCB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B3D15932-6E65-4C57-BCF6-78E7166A8CCB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B3D15932-6E65-4C57-BCF6-78E7166A8CCB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B3D15932-6E65-4C57-BCF6-78E7166A8CCB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -422,6 +430,7 @@ Global
 		{0723C8DC-78A5-4FF1-A922-490A083C7C22} = {E8CD434A-306F-41D9-B67D-BFFF3287354D}
 		{E61B18C9-F579-4A8F-BB68-2B127CCCCB35} = {6230B915-B238-4E57-AAC4-06B4498F540F}
 		{06630974-4F8C-49B1-93A9-B5B298049778} = {E8CD434A-306F-41D9-B67D-BFFF3287354D}
+		{B3D15932-6E65-4C57-BCF6-78E7166A8CCB} = {E8CD434A-306F-41D9-B67D-BFFF3287354D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7173C9F3-A7F9-496E-9078-9156E35D6E16}

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookAdapter.cs
@@ -117,6 +117,16 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task ContinueConversationAsync(ConversationReference reference, BotCallbackHandler logic)
         {
+            if (reference == null)
+            {
+                throw new ArgumentNullException(nameof(reference));
+            }
+
+            if (logic == null)
+            {
+                throw new ArgumentNullException(nameof(logic));
+            }
+
             var request = reference.GetContinuationActivity().ApplyConversationReference(reference, true);
 
             using (var context = new TurnContext(this, request))

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookAdapter.cs
@@ -68,9 +68,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
 
                 var message = FacebookHelper.ActivityToFacebook(activity);
 
-                var api = await _facebookClient.GetApiAsync(context.Activity).ConfigureAwait(false);
-
-                var res = await api.SendMessageAsync("/me/messages", message, null, cancellationToken).ConfigureAwait(false);
+                var res = await _facebookClient.SendMessageAsync("/me/messages", message, null, cancellationToken).ConfigureAwait(false);
 
                 var response = new ResourceResponse()
                 {

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookClientWrapper.cs
@@ -77,46 +77,6 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
         }
 
         /// <summary>
-        /// Get a Facebook API client with the correct credentials based on the page identified in the incoming activity.
-        /// This is used by many internal functions to get access to the Facebook API, and is exposed as `bot.api` on any BotWorker instances passed into Botkit handler functions.
-        /// </summary>
-        /// <param name="activity">An incoming message activity.</param>
-        /// <returns>A Facebook API client.</returns>
-        public virtual async Task<FacebookClientWrapper> GetApiAsync(Activity activity)
-        {
-            if (activity == null)
-            {
-                throw new ArgumentNullException(nameof(activity));
-            }
-
-            if (!string.IsNullOrWhiteSpace(_options.AccessToken))
-            {
-                return new FacebookClientWrapper(new FacebookAdapterOptions(_options.VerifyToken, _options.AppSecret, _options.AccessToken));
-            }
-
-            if (string.IsNullOrWhiteSpace(activity.Recipient?.Id))
-            {
-                throw new Exception($"Unable to create API based on activity:{activity}");
-            }
-
-            var pageId = activity.Recipient.Id;
-
-            if (activity.GetChannelData<FacebookMessage>().Message != null && activity.GetChannelData<FacebookMessage>().Message.IsEcho)
-            {
-                pageId = activity.From.Id;
-            }
-
-            var token = await _options.GetAccessTokenForPageAsync(pageId).ConfigureAwait(false);
-
-            if (string.IsNullOrWhiteSpace(token))
-            {
-                throw new ArgumentException(nameof(token));
-            }
-
-            return new FacebookClientWrapper(new FacebookAdapterOptions(_options.VerifyToken, _options.AppSecret, token));
-        }
-
-        /// <summary>
         /// Verifies the SHA1 signature of the raw request payload before bodyParser parses it will abort parsing if signature is invalid, and pass a generic error to response.
         /// </summary>
         /// <param name="request">An Http request object.</param>

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/FacebookAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/FacebookAdapterTests.cs
@@ -1,0 +1,189 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Bot.Schema;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
+{
+    public class FacebookAdapterTests
+    {
+        private readonly FacebookAdapterOptions _testOptions = new FacebookAdapterOptions("Test", "Test", "Test");
+
+        [Fact]
+        public void ConstructorShouldFailWithNullClient()
+        {
+            Assert.Throws<ArgumentNullException>(() => { new FacebookAdapter((FacebookClientWrapper)null); });
+        }
+
+        [Fact]
+        public void ConstructorWithArgumentsShouldSucceed()
+        {
+            Assert.NotNull(new FacebookAdapter(new Mock<FacebookClientWrapper>(_testOptions).Object));
+        }
+
+        [Fact]
+        public async void ContinueConversationAsyncShouldFailWithNullConversationReference()
+        {
+            var facebookAdapter = new FacebookAdapter(new Mock<FacebookClientWrapper>(_testOptions).Object);
+
+            Task BotsLogic(ITurnContext turnContext, CancellationToken cancellationToken)
+            {
+                return Task.CompletedTask;
+            }
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => { await facebookAdapter.ContinueConversationAsync(null, BotsLogic); });
+        }
+
+        [Fact]
+        public async void ContinueConversationAsyncShouldFailWithNullLogic()
+        {
+            var facebookAdapter = new FacebookAdapter(new Mock<FacebookClientWrapper>(_testOptions).Object);
+            var conversationReference = new ConversationReference();
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => { await facebookAdapter.ContinueConversationAsync(conversationReference, null); });
+        }
+
+        [Fact]
+        public async void ContinueConversationAsyncShouldSucceed()
+        {
+            var callbackInvoked = false;
+
+            var facebookAdapter = new FacebookAdapter(new Mock<FacebookClientWrapper>(_testOptions).Object);
+            var conversationReference = new ConversationReference();
+            Task BotsLogic(ITurnContext turnContext, CancellationToken cancellationToken)
+            {
+                callbackInvoked = true;
+                return Task.CompletedTask;
+            }
+
+            await facebookAdapter.ContinueConversationAsync(conversationReference, BotsLogic);
+            Assert.True(callbackInvoked);
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task DeleteActivityAsyncShouldThrowNotImplementedException()
+        {
+            var adapter = new FacebookAdapter(new FacebookClientWrapper(_testOptions));
+
+            var activity = new Activity();
+            var turnContext = new TurnContext(adapter, activity);
+
+            var conversationReference = new ConversationReference();
+
+            await Assert.ThrowsAsync<NotImplementedException>(() => adapter.DeleteActivityAsync(turnContext, conversationReference, default));
+        }
+
+        [Fact]
+        public async void ProcessAsyncShouldThrowExceptionWithInvalidBody()
+        {
+            var clientWrapper = new Mock<FacebookClientWrapper>(_testOptions);
+            clientWrapper.Setup(x => x.VerifySignature(It.IsAny<HttpRequest>(), It.IsAny<string>())).Returns(true);
+
+            var facebookAdapter = new FacebookAdapter(clientWrapper.Object);
+
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes("wrong-formatted-json"));
+
+            var httpRequest = new Mock<HttpRequest>();
+            httpRequest.SetupGet(req => req.Query[It.IsAny<string>()]).Returns("test");
+            httpRequest.SetupGet(req => req.Body).Returns(stream);
+            var httpResponse = new Mock<HttpResponse>();
+            var bot = new Mock<IBot>();
+            bot.Setup(x => x.OnTurnAsync(It.IsAny<TurnContext>(), It.IsAny<CancellationToken>())).Callback(() =>
+            {
+            });
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await facebookAdapter.ProcessAsync(httpRequest.Object, httpResponse.Object, bot.Object, default(CancellationToken));
+            });
+        }
+
+        [Fact]
+        public async void ProcessAsyncShouldSucceed()
+        {
+            var payload = File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\Payload.json");
+
+            var clientWrapper = new Mock<FacebookClientWrapper>(_testOptions);
+            clientWrapper.Setup(x => x.VerifySignature(It.IsAny<HttpRequest>(), It.IsAny<string>())).Returns(true);
+
+            var facebookAdapter = new FacebookAdapter(clientWrapper.Object);
+
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(payload));
+
+            var httpRequest = new Mock<HttpRequest>();
+            httpRequest.SetupGet(req => req.Query[It.IsAny<string>()]).Returns("test");
+            httpRequest.SetupGet(req => req.Body).Returns(stream);
+            var httpResponse = new Mock<HttpResponse>();
+            var bot = new Mock<IBot>();
+            bot.Setup(x => x.OnTurnAsync(It.IsAny<TurnContext>(), It.IsAny<CancellationToken>())).Callback(() =>
+            {
+            });
+
+            await facebookAdapter.ProcessAsync(httpRequest.Object, httpResponse.Object, bot.Object, default(CancellationToken));
+        }
+
+        [Fact]
+        public async void SendActivitiesAsyncShouldFailWithActivityTypeNotMessage()
+        {
+            var facebookAdapter = new FacebookAdapter(new Mock<FacebookClientWrapper>(_testOptions).Object);
+            var activity = new Activity
+            {
+                Type = ActivityTypes.Event,
+            };
+
+            Activity[] activities = { activity };
+
+            var turnContext = new TurnContext(facebookAdapter, activity);
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await facebookAdapter.SendActivitiesAsync(turnContext, activities, default);
+            });
+        }
+
+        [Fact]
+        public async void SendActivitiesAsyncShouldSucceedWithActivityTypeMessage()
+        {
+            var clientWrapper = new Mock<FacebookClientWrapper>(_testOptions);
+            clientWrapper.Setup(x => x.GetApiAsync(It.IsAny<Activity>())).Returns(Task.FromResult(new FacebookClientWrapper(_testOptions)));
+            clientWrapper.Setup(x => x.SendMessageAsync(It.IsAny<string>(), It.IsAny<FacebookMessage>(), It.IsAny<HttpMethod>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(string.Empty));
+
+            var facebookAdapter = new FacebookAdapter(clientWrapper.Object);
+            var activity = new Activity
+            {
+                Type = ActivityTypes.Message,
+                Text = "Test text",
+                Conversation = new ConversationAccount()
+                {
+                    Id = "Test id",
+                },
+                ChannelData = new FacebookMessage("recipientId", new Message(), "messagingtype"),
+            };
+
+            Activity[] activities = { activity };
+
+            var turnContext = new TurnContext(facebookAdapter, activity);
+
+            await facebookAdapter.SendActivitiesAsync(turnContext, activities, default);
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task UpdateActivityAsyncShouldThrowNotImplementedException()
+        {
+            var adapter = new FacebookAdapter(new FacebookClientWrapper(_testOptions));
+
+            var activity = new Activity();
+            var turnContext = new TurnContext(adapter, activity);
+            await Assert.ThrowsAsync<NotImplementedException>(() => adapter.UpdateActivityAsync(turnContext, activity, default));
+        }
+    }
+}

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/Files/Payload.json
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/Files/Payload.json
@@ -1,0 +1,29 @@
+{
+	"object":"page",
+	"entry":
+	[
+		{
+			"id":"0",
+			"time":1111111,
+			"messaging":
+			[
+				{
+					"sender":
+					{
+						"id":"0"
+					},
+					"recipient":
+					{
+						"id":"0"
+					},
+					"timestamp":2222222,
+					"message":
+					{
+						"mid":"AAAA-BBBB-CCCC",
+						"text":"text"
+					}
+				}
+			]
+		}
+	]
+}

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/Microsoft.Bot.Builder.Adapters.Facebook.Tests.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/Microsoft.Bot.Builder.Adapters.Facebook.Tests.csproj
@@ -1,0 +1,32 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+
+    <ApplicationIcon />
+
+    <OutputType>Exe</OutputType>
+
+    <StartupObject />
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Moq" Version="4.12.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\libraries\Adapters\Microsoft.Bot.Builder.Adapters.Facebook\Microsoft.Bot.Builder.Adapters.Facebook.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Files\Payload.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Description
Added most of the tests for the adapter class.

**Added test**
- ConstructorShouldFailWithNullClient
- ConstructorWithArgumentsShouldSucceed
- ContinueConversationAsyncShouldFailWithNullConversationReference
- ContinueConversationAsyncShouldFailWithNullLogic
- ContinueConversationAsyncShouldSucceed
- DeleteActivityAsyncShouldThrowNotImplementedException
- ProcessAsyncShouldThrowExceptionWithInvalidBody
- ProcessAsyncShouldSucceed
- SendActivitiesAsyncShouldFailWithActivityTypeNotMessage
- SendActivitiesAsyncShouldSucceedWithActivityTypeMessage
- UpdateActivityAsyncShouldThrowNotImplementedException

**Added files**
- FacebookAdapterTests.cs
- Payload.json
- Microsoft.Bot.Builder.Adapters.Facebook.Tests.csproj 