### PR TITLE
Improves Microsoft.Bot.ApplicationInsights.Core.Tests

### DIFF
--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/TelemetryInitializerTests.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/TelemetryInitializerTests.cs
@@ -368,7 +368,6 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
                     RelatesTo = context.Activity.RelatesTo,
                 };
                 await context.SendActivityAsync(typingActivity);
-                await Task.Delay(500);
                 await context.SendActivityAsync("echo:" + context.Activity.Text);
             })
                 .Send("foo")
@@ -412,7 +411,6 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
                     RelatesTo = context.Activity.RelatesTo,
                 };
                 await context.SendActivityAsync(typingActivity);
-                await Task.Delay(500);
                 await context.SendActivityAsync("echo:" + context.Activity.Text);
             })
                 .Send("foo")
@@ -455,7 +453,6 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
                     RelatesTo = context.Activity.RelatesTo,
                 };
                 await context.SendActivityAsync(typingActivity);
-                await Task.Delay(500);
                 await context.SendActivityAsync("echo:" + context.Activity.Text);
             })
                 .Send("foo")


### PR DESCRIPTION
## Description

Tests from _TelemetryInitializerTests_ within _Microsoft.Bot.ApplicationInsights.Core.Tests_ feature a _Task.Delay_ of 0.5 seconds 
for each test message sent (between sending typing activities and messages). 

Conversation flows are employed to test telemetry in sets of two message-reply for three tests, adding up to a total of 3 seconds of delayed time.

Removing all three does not affect effectivity and **reduces the time by 3 seconds**.

## Specific Changes

  - Removed all three _Task.Delay_ instances of _TelemetryInitializerTests_

## Testing

The following image shows a comparison of the before and after removal (time variations within are to be expected for tests in general).

![image](https://user-images.githubusercontent.com/64803884/91564518-20adc480-e917-11ea-854f-7868692e0285.png)
