### PR TITLE
Improves Microsoft.Bot.Builder.Dialogs.Tests

### DIFF
--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogStateManagerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogStateManagerTests.cs
@@ -689,7 +689,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
             var dm = new DialogManager(new TestDialog())
             {
-                ExpireAfter = 1000
+                ExpireAfter = 100
             };
 
             await new TestFlow((TestAdapter)adapter, (turnContext, cancellationToken) =>
@@ -700,7 +700,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 .AssertReply("unknown")
             .Send("yo")
                 .AssertReply("havedata")
-            .Delay(TimeSpan.FromSeconds(1.1))
+            .Delay(TimeSpan.FromMilliseconds(200))
             .Send("yo")
                 .AssertReply("unknown", "Should have expired conversation and ended up with yo=>unknown")
             .Send("yo")


### PR DESCRIPTION
## Description

_DialogStateManagerTests_ asserts the expected expiration time behavior of a dialog, setting up a dialog's expiration time and then waiting for it to expire within a dialog flow. Currently the expiration time is set to 1 second, the wait time to 1.1 seconds.

We decided to go with 0.1 seconds as the shortest measure of time since going below that mark can lead to unreliable results with occasional failures, that way the expiration time ends up at 0.1 seconds, wait time at 0.2 seconds.

The reduction **saves 0.9 seconds**.

## Specific Changes

  - _DialogStateManagerTests_ expiration time set up as 100 milliseconds, time waited updated to 200 milliseconds.

## Testing

The following image showcases a local test comparison between the current implementation and the improvement.

![image](https://user-images.githubusercontent.com/64803884/91483294-dfb5a180-e87d-11ea-8345-2b517852ad20.png)
