### PR TITLE
Improves Microsoft.Bot.Builder.TemplateManager.Tests

### DIFF
--- a/tests/Microsoft.Bot.Builder.TemplateManager/TemplateManagerTests.cs
+++ b/tests/Microsoft.Bot.Builder.TemplateManager/TemplateManagerTests.cs
@@ -70,23 +70,6 @@ namespace Microsoft.Bot.Builder.TemplateManager.Tests
         }
 
         [TestMethod]
-        public void TemplateManager_MultiTemplate()
-        {
-            var templateManager = new TemplateManager();
-            Assert.AreEqual(templateManager.List().Count, 0, "nothing registered yet");
-            var templateEngine1 = new DictionaryRenderer(templates1);
-            var templateEngine2 = new DictionaryRenderer(templates2);
-            templateManager.Register(templateEngine1);
-            Assert.AreEqual(templateManager.List().Count, 1, "one registered");
-
-            templateManager.Register(templateEngine1);
-            Assert.AreEqual(templateManager.List().Count, 1, "only  one registered");
-
-            templateManager.Register(templateEngine2);
-            Assert.AreEqual(templateManager.List().Count, 2, "two registered");
-        }
-
-        [TestMethod]
         public async Task DictionaryTemplateEngine_SimpleStringBinding()
         {
             var engine = new DictionaryRenderer(templates1);
@@ -211,26 +194,6 @@ namespace Microsoft.Bot.Builder.TemplateManager.Tests
                 })
                 .Send("stringTemplate2").AssertReply("fr: Yo joe")
                 .Send("activityTemplate").AssertReply("(Activity)fr: joe")
-                .StartTestAsync();
-        }
-
-        [TestMethod]
-        public async Task TemplateManager_useTemplateEngine()
-        {
-            TestAdapter adapter = new TestAdapter(TestAdapter.CreateConversation(TestContext.TestName))
-                                .Use(new TranscriptLoggerMiddleware(new TraceTranscriptLogger(traceActivity: false)));
-
-            var templateManager = new TemplateManager()
-                .Register(new DictionaryRenderer(templates1))
-                .Register(new DictionaryRenderer(templates2));
-
-            await new TestFlow(adapter, async (context, cancellationToken) =>
-                {
-                    var templateId = context.Activity.AsMessageActivity().Text.Trim();
-                    await templateManager.ReplyWith(context, templateId, new { name = "joe" });
-                })
-                .Send("stringTemplate").AssertReply("default: joe")
-                .Send("activityTemplate").AssertReply("(Activity)default: joe")
                 .StartTestAsync();
         }
     }


### PR DESCRIPTION
## Description

Two test cases from _TemplateManagerTests_ within _Microsoft.Bot.Builder.TemplateManager.Tests_ are duplicated.

Despite their names pointing to different cases, the test's contents are exactly the same, hence why removing them does not imply any change on code coverage, **improving time consumed slightly by a few milliseconds**. Due to the imprecise nature of test times when analyzed down to the milliseconds mark, there's no way to precisely measure by how much the test's time would improve.

## Specific Changes

  - Removes _TemplateManager_MultiTemplate_ as its contents match exactly those of _TemplateManager_Registration_.
  - Removes _TemplateManager_useTemplateEngine_ as its contents match exactly those of _TemplateManager_DataDefined_.

## Testing

The following image shows a comparison of the before and after removal.

![image](https://user-images.githubusercontent.com/64803884/91579998-cdda0a00-e922-11ea-9355-033dbd34cd1f.png)
