### PR TITLE
Set logProjectEvents to false in MSBuild task

### DIFF
--- a/build/yaml/ci-build-steps.yml
+++ b/build/yaml/ci-build-steps.yml
@@ -29,6 +29,7 @@ steps:
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
     maximumCpuCount: true
+    logProjectEvents: false
 
 - script: |
    cd ..


### PR DESCRIPTION
Fixes # 4047

## Description
This pull request updates the yaml for the CI pipeline setting the _logProjectEvents_ option to false, reducing the pipeline's build time.

_Note: According to the [MSBuild task documentation](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/build/msbuild?view=azure-devops) the default value for logProjectEvents is false, but we noticed in our pipeline that this is not the case, and the log lines were actually reduced after setting the option to false._ 

## Specific Changes
- Added variable `logProjectEvents: false`. When true, this option records timeline details for each project.


## Testing
The following images show the improvement made in the pipeline's build time after setting logProjectEvents to false.

![image](https://user-images.githubusercontent.com/44245136/88569909-80ac0500-d011-11ea-9d29-3fc89de6c56f.png)

The following images show the logs for Release_3.1 build before and after the change.
![image](https://user-images.githubusercontent.com/44245136/88575658-9e319c80-d01a-11ea-8031-cd1555ce8c57.png)

