### PR TITLE
[Slack Adapter] Fix to filter bot messages

### DIFF
--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/SlackClientTest.cs
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/SlackClientTest.cs
@@ -2,24 +2,28 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Specialized;
-using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.FunctionalTests.Payloads;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder.FunctionalTests
 {
     [TestClass]
     [TestCategory("FunctionalTests")]
+    [TestCategory("Adapters")]
     public class SlackClientTest
     {
         private const string SlackUrlBase = "https://slack.com/api";
         private HttpClient _client;
         private string _slackChannel;
         private string _slackBotToken;
+        private string _slackClientSigningSecret;
+        private string _slackVerificationToken;
+        private string _botName;
 
         [TestMethod]
         public async Task SendAndReceiveSlackMessageShouldSucceed()
@@ -64,23 +68,72 @@ namespace Microsoft.Bot.Builder.FunctionalTests
 
         private async Task SendMessageAsync(string echoGuid)
         {
-            var data = new NameValueCollection
+            var timestamp = DateTime.Now.ToString();
+
+            using (var client = new HttpClient())
+            using (var request = new HttpRequestMessage())
             {
-                ["token"] = _slackBotToken,
-                ["channel"] = _slackChannel,
-                ["text"] = echoGuid,
-                ["as_user"] = "true",
+                var message = CreateMessage(echoGuid);
+                var hubSignature = CreateHubSignature(message, timestamp);
+
+                request.Headers.Add("X-Slack-Request-Timestamp", timestamp);
+                request.Headers.Add("X-Slack-Signature", hubSignature);
+                request.Content = new StringContent(message, Encoding.UTF8, "application/json");
+                request.Method = HttpMethod.Post;
+
+                request.RequestUri = new Uri($"https://{_botName}.azurewebsites.net/api/messages");
+
+                var response = await client.SendAsync(request);
+            }
+        }
+
+        private string CreateHubSignature(string message, string timestamp)
+        {
+            var hashResult = string.Empty;
+
+            object[] signature = { "v0", timestamp, message };
+
+            var baseString = string.Join(":", signature);
+
+            using (var hmac = new System.Security.Cryptography.HMACSHA256(Encoding.UTF8.GetBytes(_slackClientSigningSecret)))
+            {
+                var hashArray = hmac.ComputeHash(Encoding.UTF8.GetBytes(baseString));
+                var hash = string.Concat("v0=", BitConverter.ToString(hashArray).Replace("-", string.Empty)).ToUpperInvariant();
+
+                hashResult = hash;
+            }
+
+            return hashResult;
+        }
+
+        private string CreateMessage(string echoGuid)
+        {
+            var message = new JObject
+            {
+                ["token"] = _slackVerificationToken,
+                ["team_id"] = "teamId",
+                ["api_app_id"] = "apiAppId"
             };
 
-            using (var client = new WebClient())
+            var slackEvent = new JObject
             {
-                await client.UploadValuesTaskAsync($"{SlackUrlBase}/chat.postMessage", "POST", data);
-            }
+                ["client_msg_id"] = "client_msg_id",
+                ["type"] = "message",
+                ["text"] = echoGuid,
+                ["user"] = "userId",
+                ["channel"] = _slackChannel,
+                ["channel_type"] = "im"
+            };
+
+            message["event"] = slackEvent;
+            message["type"] = "event_callback";
+
+            return message.ToString();
         }
 
         private void GetEnvironmentVars()
         {
-            if (string.IsNullOrWhiteSpace(_slackChannel) || string.IsNullOrWhiteSpace(_slackBotToken))
+            if (string.IsNullOrWhiteSpace(_slackChannel) || string.IsNullOrWhiteSpace(_slackBotToken) || string.IsNullOrWhiteSpace(_slackClientSigningSecret) || string.IsNullOrWhiteSpace(_slackVerificationToken))
             {
                 _slackChannel = Environment.GetEnvironmentVariable("SLACK_CHANNEL");
                 if (string.IsNullOrWhiteSpace(_slackChannel))
@@ -92,6 +145,24 @@ namespace Microsoft.Bot.Builder.FunctionalTests
                 if (string.IsNullOrWhiteSpace(_slackBotToken))
                 {
                     Assert.Inconclusive("Environment variable 'SLACK_BOT_TOKEN' not found.");
+                }
+
+                _slackClientSigningSecret = Environment.GetEnvironmentVariable("SLACK_CLIENT_SIGNING_SECRET");
+                if (string.IsNullOrWhiteSpace(_slackClientSigningSecret))
+                {
+                    Assert.Inconclusive("Environment variable 'SLACK_CLIENT_SIGNING_SECRET' not found.");
+                }
+
+                _slackVerificationToken = Environment.GetEnvironmentVariable("SLACK_VERIFICATION_TOKEN");
+                if (string.IsNullOrWhiteSpace(_slackVerificationToken))
+                {
+                    Assert.Inconclusive("Environment variable 'SLACK_VERIFICATION_TOKEN' not found.");
+                }
+
+                _botName = Environment.GetEnvironmentVariable("BOT_NAME");
+                if (string.IsNullOrWhiteSpace(_botName))
+                {
+                    Assert.Inconclusive("Environment variable 'BOT_NAME' not found.");
                 }
             }
         }

--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/SlackClientTest.cs
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/SlackClientTest.cs
@@ -90,9 +90,7 @@ namespace Microsoft.Bot.Builder.FunctionalTests
         private string CreateHubSignature(string message, string timestamp)
         {
             var hashResult = string.Empty;
-
             object[] signature = { "v0", timestamp, message };
-
             var baseString = string.Join(":", signature);
 
             using (var hmac = new System.Security.Cryptography.HMACSHA256(Encoding.UTF8.GetBytes(_slackClientSigningSecret)))
@@ -133,7 +131,7 @@ namespace Microsoft.Bot.Builder.FunctionalTests
 
         private void GetEnvironmentVars()
         {
-            if (string.IsNullOrWhiteSpace(_slackChannel) || string.IsNullOrWhiteSpace(_slackBotToken) || string.IsNullOrWhiteSpace(_slackClientSigningSecret) || string.IsNullOrWhiteSpace(_slackVerificationToken))
+            if (string.IsNullOrWhiteSpace(_slackChannel) || string.IsNullOrWhiteSpace(_slackBotToken) || string.IsNullOrWhiteSpace(_slackClientSigningSecret) || string.IsNullOrWhiteSpace(_slackVerificationToken) || string.IsNullOrWhiteSpace(_botName))
             {
                 _slackChannel = Environment.GetEnvironmentVariable("SLACK_CHANNEL");
                 if (string.IsNullOrWhiteSpace(_slackChannel))

--- a/build/yaml/botbuilder-dotnet-ci-slacktest.yml
+++ b/build/yaml/botbuilder-dotnet-ci-slacktest.yml
@@ -61,6 +61,9 @@ steps:
 - powershell: |
    echo '##vso[task.setvariable variable=SLACK_CHANNEL]$(SlackChannel)'
    echo '##vso[task.setvariable variable=SLACK_BOT_TOKEN]$(SlackBotToken)'
+   echo '##vso[task.setvariable variable=SLACK_CLIENT_SIGNING_SECRET]$(SlackClientSigningSecret)'
+   echo '##vso[task.setvariable variable=SLACK_VERIFICATION_TOKEN]$(SlackVerificationToken)'
+   echo '##vso[task.setvariable variable=BOT_NAME]$(BotName)'
    echo '##vso[task.setvariable variable=TESTAPPID]$(AppId)'
    echo '##vso[task.setvariable variable=TESTPASSWORD]$(AppSecret)'
   displayName: 'Set Environment Variables'

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
@@ -237,7 +237,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
             activity.Recipient.Id = await client.GetBotUserByTeamAsync(activity, cancellationToken).ConfigureAwait(false);
 
             // If this is conclusively a message originating from a user, we'll mark it as such
-            if (slackEvent.Type == "message" && slackEvent.BotId == null)
+            if (slackEvent.Type == "message" && slackEvent.ClientMsgId != null)
             {
                 if (slackEvent.SubType == null)
                 {
@@ -352,6 +352,15 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                     Payload = payload,
                     Token = payload.Token,
                 };
+            }
+
+            try
+            {
+                var json = JsonConvert.DeserializeObject<SlackRequestBody>(requestBody, new UnixDateTimeConverter());
+            }
+            catch (Exception ex)
+            {
+                throw new Exception(ex.Message);
             }
 
             return JsonConvert.DeserializeObject<SlackRequestBody>(requestBody, new UnixDateTimeConverter());

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
@@ -237,7 +237,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
             activity.Recipient.Id = await client.GetBotUserByTeamAsync(activity, cancellationToken).ConfigureAwait(false);
 
             // If this is conclusively a message originating from a user, we'll mark it as such
-            if (slackEvent.Type == "message" && slackEvent.ClientMsgId != null)
+            if (slackEvent.Type == "message" && slackEvent.BotId == null)
             {
                 if (slackEvent.SubType == null)
                 {
@@ -352,15 +352,6 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                     Payload = payload,
                     Token = payload.Token,
                 };
-            }
-
-            try
-            {
-                var json = JsonConvert.DeserializeObject<SlackRequestBody>(requestBody, new UnixDateTimeConverter());
-            }
-            catch (Exception ex)
-            {
-                throw new Exception(ex.Message);
             }
 
             return JsonConvert.DeserializeObject<SlackRequestBody>(requestBody, new UnixDateTimeConverter());

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
@@ -237,10 +237,13 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
             activity.Recipient.Id = await client.GetBotUserByTeamAsync(activity, cancellationToken).ConfigureAwait(false);
 
             // If this is conclusively a message originating from a user, we'll mark it as such
-            if (slackEvent.Type == "message" && slackEvent.SubType == null)
+            if (slackEvent.Type == "message" && slackEvent.BotId == null)
             {
-                activity.Type = ActivityTypes.Message;
-                activity.Text = slackEvent.Text;
+                if (slackEvent.SubType == null)
+                {
+                    activity.Type = ActivityTypes.Message;
+                    activity.Text = slackEvent.Text;
+                }
             }
 
             return activity;

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.TestBot/Bots/EchoBot.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.TestBot/Bots/EchoBot.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.TestBot.Bots
         {
             if (turnContext.Activity.TryGetChannelData(out SlackRequestBody _))
             {
-                if (turnContext.Activity.GetChannelData<SlackRequestBody>().Command == "/test")
+                if (turnContext.Activity.GetChannelData<SlackRequestBody>().Command == "/block")
                 {
                     var interactiveMessage = MessageFactory.Attachment(
                         CreateInteractiveMessage(


### PR DESCRIPTION
### Description 
This PR contains the fix to correctly determine if a message comes from a user or a bot. Also, the updated functional test to work with the changes made in the adapter and the yaml file to run the test.

### Detailed Changes
#### Slack Adapter
With the [changes](https://api.slack.com/messaging/retrieving) in the Slack API, the field subtype that we used to filter bot messages, is no longer part of the event's body. 
In the _EventToActivityAsync_ method of the **_SlackHelper_** class, we now filter the messages using the _bot_id_ field of the slack event.
#### Functional Test
In the **_SlackClientTest_** we updated the _SendMessageAsync_ method to create and send the message directly to the bot instead of using the API, because there's no way to impersonate a user to send the message and the bot could respond to it.
#### Yaml file
We updated the **_botbuilder-dotnet-ci-slacktest_** yaml file to pass the necessary variables to the test so it can send the message to the bot. 
