### PR TITLE
[xUnit] Fix issues on Microsoft.Bot.Builder.Ai.LuisV3.Tests

### DIFF
--- a/tests/Microsoft.Bot.Builder.Ai.LUISV3.tests/LuisV3OracleTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.LUISV3.tests/LuisV3OracleTests.cs
@@ -741,7 +741,7 @@ namespace Microsoft.Bot.Builder.AI.LuisV3.Tests
         // The version parameter controls where in the expected json the luisResult is put.  This allows multiple endpoint responses like from
         // LUIS V2 and V3 endpoints.  You should run V3 first since it sometimes adds more information that V2.
         // NOTE: The same oracle files are shared between Luis and LuisPreview in order to ensure the mapping is the same.
-        internal async Task TestJson<T>(string file, ITurnContext turnContext = null)
+        private async Task TestJson<T>(string file, ITurnContext turnContext = null)
             where T : IRecognizerConvert, new()
         {
             GetEnvironmentVars();

--- a/tests/Microsoft.Bot.Builder.Ai.LUISV3.tests/LuisV3OracleTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.LUISV3.tests/LuisV3OracleTests.cs
@@ -130,65 +130,6 @@ namespace Microsoft.Bot.Builder.AI.LuisV3.Tests
             return new TurnContext(testAdapter, activity);
         }
 
