### PR TITLE
Run all API Compatibility Validations in one job

### DIFF
--- a/build/yaml/botbuilder-dotnet-ci.yml
+++ b/build/yaml/botbuilder-dotnet-ci.yml
@@ -78,33 +78,26 @@ stages:
 - stage: API_Compatibility_Validation
   dependsOn: Build
   jobs:
-  - job: generate_multiconfig_var
-    steps:
-    - powershell: |
-       $multiconfig = '{';
-
-       $env:BotBuilderDll.Split(",") | ForEach {
-           $library = $_.Trim()
-           Write-Host $library
-
-           $threadName = $library.Split(".")[-1];
-           $multiconfig += "'" + $threadName + "':{'BotBuilderDll':'" + $library + "'}, ";
-         }
-       $multiconfig = $multiconfig.TrimEnd(' ').TrimEnd(',') + "}";
-       $multiconfig
-
-       "##vso[task.setVariable variable=MULTICONFIG;isOutput=true]$multiconfig"
-      name: generate_var
-    - script: echo $(generate_var.MULTICONFIG)
-
-  - job: check_api_for
-    dependsOn: generate_multiconfig_var
+  - job: Check_API_for_libraries
     timeoutInMinutes: 10
-    strategy:
-      maxParallel: 10
-      matrix: $[ dependencies.generate_multiconfig_var.outputs['generate_var.MULTICONFIG'] ]
     steps:
     - template: ci-api-validation-steps.yml
+      parameters:
+        libraries: 
+        - Microsoft.Bot.Builder.AI.Luis
+        - Microsoft.Bot.Builder.AI.QnA
+        - Microsoft.Bot.Builder.ApplicationInsights
+        - Microsoft.Bot.Builder.Azure
+        - Microsoft.Bot.Builder.Dialogs
+        - Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
+        - Microsoft.Bot.Builder.Integration.AspNet.Core
+        - Microsoft.Bot.Builder.TemplateManager
+        - Microsoft.Bot.Builder.Testing
+        - Microsoft.Bot.Builder
+        - Microsoft.Bot.Configuration
+        - Microsoft.Bot.Connector
+        - Microsoft.Bot.Schema
+        - Microsoft.Bot.Streaming
 
 - stage: Post_Results_to_GitHub
   dependsOn: API_Compatibility_Validation

--- a/build/yaml/ci-api-validation-steps.yml
+++ b/build/yaml/ci-api-validation-steps.yml
@@ -1,59 +1,47 @@
+parameters:
+  libraries: []
+
 steps:
 - task: DownloadPipelineArtifact@1
   displayName: 'Download BotBuilderDLLs artifact'
   inputs:
     artifactName: 'BotBuilderDLLs-Debug-Windows-netcoreapp31'
     targetPath: '$(System.ArtifactsDirectory)/Artifacts'
+- ${{ each library in parameters.libraries }}:
+    - task: NuGetCommand@2
+      displayName: 'NuGet Install Target: ${{ library }}'
+      inputs:
+        command: custom
+        arguments: 'install ${{ library }} -Version $(ApiCompatVersion) -OutputDirectory $(System.DefaultWorkingDirectory)\DownloadedNuGet'
 
-- task: NuGetCommand@2
-  displayName: 'NuGet Install of Compatability Target Package: $(BotBuilderDll)'
-  inputs:
-    command: custom
-    arguments: 'install $(BotBuilderDll) -Version $(ApiCompatVersion) -OutputDirectory $(System.DefaultWorkingDirectory)\DownloadedNuGet'
+    - task: SOUTHWORKS.binaries-comparer.custom-build-release-task.binaries-comparer@0
+      displayName: 'Compare Binaries: ${{ library }}'
+      inputs:
+        contractsRootFolder: 'DownloadedNuGet\${{ library }}.$(ApiCompatVersion)\lib\netstandard2.0'
+        contractsFileName: '${{ library }}.dll'
+        implFolder: '$(System.ArtifactsDirectory)/Artifacts'
+        failOnIssue: true
+        resolveFx: false
+        generateLog: true
+        outputFilename: '${{ library }}.$(ApiCompatVersion).CompatResults.txt'
+        outputFolder: '$(Build.ArtifactStagingDirectory)'
+        useBaseline: false
 
