### PR TITLE
Add YAML file to set up pipeline for functional test with Slack

### DIFF
--- a/build/yaml/botbuilder-dotnet-ci-slacktest.yml
+++ b/build/yaml/botbuilder-dotnet-ci-slacktest.yml
@@ -1,0 +1,86 @@
+trigger:
+  - master
+
+pr:
+  - master
+
+pool:
+  vmImage: 'windows-2019'
+
+variables:
+  BotGroup: 'TestSlackBot-Group-CI-Build'
+  BotName: 'TestSlackBot-Echo-CI-Build'
+  BuildConfiguration: 'debug'
+  BuildPlatform: 'any cpu'
+
+steps:
+- task: UseDotNet@2
+  displayName: 'Use .Net Core sdk 2.1.x'
+  inputs:
+    version: 2.1.x
+
+- task: UseDotNet@2
+  displayName: 'Use .Net Core sdk 3.0.x'
+  inputs:
+    version: 3.0.x
+
+- task: NuGetToolInstaller@0
+  displayName: 'Use NuGet 4.9.1'
+  inputs:
+    versionSpec: 4.9.1
+
+- task: NuGetCommand@2
+  displayName: 'NuGet restore'
+  inputs:
+    restoreSolution: '$(System.DefaultWorkingDirectory)\Microsoft.Bot.Builder.sln'
+
+- task: VSBuild@1
+  displayName: 'Build solution Microsoft.Bot.Builder.sln'
+  inputs:
+    solution: Microsoft.Bot.Builder.sln
+    vsVersion: 16.0
+    msbuildArgs: '-p:DefineConstants="FUNCTIONALTESTS"'
+    platform: '$(BuildPlatform)'
+    configuration: '$(BuildConfiguration)'
+
+- task: DotNetCoreCLI@2
+  displayName: 'Dotnet Publish TestBot'
+  inputs:
+    command: publish
+    publishWebProjects: false
+    projects: '$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Slack.TestBot\Microsoft.Bot.Builder.Adapters.Slack.TestBot.csproj'
+    arguments: '--output $(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Slack.TestBot\PublishedBot --framework netcoreapp2.1'
+    modifyOutputPath: false
+
+- task: AzureCLI@1
+  displayName: 'Create Resources'
+  inputs:
+    azureSubscription: '$(AzureSubscription)'
+    scriptLocation: inlineScript
+    inlineScript: |
+     call az deployment create --name "$(BotGroup)" --template-file "$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Slack.TestBot\DeploymentTemplates\template-with-new-rg.json" --location "westus" --parameters appId=$(AppId) appSecret="$(AppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)" groupName="$(BotGroup)" groupLocation="westus" newAppServicePlanLocation="westus" slackVerificationToken="$(SlackVerificationToken)" slackBotToken="$(SlackBotToken)"  slackClientSigningSecret="$(SlackClientSigningSecret)"
+     call az webapp deployment source config-zip --resource-group "$(BotGroup)" --name "$(BotName)" --src "$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Slack.TestBot\PublishedBot\PublishedBot.zip"
+
+- powershell: |
+   echo '##vso[task.setvariable variable=SLACK_CHANNEL]$(SlackChannel)'
+   echo '##vso[task.setvariable variable=SLACK_BOT_TOKEN]$(SlackBotToken)'
+   echo '##vso[task.setvariable variable=TESTAPPID]$(AppId)'
+   echo '##vso[task.setvariable variable=TESTPASSWORD]$(AppSecret)'
+  displayName: 'Set Environment Variables'
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet test'
+  inputs:
+    command: test
+    projects: |
+     FunctionalTests\Microsoft.Bot.Builder.FunctionalTests\Microsoft.Bot.Builder.FunctionalTests.csproj
+    arguments: '-v n --configuration $(BuildConfiguration) --no-build --no-restore --filter SlackClientTest'
+    workingDirectory: tests
+
+- task: AzureCLI@1
+  displayName: 'Delete Resources'
+  inputs:
+    azureSubscription: '$(AzureSubscription)'
+    scriptLocation: inlineScript
+    inlineScript: 'call az group delete -n "$(BotGroup)" --yes'
+  condition: always()