-        // To create a file to test:
-        // 1) Create a <name>.json file with an object { text:<query> } in it.
-        // 2) Run this test which will fail and generate a <name>.json.new file.
-        // 3) Check the .new file and if correct, replace the original .json file with it.
-        // The version parameter controls where in the expected json the luisResult is put.  This allows multiple endpoint responses like from
-        // LUIS V2 and V3 endpoints.  You should run V3 first since it sometimes adds more information that V2.
-        // NOTE: The same oracle files are shared between Luis and LuisPreview in order to ensure the mapping is the same.
-        public async Task TestJson<T>(string file, ITurnContext turnContext = null)
-            where T : IRecognizerConvert, new()
-        {
-            GetEnvironmentVars();
-            var version = "v3";
-            var expectedPath = GetFilePath(file);
-            JObject oracle;
-            using (var expectedJsonReader = new JsonTextReader(new StreamReader(expectedPath)))
-            {
-                oracle = (JObject)await JToken.ReadFromAsync(expectedJsonReader);
-            }
-
-            if (oracle[version] == null)
-            {
-                oracle[version] = new JObject();
-            }
-
-            var oldResponse = oracle[version].DeepClone();
-            var newPath = expectedPath + ".new";
-            var query = oracle["text"].ToString();
-            var context = turnContext ?? GetContext(query);
-            var response = oracle[version];
-            var mockResponse = new MemoryStream(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(response?["response"])));
-            var mockHttp = GetMockHttpClientHandlerObject((string)oracle["text"], mockResponse);
-            var oracleOptions = response["options"];
-            var options = (oracleOptions == null || oracleOptions.Type == JTokenType.Null)
-            #pragma warning disable CS0612 // Type or member is obsolete
-                ? new LuisPredictionOptions { IncludeAllIntents = true, IncludeInstanceData = true, IncludeAPIResults = true }
-            #pragma warning restore CS0612 // Type or member is obsolete
-                    : oracleOptions.ToObject<LuisPredictionOptions>();
-            var settings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore };
-            response["options"] = (JObject)JsonConvert.DeserializeObject(JsonConvert.SerializeObject(options, settings));
-            var luisRecognizer = GetLuisRecognizer(mockHttp, options);
-            var typedResult = await luisRecognizer.RecognizeAsync<T>(context, CancellationToken.None);
-            var typedJson = Utils.Json(typedResult, version, oracle);
-
-            // Threshold is 0.0 so when hitting endpoint get exact and when mocking isn't needed.
-            if (!Utils.WithinDelta(oracle, typedJson, 0.0) && !JToken.DeepEquals(typedJson[version], oldResponse))
-            {
-                using (var writer = new StreamWriter(newPath))
-                {
-                    writer.Write(typedJson);
-                }
-
-                Assert.Equal(newPath, expectedPath);
-            }
-            else
-            {
-                File.Delete(expectedPath + ".new");
-            }
-        }
-
         [Fact]
         public async Task TraceActivity()
         {
@@ -271,8 +212,10 @@ namespace Microsoft.Bot.Builder.AI.LuisV3.Tests
         public async Task Minimal() => await TestJson<RecognizerResult>("Minimal.json");
 
         // TODO: This is disabled until the bug requiring instance data for geo is fixed.
-        // [Fact]
+        //[Fact]
+#pragma warning disable xUnit1013 // Public method should be marked as test
         public async Task MinimalWithGeo() => await TestJson<RecognizerResult>("MinimalWithGeo.json");
+#pragma warning restore xUnit1013 // Public method should be marked as test
 
         [Fact]
         public async Task PrebuiltDomains() => await TestJson<RecognizerResult>("Prebuilt.json");
@@ -789,6 +732,65 @@ namespace Microsoft.Bot.Builder.AI.LuisV3.Tests
             Assert.Equal(3.14159, ((Dictionary<string, double>)telemetryClient.Invocations[0].Arguments[2])["moo"]);
             Assert.True(((Dictionary<string, double>)telemetryClient.Invocations[0].Arguments[2]).ContainsKey("luis"));
             Assert.Equal(1.0001, ((Dictionary<string, double>)telemetryClient.Invocations[0].Arguments[2])["luis"]);
+        }
+
+        // To create a file to test:
+        // 1) Create a <name>.json file with an object { text:<query> } in it.
+        // 2) Run this test which will fail and generate a <name>.json.new file.
+        // 3) Check the .new file and if correct, replace the original .json file with it.
+        // The version parameter controls where in the expected json the luisResult is put.  This allows multiple endpoint responses like from
+        // LUIS V2 and V3 endpoints.  You should run V3 first since it sometimes adds more information that V2.
+        // NOTE: The same oracle files are shared between Luis and LuisPreview in order to ensure the mapping is the same.
+        internal async Task TestJson<T>(string file, ITurnContext turnContext = null)
+            where T : IRecognizerConvert, new()
+        {
+            GetEnvironmentVars();
+            var version = "v3";
+            var expectedPath = GetFilePath(file);
+            JObject oracle;
+            using (var expectedJsonReader = new JsonTextReader(new StreamReader(expectedPath)))
+            {
+                oracle = (JObject)await JToken.ReadFromAsync(expectedJsonReader);
+            }
+
+            if (oracle[version] == null)
+            {
+                oracle[version] = new JObject();
+            }
+
+            var oldResponse = oracle[version].DeepClone();
+            var newPath = expectedPath + ".new";
+            var query = oracle["text"].ToString();
+            var context = turnContext ?? GetContext(query);
+            var response = oracle[version];
+            var mockResponse = new MemoryStream(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(response?["response"])));
+            var mockHttp = GetMockHttpClientHandlerObject((string)oracle["text"], mockResponse);
+            var oracleOptions = response["options"];
+            var options = (oracleOptions == null || oracleOptions.Type == JTokenType.Null)
+#pragma warning disable CS0612 // Type or member is obsolete
+                ? new LuisPredictionOptions { IncludeAllIntents = true, IncludeInstanceData = true, IncludeAPIResults = true }
+#pragma warning restore CS0612 // Type or member is obsolete
+                    : oracleOptions.ToObject<LuisPredictionOptions>();
+            var settings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore };
+            response["options"] = (JObject)JsonConvert.DeserializeObject(JsonConvert.SerializeObject(options, settings));
+            var luisRecognizer = GetLuisRecognizer(mockHttp, options);
+            var typedResult = await luisRecognizer.RecognizeAsync<T>(context, CancellationToken.None);
+            var typedJson = Utils.Json(typedResult, version, oracle);
+
+            // Threshold is 0.0 so when hitting endpoint get exact and when mocking isn't needed.
+            if (!Utils.WithinDelta(oracle, typedJson, 0.0) && !JToken.DeepEquals(typedJson[version], oldResponse))
+            {
+                using (var writer = new StreamWriter(newPath))
+                {
+                    writer.Write(typedJson);
+                }
+
+                Assert.Equal(newPath, expectedPath);
+            }
+            else
+            {
+                File.Delete(expectedPath + ".new");
+            }
         }
 
         private IRecognizer GetLuisRecognizer(MockedHttpClientHandler httpClientHandler, LuisPredictionOptions options = null)


### PR DESCRIPTION
Addresses # 4349

## Description
This PR fixes the xUnit1013 issue in **[Microsoft.Bot.Builder.Ai.LuisV3.Tests](https://github.com/microsoft/botbuilder-dotnet/tree/main/tests/Microsoft.Bot.Builder.Ai.LUISV3.tests)** project.

![image](https://user-images.githubusercontent.com/62260472/91737913-1d6c4000-eb86-11ea-9129-60fcd65b88b5.png)

## Specific Changes
- **_LuisV3OracleTests_**
      - Fixed xUnit1013 issue by changing the access modifier to `private` in the `TestJson` method.
      - Disabled xUnit1013 warning in `MinimalWithGeo` method.  

## Testing
The next image shows the tests passing after the changes made:
![image](https://user-images.githubusercontent.com/62260472/91738427-d16dcb00-eb86-11ea-9f39-e91491c98ee8.png)