### PR TITLE
[Facebook Adapter] Add tests for standby messages and adapter

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookAdapter.cs
@@ -155,7 +155,6 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
                 return;
             }
 
-            // await FacebookHelper.WriteAsync(response, HttpStatusCode.OK, string.Empty, Encoding.UTF8, cancellationToken).ConfigureAwait(false);
             string stringifyBody;
 
             using (var sr = new StreamReader(request.Body))
@@ -214,8 +213,6 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
                     }
                 }
             }
-
-            // await FacebookHelper.WriteAsync(response, HttpStatusCode.OK, string.Empty, Encoding.UTF8, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/FacebookAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/FacebookAdapterTests.cs
@@ -81,9 +81,8 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
-        public async void ProcessAsyncShouldSucceed()
+        public async void ProcessAsyncShouldSucceedWithCorrectData()
         {
-            var callback = false;
             var payload = File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\Payload.json");
             var facebookClientWrapper = new Mock<FacebookClientWrapper>(_testOptions);
             var facebookAdapter = new FacebookAdapter(facebookClientWrapper.Object);
@@ -97,20 +96,14 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
             httpRequest.SetupGet(req => req.Query[It.IsAny<string>()]).Returns("test");
             httpRequest.SetupGet(req => req.Body).Returns(stream);
 
-            bot.Setup(x => x.OnTurnAsync(It.IsAny<TurnContext>(), It.IsAny<CancellationToken>())).Callback(() =>
-            {
-                callback = true;
-            });
-
             await facebookAdapter.ProcessAsync(httpRequest.Object, httpResponse.Object, bot.Object, default(CancellationToken));
 
-            Assert.True(callback);
+            bot.Verify(b => b.OnTurnAsync(It.IsAny<TurnContext>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Fact]
         public async void ProcessAsyncShouldSucceedWithStandbyMessages()
         {
-            var callback = false;
             var payload = File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\PayloadWithStandby.json");
             var facebookClientWrapper = new Mock<FacebookClientWrapper>(_testOptions);
             var facebookAdapter = new FacebookAdapter(facebookClientWrapper.Object);
@@ -124,38 +117,25 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
             httpRequest.SetupGet(req => req.Query[It.IsAny<string>()]).Returns("test");
             httpRequest.SetupGet(req => req.Body).Returns(stream);
 
-            bot.Setup(x => x.OnTurnAsync(It.IsAny<TurnContext>(), It.IsAny<CancellationToken>())).Callback(() =>
-            {
-                callback = true;
-            });
-
             await facebookAdapter.ProcessAsync(httpRequest.Object, httpResponse.Object, bot.Object, default(CancellationToken));
-
-            Assert.True(callback);
+            bot.Verify(b => b.OnTurnAsync(It.IsAny<TurnContext>(), It.IsAny<CancellationToken>()), Times.AtLeastOnce);
         }
 
         [Fact]
         public async void ProcessAsyncShouldReturnWhenHubModeSubscribe()
         {
-            var callback = false;
             var facebookClientWrapper = new Mock<FacebookClientWrapper>(_testOptions);
             var facebookAdapter = new FacebookAdapter(facebookClientWrapper.Object);
             var httpRequest = new Mock<HttpRequest>();
             var httpResponse = new Mock<HttpResponse>();
             var bot = new Mock<IBot>();
 
-            bot.Setup(x => x.OnTurnAsync(It.IsAny<TurnContext>(), It.IsAny<CancellationToken>())).Callback(() =>
-            {
-                callback = true;
-            });
-
             facebookClientWrapper.Setup(api => api.VerifyWebhookAsync(It.IsAny<HttpRequest>(), It.IsAny<HttpResponse>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
 
             httpRequest.SetupGet(req => req.Query[It.IsAny<string>()]).Returns("subscribe");
 
             await facebookAdapter.ProcessAsync(httpRequest.Object, httpResponse.Object, bot.Object, default(CancellationToken));
-
-            Assert.False(callback);
+            bot.Verify(b => b.OnTurnAsync(It.IsAny<TurnContext>(), It.IsAny<CancellationToken>()), Times.Never);
         }
 
         [Fact]

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/FacebookAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/FacebookAdapterTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using System.Text;
@@ -107,6 +108,57 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
+        public async void ProcessAsyncShouldSucceedWithStandbyMessages()
+        {
+            var callback = false;
+            var payload = File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\PayloadWithStandby.json");
+            var facebookClientWrapper = new Mock<FacebookClientWrapper>(_testOptions);
+            var facebookAdapter = new FacebookAdapter(facebookClientWrapper.Object);
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(payload));
+            var httpRequest = new Mock<HttpRequest>();
+            var httpResponse = new Mock<HttpResponse>();
+            var bot = new Mock<IBot>();
+
+            facebookClientWrapper.Setup(api => api.VerifySignature(It.IsAny<HttpRequest>(), It.IsAny<string>())).Returns(true);
+
+            httpRequest.SetupGet(req => req.Query[It.IsAny<string>()]).Returns("test");
+            httpRequest.SetupGet(req => req.Body).Returns(stream);
+
+            bot.Setup(x => x.OnTurnAsync(It.IsAny<TurnContext>(), It.IsAny<CancellationToken>())).Callback(() =>
+            {
+                callback = true;
+            });
+
+            await facebookAdapter.ProcessAsync(httpRequest.Object, httpResponse.Object, bot.Object, default(CancellationToken));
+
+            Assert.True(callback);
+        }
+
+        [Fact]
+        public async void ProcessAsyncShouldReturnWhenHubModeSubscribe()
+        {
+            var callback = false;
+            var facebookClientWrapper = new Mock<FacebookClientWrapper>(_testOptions);
+            var facebookAdapter = new FacebookAdapter(facebookClientWrapper.Object);
+            var httpRequest = new Mock<HttpRequest>();
+            var httpResponse = new Mock<HttpResponse>();
+            var bot = new Mock<IBot>();
+
+            bot.Setup(x => x.OnTurnAsync(It.IsAny<TurnContext>(), It.IsAny<CancellationToken>())).Callback(() =>
+            {
+                callback = true;
+            });
+
+            facebookClientWrapper.Setup(api => api.VerifyWebhookAsync(It.IsAny<HttpRequest>(), It.IsAny<HttpResponse>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+
+            httpRequest.SetupGet(req => req.Query[It.IsAny<string>()]).Returns("subscribe");
+
+            await facebookAdapter.ProcessAsync(httpRequest.Object, httpResponse.Object, bot.Object, default(CancellationToken));
+
+            Assert.False(callback);
+        }
+
+        [Fact]
         public async void ProcessAsyncShouldThrowExceptionWithInvalidBody()
         {
             var facebookClientWrapper = new Mock<FacebookClientWrapper>(_testOptions);
@@ -128,6 +180,32 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
+        public async Task ProcessAsyncShouldThrowExceptionWithUnverifiedSignature()
+        {
+            var facebookClientWrapper = new Mock<FacebookClientWrapper>(_testOptions);
+            var facebookAdapter = new FacebookAdapter(facebookClientWrapper.Object);
+            var payload = File.ReadAllText(Directory.GetCurrentDirectory() + @"\Files\Payload.json");
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(payload));
+            var httpRequest = new Mock<HttpRequest>();
+            var httpResponse = new Mock<HttpResponse>();
+            var bot = new Mock<IBot>();
+
+            httpRequest.SetupGet(req => req.Query[It.IsAny<string>()]).Returns("test");
+            httpRequest.SetupGet(req => req.Body).Returns(stream);
+
+            httpResponse.Setup(_ => _.Body.WriteAsync(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                .Callback((byte[] data, int offset, int length, CancellationToken token) =>
+                {
+                    if (length > 0)
+                    {
+                        var actual = Encoding.UTF8.GetString(data);
+                    }
+                });
+
+            await Assert.ThrowsAsync<Exception>(() => facebookAdapter.ProcessAsync(httpRequest.Object, httpResponse.Object, bot.Object, default(CancellationToken)));
+        }
+
+        [Fact]
         public async void SendActivitiesAsyncShouldSucceedWithActivityTypeMessage()
         {
             const string testResponse = "Test Response";
@@ -142,6 +220,40 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
                     Id = "Test id",
                 },
                 ChannelData = new FacebookMessage("recipientId", new Message(), "messagingtype"),
+            };
+            Activity[] activities = { activity };
+            ResourceResponse[] responses = null;
+
+            facebookClientWrapper.Setup(api => api.SendMessageAsync(It.IsAny<string>(), It.IsAny<FacebookMessage>(), It.IsAny<HttpMethod>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(testResponse));
+
+            using (var turnContext = new TurnContext(facebookAdapter, activity))
+            {
+                responses = await facebookAdapter.SendActivitiesAsync(turnContext, activities, default);
+            }
+
+            Assert.Equal(testResponse, responses[0].Id);
+        }
+
+        [Fact]
+        public async void SendActivitiesAsyncShouldSucceedWithActivityTypeMessageAndAttachments()
+        {
+            const string testResponse = "Test Response";
+            var facebookClientWrapper = new Mock<FacebookClientWrapper>(_testOptions);
+            var facebookAdapter = new FacebookAdapter(facebookClientWrapper.Object);
+
+            var attachments = new List<Attachment>();
+            attachments.Add(new Attachment("text/html", "http://contoso.com"));
+
+            var activity = new Activity
+            {
+                Type = ActivityTypes.Message,
+                Text = "Test text",
+                Conversation = new ConversationAccount()
+                {
+                    Id = "Test id",
+                },
+                ChannelData = new FacebookMessage("recipientId", new Message(), "messagingtype"),
+                Attachments = attachments,
             };
             Activity[] activities = { activity };
             ResourceResponse[] responses = null;

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/FacebookAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/FacebookAdapterTests.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
-        public async void ProcessAsyncShouldReturnWhenHubModeSubscribe()
+        public async void ProcessAsyncShouldVerifyWebhookOnHubModeSubscribe()
         {
             var facebookClientWrapper = new Mock<FacebookClientWrapper>(_testOptions);
             var facebookAdapter = new FacebookAdapter(facebookClientWrapper.Object);
@@ -220,10 +220,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
             const string testResponse = "Test Response";
             var facebookClientWrapper = new Mock<FacebookClientWrapper>(_testOptions);
             var facebookAdapter = new FacebookAdapter(facebookClientWrapper.Object);
-
             var attachments = new List<Attachment>();
-            attachments.Add(new Attachment("text/html", "http://contoso.com"));
-
             var activity = new Activity
             {
                 Type = ActivityTypes.Message,
@@ -238,6 +235,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
             Activity[] activities = { activity };
             ResourceResponse[] responses = null;
 
+            attachments.Add(new Attachment("text/html", "http://contoso.com"));
             facebookClientWrapper.Setup(api => api.SendMessageAsync(It.IsAny<string>(), It.IsAny<FacebookMessage>(), It.IsAny<HttpMethod>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(testResponse));
 
             using (var turnContext = new TurnContext(facebookAdapter, activity))

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/Files/PayloadWithStandby.json
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/Files/PayloadWithStandby.json
@@ -1,0 +1,42 @@
+﻿{
+  "object": "page",
+  "entry": [
+    {
+      "id": "page1",
+      "time": 1458692752478,
+      "standby": [
+        {
+          "sender": {
+            "id": "user1"
+          },
+          "recipient": {
+            "id": "page1"
+          }
+        },
+        {
+          "sender": {
+            "id": "user2"
+          },
+          "recipient": {
+            "id": "page1"
+          }
+        }
+      ],
+      "messaging": [
+        {
+          "sender": {
+            "id": "0"
+          },
+          "recipient": {
+            "id": "0"
+          },
+          "timestamp": 2222222,
+          "message": {
+            "mid": "AAAA-BBBB-CCCC",
+            "text": "text"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/Microsoft.Bot.Builder.Adapters.Facebook.Tests.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/Microsoft.Bot.Builder.Adapters.Facebook.Tests.csproj
@@ -27,6 +27,9 @@
     <None Update="Files\Payload.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Files\PayloadWithStandby.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Description
Added more tests to reach a 97% of coverage in FacebookAdapter.

**Added tests**

- ProcessAsyncShouldSucceedWithStandbyMessages
- ProcessAsyncShouldReturnWhenHubModeSubscribe
- ProcessAsyncShouldThrowExceptionWithUnverifiedSignature
- SendActivitiesAsyncShouldSucceedWithActivityTypeMessageAndAttachments