--- a/build/yaml/botbuilder-dotnet-ci-slacktest.yml
+++ b/build/yaml/botbuilder-dotnet-ci-slacktest.yml
@@ -39,7 +39,6 @@ steps:
   inputs:
     solution: Microsoft.Bot.Builder.sln
     vsVersion: 16.0
-    msbuildArgs: '-p:DefineConstants="FUNCTIONALTESTS"'
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
 


### PR DESCRIPTION
## Description
This pull request adds a YAML file to set up a build pipeline for Slack Functional Test.

## Specific Changes
We added the file `botbuilder-dotnet-ci-slacktest.yml` inside the `build/yaml` folder, this file can be used to set up a pipeline to run functional tests for slack.

By default, the file is configured to run the pipeline for each commit or pull request in the master branch. This can be changed in the file or in the UI when setting the pipeline. 

## How to use
The next steps will guide you through the configuration of a Build pipeline based on the YAML files.

### Prerequisites
- Azure DevOps organization.
- Azure subscription. Required to create and delete Azure resources.
- One app registration in Azure. [More info](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app)
- Configure an Azure Connection Service. [Steps here](#add-a-connection-service)
- Create a Slack Application and get the Slack variables. [Steps here](#create-a-slack-application-and-get-the-slack-variables)

### Set up build pipeline
1- Create a pipeline using the classic editor, this options allows us to select the YAML file to configure the pipeline.
![image](https://user-images.githubusercontent.com/38112957/70465480-cecec100-1a9f-11ea-8321-49eb42c126f2.png)

2- Configure the repository and branch.
![image](https://user-images.githubusercontent.com/38112957/70465714-4f8dbd00-1aa0-11ea-9a27-f5966bf150bb.png)

3- In the Configuration as code, select the YAML option.
![image](https://user-images.githubusercontent.com/38112957/70465840-9b406680-1aa0-11ea-9598-b6f47dd9c6cd.png)

4- In section YAML, write the build name and select the build YAML file inside the folder `build-CI-yaml` in the root of the directory.
![image](https://user-images.githubusercontent.com/38112957/70465856-a7c4bf00-1aa0-11ea-89cd-27e49ac28eb5.png)

5- In the Variables section add the following variables.
  - TestBotAppdId
  - TestBotAppSecret
  - AzureSubscription (Connection name from Connected Service)
  - SlackBotToken
  - SlackChannel
  - SlackClientSigningSecret
  - SlackVerificationToken

### Add a Connection Service
This step is required to use your Azure Subscription for the Windows and Linux CI builds. If you already have a Connection Service configured, save its Connection name to use it later as _AzureSubscription_.

For more info go to [this link](https://docs.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml).

1-  In your Azure DevOps project, go to project settings -> Service Connections -> New service connection.
![image](https://user-images.githubusercontent.com/38112957/70467844-b319e980-1aa4-11ea-8f92-987bbba28120.png)

2- Select Azure Resource Manager and click Next. In the dialog select `use the full version of the service connection dialog`.
![image](https://user-images.githubusercontent.com/38112957/70468143-4fdc8700-1aa5-11ea-9f0a-f679125e0d25.png)

3- Fill all the fields and check the `Allow all pipelines to use this connection` option. Save the name you are using in `Connection name`, this will be the variable **AzureSubscription** in following steps
![image](https://user-images.githubusercontent.com/38112957/70469973-d6df2e80-1aa8-11ea-9240-563552f41a6a.png)

### Create a Slack Application and get the Slack variables
1- Create a Slack App [here](https://api.slack.com/apps) associating it with a Workspace.
![image](https://user-images.githubusercontent.com/38112957/71115104-f6b0d980-21af-11ea-927f-271d9ddb0bbe.png)

In the Basic Information tab are shown the app credentials. Copy the Signing Secret and the Verification Token. These tokens will be needed to configure the bot.
![image](https://user-images.githubusercontent.com/38112957/71115147-0d573080-21b0-11ea-9049-279f6fdd973c.png)

In the Bot Users tab, click the Add a Bot User button and enable the option Always Show My Bot as Online.
![image](https://user-images.githubusercontent.com/38112957/71115160-1811c580-21b0-11ea-98ee-0d6669d336fd.png)

In the OAuth & Permissions tab, after clicking on the Install App to Workspace button the OAuthTokens will be generated. Copy the Bot User OAuth Access Token.
![image](https://user-images.githubusercontent.com/38112957/71115180-2364f100-21b0-11ea-8cc6-38b6122c86b5.png)

2- Deploy the Bot manually
In order to finish the App configuration, we'll need to have the bot deployed. 
 
From the CMD navigate to the SlackTestBot directory. Then execute
>dotnet publish --framework netcoreapp2.1 --output PublishedBot

Zip the content of the output folder PublishedBot in a `.zip` file.
 
Run the following commands replacing the variable's values:
>call az deployment create --name "TestSlackBot-Group-CI-Build" --template-file "BotBuilder-dotnet\tests\Adapters\Microsoft.Bot.Builder.Adapters.Slack.TestBot\DeploymentTemplates\template-with-new-rg.json" --location "westus" --parameters appId="`app-id`" appSecret="`app-secret`" botId="TestSlackBot-Echo-CI-Build" botSku=F0 newAppServicePlanName="TestSlackBot-Echo-CI-Build" newWebAppName="TestSlackBot-Echo-CI-Build" groupName="TestSlackBot-Group-CI-Build" groupLocation="westus" newAppServicePlanLocation="westus" slackVerificationToken="`verification-token`" >slackBotToken="`bot-user-oauth-access-token`"  slackClientSigningSecret="`signing-secret`"

>call az webapp deployment source config-zip --resource-group "TestSlackBot-Group-CI-Build" --name "TestSlackBot-Echo-CI-Build" --src "PublishedBot.zip"

3- Finish configuring the Slack App
Once the bot is deployed, copy the URL to finish configuring the Slack Application.
 
In the Oauth & Permissions tab, add a Redirect URL with the bot's endpoint in Azure:
![image](https://user-images.githubusercontent.com/38112957/71115584-067ced80-21b1-11ea-8cbc-fef4ab5126b3.png)

In the Event Subscriptions tab, enable Events and fill in the Request URL with the bot's endpoint adding '/api/messages'.
Also, subscribe to the message.im and message.mpim events for the bot to listen only to direct messages.
![image](https://user-images.githubusercontent.com/38112957/71115601-0f6dbf00-21b1-11ea-94b4-37bbe057fa58.png)
![image](https://user-images.githubusercontent.com/38112957/71115616-15fc3680-21b1-11ea-8e11-4b91881a45c5.png)

4- Add the Application in the Slack Desktop Client
In the Slack Desktop Client, browse for the created App and test it by sending a message.
![image](https://user-images.githubusercontent.com/38112957/71115668-36c48c00-21b1-11ea-9395-4642f060db34.png)
![image](https://user-images.githubusercontent.com/38112957/71115676-3c21d680-21b1-11ea-8cbe-faacc282fe32.png)

Then, obtain the Channel ID by right-clicking on the App and copying the link. This Channel ID will be needed to set up the pipeline.
![image](https://user-images.githubusercontent.com/38112957/71115694-4512a800-21b1-11ea-9839-aa31b3195501.png)

Now, the manually deployed bot can be deleted from Azure as this will be part of the Nightly Build Pipeline. Run the following command:
> call az group delete -n "TestSlackBot-Group-CI-Build" --yes

## Testing
In the image below, you can see the build running in a pipeline from the YAML file.
![image](https://user-images.githubusercontent.com/38112957/71116070-1fd26980-21b2-11ea-9279-dc0a1aded19f.png)