### PR TITLE
API Compatibility Validations: Execute jobs sequentially

### DIFF
--- a/build/yaml/botbuilder-dotnet-ci.yml
+++ b/build/yaml/botbuilder-dotnet-ci.yml
@@ -101,7 +101,7 @@ stages:
     dependsOn: generate_multiconfig_var
     timeoutInMinutes: 10
     strategy:
-      maxParallel: 10
+      maxParallel: 1
       matrix: $[ dependencies.generate_multiconfig_var.outputs['generate_var.MULTICONFIG'] ]
     steps:
     - template: ci-api-validation-steps.yml


### PR DESCRIPTION
Addresses # 4320

## Description
This PR updates the [botbuilder-dotnet-ci](https://github.com/microsoft/botbuilder-dotnet/blob/master/build/yaml/botbuilder-dotnet-ci.yml) yaml file setting the _maxParallel_ parameter in 1 so the API Compat jobs won't run in parallel.

## Specific Changes
  - Changed the setting of _maxParallel_ from 10 to 1 in the API Compatibility jobs. This will prevent them from running in parallel, reducing the agents needed for this stage to 1.
  
## Testing
The following image shows the API Compat jobs running sequentially after the change.
![image](https://user-images.githubusercontent.com/44245136/89072737-81190880-d34f-11ea-9c7e-fa8fd311ddc9.png)

The next image shows how the pipeline's execution time increased.
![image](https://user-images.githubusercontent.com/44245136/89068036-d7ce1480-d346-11ea-884e-9ec04f9a9189.png)