-- task: CmdLine@1
-  displayName: 'Run dir'
-  inputs:
-    filename: dir
-    arguments: '..\*.* /s'
-  enabled: false
+    - powershell: |
+       $FileName = "$(Build.ArtifactStagingDirectory)\${{ library }}.$(ApiCompatVersion).CompatResults.txt"
+       $FileContent = @(Get-Content $FileName)
 
-- task: SOUTHWORKS.binaries-comparer.custom-build-release-task.binaries-comparer@0
-  displayName: 'Compare Binaries'
-  inputs:
-    contractsRootFolder: 'DownloadedNuGet\$(BotBuilderDll).$(ApiCompatVersion)\lib\netstandard2.0'
-    contractsFileName: '$(BotBuilderDll).dll'
-    implFolder: '$(System.ArtifactsDirectory)/Artifacts'
-    failOnIssue: true
-    resolveFx: false
-    generateLog: true
-    outputFilename: '$(BotBuilderDll).$(ApiCompatVersion).CompatResults.txt'
-    outputFolder: '$(Build.ArtifactStagingDirectory)'
-    useBaseline: false
+       $FileContent[0] = $FileContent[0] + " compared against [version $(ApiCompatVersion)](https://www.nuget.org/packages/${{ library }}/$(ApiCompatVersion))"
 
-- powershell: |
-   $FileName = "$(Build.ArtifactStagingDirectory)\$(BotBuilderDll).$(ApiCompatVersion).CompatResults.txt"
-   $FileContent = @(Get-Content $FileName)
-    
-   $FileContent[0] = $FileContent[0] + " compared against [version $(ApiCompatVersion)](https://www.nuget.org/packages/$(BotBuilderDll)/$(ApiCompatVersion))"
-    
-   if ($FileContent.Length -eq 1) {
-   [system.io.file]::WriteAllText($fileName,$FileContent)
-   } else {
-   Set-Content $fileName $FileContent
-   }
-   
-   Write-Host "The updated line 1: `n$FileContent[0]"
-  displayName: 'Insert nuget link into ApiCompat results file.'
+       if ($FileContent.Length -eq 1) {
+       [system.io.file]::WriteAllText($fileName,$FileContent)
+       } else {
+       Set-Content $fileName $FileContent
+       }
+       Write-Host "The updated line 1: `n$FileContent[0]"
+      displayName: 'Insert nuget link into ApiCompat results file.'
 
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish Compat Results artifact'
-  inputs:
-    ArtifactName: '$(BotBuilderDll).$(ApiCompatVersion).CompatResults'
-
-- script: |
-   cd ..
-   dir /s
-  displayName: 'Dir workspace'
-  continueOnError: true
-  condition: succeededOrFailed()
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish Compat Results artifact'
+      inputs:
+        ArtifactName: '${{ library }}.$(ApiCompatVersion).CompatResults'


### PR DESCRIPTION
Fixes # 4320

## Description
This PR updates the [botbuilder-dotnet-ci](https://github.com/microsoft/botbuilder-dotnet/blob/master/build/yaml/botbuilder-dotnet-ci.yml) yaml file and the [ci-api-validation-steps](https://github.com/microsoft/botbuilder-dotnet/blob/master/build/yaml/ci-api-validation-steps.yml) template to run all the API compatibility validations in one job to provision only one VM and use one Agent.

## Specific Changes
  - In _**botbuilder-dotnet-ci**_ yaml:
    - Removed the _generate_multiconfig_var_ job. The formatting of the _BotBuilderDll_ variable is no longer necessary.
    - Renamed the _check_api_for_ job as _Check_API_for_libraries_.
    - Added new parameter libraries in the _Check_API_for_libraries_ job. 

 - In _**ci-api-validation-steps**_ yaml template:
    - Added new parameter libraries to iterate over it with the API Compat checks.
    - Removed unnecessary steps _Run dir_ and _Dir workspace_.
    - Added an _each loop_ to iterate over the list of libraries for the API Compat steps.

## Testing
The following image shows the pipeline running the API_Compatibility_Validation stage in one job.

![image](https://user-images.githubusercontent.com/44245136/89432853-fd2c9b00-d717-11ea-9f1e-897d7fa08872.png)
