### PR TITLE
[botkit] Facebook Handover - Exclude CodeCoverage Files

### DIFF
--- a/CodeCoverage.runsettings
+++ b/CodeCoverage.runsettings
@@ -46,8 +46,6 @@
                 <Source>.*\\SlackEvent.cs</Source>
                 <Source>.*\\SlackPayload.cs</Source>
                 <Source>.*\\SlackRequestBody.cs</Source>
-                <Source>.*\\FacebookAdapterOptions.cs</Source>
-                <Source>.*\\FacebookMessage.cs</Source>
                 <Source>.*\\Button.cs</Source>
                 <Source>.*\\DefaultAction.cs</Source>
                 <Source>.*\\Element.cs</Source>
@@ -60,7 +58,12 @@
                 <Source>.*\\FacebookResponseOk.cs</Source>
                 <Source>.*\\FacebookQuickReply.cs</Source>
                 <Source>.*\\MessagePayload.cs</Source>
-                <Source>.*\\Message.cs</Source>
+                <Source>.*\\FacebookPassThreadControl.cs</Source>
+                <Source>.*\\FacebookRequestThreadControl.cs</Source>
+                <Source>.*\\FacebookTakeThreadControl.cs</Source>
+                <Source>.*\\FacebookThreadControl.cs</Source>
+                <Source>.*\\HandoverConstants.cs</Source>
+                <Source>.*\\AttachmentPayload.cs</Source>
               </Exclude>
             </Sources>
           </CodeCoverage>

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/FacebookAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/FacebookAdapterTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
+using System.Security.Authentication;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -161,7 +162,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
                     }
                 });
 
-            await Assert.ThrowsAsync<Exception>(() => facebookAdapter.ProcessAsync(httpRequest.Object, httpResponse.Object, bot.Object, default(CancellationToken)));
+            await Assert.ThrowsAsync<AuthenticationException>(() => facebookAdapter.ProcessAsync(httpRequest.Object, httpResponse.Object, bot.Object, default(CancellationToken)));
         }
 
         [Fact]


### PR DESCRIPTION
### Description

Some files are excluded from the CodeCoverage result and an Adapter test is fixed.

### Test
![image](https://user-images.githubusercontent.com/37625424/68305333-43b87080-0086-11ea-8359-91ce56a04c8e.png)
