### PR TITLE
Migrate Microsoft.Bot.Builder.ApplicationInsights.Tests to xUnit

### DIFF
--- a/tests/Microsoft.Bot.Builder.ApplicationInsights.Tests/BotTelemetryClientTests.cs
+++ b/tests/Microsoft.Bot.Builder.ApplicationInsights.Tests/BotTelemetryClientTests.cs
@@ -8,32 +8,32 @@ using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Bot.Builder.ApplicationInsights;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using Xunit;
+using Xunit.Sdk;
 
 namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Tests
 {
     public class BotTelemetryClientTests
     {
-        [TestClass]
         public class ConstructorTests
         {
-            [TestMethod]
+            [Fact]
             public void NullTelemetryClientThrows()
             {
                 try
                 {
                     new BotTelemetryClient(null);
 
-                    Assert.Fail("Expected an exception to be thrown.");
+                    throw new XunitException("Expected an exception to be thrown.");
                 }
                 catch (ArgumentNullException exception)
                 {
-                    Assert.AreEqual<string>("telemetryClient", exception.ParamName);
+                    Assert.Equal("telemetryClient", exception.ParamName);
                 }
             }
 
-            [TestMethod]
+            [Fact]
             public void NonNullTelemtryClientSucceeds()
             {
                 var telemetryClient = new TelemetryClient();
@@ -41,7 +41,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Tests
                 var botTelemetryClient = new BotTelemetryClient(telemetryClient);
             }
 
-            [TestMethod]
+            [Fact]
             public void OverrideTest()
             {
                 var telemetryClient = new TelemetryClient();
@@ -49,14 +49,12 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Tests
             }
         }
 
-        [TestClass]
         public class TrackTelemetryTests
         {
             private BotTelemetryClient _botTelemetryClient;
             private Mock<ITelemetryChannel> _mockTelemetryChannel;
 
-            [TestInitialize]
-            public void TestInitialize()
+            public TrackTelemetryTests()
             {
                 _mockTelemetryChannel = new Mock<ITelemetryChannel>();
 
@@ -66,7 +64,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Tests
                 _botTelemetryClient = new BotTelemetryClient(telemetryClient);
             }
 
-            [TestMethod]
+            [Fact]
             public void TrackAvailabilityTest()
             {
                 _botTelemetryClient.TrackAvailability(
@@ -85,7 +83,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Tests
                 _mockTelemetryChannel.Verify(tc => tc.Send(It.Is<AvailabilityTelemetry>(t => t.Metrics["metric"] == 0.6)));
             }
 
-            [TestMethod]
+            [Fact]
             public void TrackEventTest()
             {
                 _botTelemetryClient.TrackEvent("test", new Dictionary<string, string>() { { "hello", "value" } }, new Dictionary<string, double>() { { "metric", 0.6 } });
@@ -95,7 +93,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Tests
                 _mockTelemetryChannel.Verify(tc => tc.Send(It.Is<EventTelemetry>(t => t.Metrics["metric"] == 0.6)));
             }
 
-            [TestMethod]
+            [Fact]
             public void TrackDependencyTest()
             {
                 _botTelemetryClient.TrackDependency("test", "target", "dependencyname", "data", DateTimeOffset.Now, new TimeSpan(10000), "result", false);
@@ -108,7 +106,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Tests
                 _mockTelemetryChannel.Verify(tc => tc.Send(It.Is<DependencyTelemetry>(t => t.Success == false)));
             }
 
-            [TestMethod]
+            [Fact]
             public void TrackExceptionTest()
             {
                 var expectedException = new Exception("test-exception");
@@ -119,7 +117,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Tests
                 _mockTelemetryChannel.Verify(tc => tc.Send(It.Is<ExceptionTelemetry>(t => t.Metrics["metric"] == 0.6)));
             }
 
-            [TestMethod]
+            [Fact]
             public void TrackTraceTest()
             {
                 _botTelemetryClient.TrackTrace("hello", Severity.Critical, new Dictionary<string, string>() { { "foo", "bar" } });
@@ -129,7 +127,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Tests
                 _mockTelemetryChannel.Verify(tc => tc.Send(It.Is<TraceTelemetry>(t => t.Properties["foo"] == "bar")));
             }
 
-            [TestMethod]
+            [Fact]
             public void TrackPageViewTest()
             {
                 _botTelemetryClient.TrackDialogView("test", new Dictionary<string, string>() { { "hello", "value" } }, new Dictionary<string, double>() { { "metric", 0.6 } });

--- a/tests/Microsoft.Bot.Builder.ApplicationInsights.Tests/Microsoft.Bot.Builder.ApplicationInsights.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.ApplicationInsights.Tests/Microsoft.Bot.Builder.ApplicationInsights.Tests.csproj
@@ -11,8 +11,11 @@
   <ItemGroup>    
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Bot.Builder.ApplicationInsights.Tests/TelemetryWaterfallTests.cs
+++ b/tests/Microsoft.Bot.Builder.ApplicationInsights.Tests/TelemetryWaterfallTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Tests
         {
             var convoState = new ConversationState(new MemoryStorage());
 
-            var adapter = new TestAdapter(TestAdapter.CreateConversation("Waterfall"))
+            var adapter = new TestAdapter(TestAdapter.CreateConversation(nameof(Waterfall)))
                 .Use(new AutoSaveStateMiddleware(convoState));
             
             var telemetryClient = new Mock<IBotTelemetryClient>();
@@ -54,7 +54,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Tests
         {
             var convoState = new ConversationState(new MemoryStorage());
 
-            var adapter = new TestAdapter(TestAdapter.CreateConversation("WaterfallWithCallback"))
+            var adapter = new TestAdapter(TestAdapter.CreateConversation(nameof(WaterfallWithCallback)))
                 .Use(new AutoSaveStateMiddleware(convoState));
 
             var dialogState = convoState.CreateProperty<DialogState>("dialogState");
@@ -100,7 +100,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Tests
         {
             var convoState = new ConversationState(new MemoryStorage());
 
-            var adapter = new TestAdapter(TestAdapter.CreateConversation("EnsureEndDialogCalled"))
+            var adapter = new TestAdapter(TestAdapter.CreateConversation(nameof(EnsureEndDialogCalled)))
                 .Use(new AutoSaveStateMiddleware(convoState));
 
             var dialogState = convoState.CreateProperty<DialogState>("dialogState");
@@ -160,7 +160,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Tests
         {
             var convoState = new ConversationState(new MemoryStorage());
 
-            var adapter = new TestAdapter(TestAdapter.CreateConversation("EnsureCancelDialogCalled"))
+            var adapter = new TestAdapter(TestAdapter.CreateConversation(nameof(EnsureCancelDialogCalled)))
                 .Use(new AutoSaveStateMiddleware(convoState));
 
             var dialogState = convoState.CreateProperty<DialogState>("dialogState");

--- a/tests/Microsoft.Bot.Builder.ApplicationInsights.Tests/TelemetryWaterfallTests.cs
+++ b/tests/Microsoft.Bot.Builder.ApplicationInsights.Tests/TelemetryWaterfallTests.cs
@@ -6,26 +6,22 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
-using Microsoft.Bot.Builder.ApplicationInsights;
 using Microsoft.Bot.Builder.Dialogs;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Tests
 {
-    [TestClass]
     public class TelemetryWaterfallTests
     {
-        public TestContext TestContext { get; set; }
-
-        [TestMethod]
+        [Fact]
         public async Task Waterfall()
         {
             var convoState = new ConversationState(new MemoryStorage());
 
-            var adapter = new TestAdapter(TestAdapter.CreateConversation(TestContext.TestName))
+            var adapter = new TestAdapter(TestAdapter.CreateConversation("Waterfall"))
                 .Use(new AutoSaveStateMiddleware(convoState));
-
+            
             var telemetryClient = new Mock<IBotTelemetryClient>();
             var dialogState = convoState.CreateProperty<DialogState>("dialogState");
             var dialogs = new DialogSet(dialogState);
@@ -53,12 +49,12 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Tests
             Console.WriteLine("Complete");
         }
 
-        [TestMethod]
+        [Fact]
         public async Task WaterfallWithCallback()
         {
             var convoState = new ConversationState(new MemoryStorage());
 
-            var adapter = new TestAdapter(TestAdapter.CreateConversation(TestContext.TestName))
+            var adapter = new TestAdapter(TestAdapter.CreateConversation("WaterfallWithCallback"))
                 .Use(new AutoSaveStateMiddleware(convoState));
 
             var dialogState = convoState.CreateProperty<DialogState>("dialogState");
@@ -88,21 +84,23 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Tests
             telemetryClient.Verify(m => m.TrackEvent(It.IsAny<string>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<IDictionary<string, double>>()), Times.Exactly(4));
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public void WaterfallWithActionsNull()
         {
-            var telemetryClient = new Mock<IBotTelemetryClient>();
-            var waterfall = new WaterfallDialog("test") { TelemetryClient = telemetryClient.Object };
-            waterfall.AddStep(null);
+            Assert.ThrowsAny<ArgumentNullException>(() =>
+            {
+                var telemetryClient = new Mock<IBotTelemetryClient>();
+                var waterfall = new WaterfallDialog("test") { TelemetryClient = telemetryClient.Object };
+                waterfall.AddStep(null);
+            });
         }
 
-        [TestMethod]
+        [Fact]
         public async Task EnsureEndDialogCalled()
         {
             var convoState = new ConversationState(new MemoryStorage());
 
-            var adapter = new TestAdapter(TestAdapter.CreateConversation(TestContext.TestName))
+            var adapter = new TestAdapter(TestAdapter.CreateConversation("EnsureEndDialogCalled"))
                 .Use(new AutoSaveStateMiddleware(convoState));
 
             var dialogState = convoState.CreateProperty<DialogState>("dialogState");
@@ -145,24 +143,24 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Tests
             // Event occurs on the 4th event logged
             // Event contains DialogId
             // Event DialogId is set correctly.
-            Assert.IsTrue(saved_properties["WaterfallComplete_4"].ContainsKey("DialogId"));
-            Assert.IsTrue(saved_properties["WaterfallComplete_4"]["DialogId"] == "test");
-            Assert.IsTrue(saved_properties["WaterfallComplete_4"].ContainsKey("InstanceId"));
-            Assert.IsTrue(saved_properties["WaterfallStep_1"].ContainsKey("InstanceId"));
+            Assert.True(saved_properties["WaterfallComplete_4"].ContainsKey("DialogId"));
+            Assert.True(saved_properties["WaterfallComplete_4"]["DialogId"] == "test");
+            Assert.True(saved_properties["WaterfallComplete_4"].ContainsKey("InstanceId"));
+            Assert.True(saved_properties["WaterfallStep_1"].ContainsKey("InstanceId"));
 
             // Verify naming on lambda's is "StepXofY"
-            Assert.IsTrue(saved_properties["WaterfallStep_1"].ContainsKey("StepName"));
-            Assert.IsTrue(saved_properties["WaterfallStep_1"]["StepName"] == "Step1of3");
-            Assert.IsTrue(saved_properties["WaterfallStep_1"].ContainsKey("InstanceId"));
-            Assert.IsTrue(waterfallDialog.EndDialogCalled);
+            Assert.True(saved_properties["WaterfallStep_1"].ContainsKey("StepName"));
+            Assert.True(saved_properties["WaterfallStep_1"]["StepName"] == "Step1of3");
+            Assert.True(saved_properties["WaterfallStep_1"].ContainsKey("InstanceId"));
+            Assert.True(waterfallDialog.EndDialogCalled);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task EnsureCancelDialogCalled()
         {
             var convoState = new ConversationState(new MemoryStorage());
 
-            var adapter = new TestAdapter(TestAdapter.CreateConversation(TestContext.TestName))
+            var adapter = new TestAdapter(TestAdapter.CreateConversation("EnsureCancelDialogCalled"))
                 .Use(new AutoSaveStateMiddleware(convoState));
 
             var dialogState = convoState.CreateProperty<DialogState>("dialogState");
@@ -222,18 +220,18 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Tests
             // Event occurs on the 4th event logged
             // Event contains DialogId
             // Event DialogId is set correctly.
-            Assert.IsTrue(saved_properties["WaterfallStart_0"].ContainsKey("DialogId"));
-            Assert.IsTrue(saved_properties["WaterfallStart_0"].ContainsKey("InstanceId"));
-            Assert.IsTrue(saved_properties["WaterfallCancel_4"].ContainsKey("DialogId"));
-            Assert.IsTrue(saved_properties["WaterfallCancel_4"]["DialogId"] == "test");
-            Assert.IsTrue(saved_properties["WaterfallCancel_4"].ContainsKey("StepName"));
-            Assert.IsTrue(saved_properties["WaterfallCancel_4"].ContainsKey("InstanceId"));
+            Assert.True(saved_properties["WaterfallStart_0"].ContainsKey("DialogId"));
+            Assert.True(saved_properties["WaterfallStart_0"].ContainsKey("InstanceId"));
+            Assert.True(saved_properties["WaterfallCancel_4"].ContainsKey("DialogId"));
+            Assert.True(saved_properties["WaterfallCancel_4"]["DialogId"] == "test");
+            Assert.True(saved_properties["WaterfallCancel_4"].ContainsKey("StepName"));
+            Assert.True(saved_properties["WaterfallCancel_4"].ContainsKey("InstanceId"));
 
             // Event contains "StepName"
             // Event naming on lambda's is "StepXofY"
-            Assert.IsTrue(saved_properties["WaterfallCancel_4"]["StepName"] == "Step3of3");
-            Assert.IsTrue(waterfallDialog.CancelDialogCalled);
-            Assert.IsFalse(waterfallDialog.EndDialogCalled);
+            Assert.True(saved_properties["WaterfallCancel_4"]["StepName"] == "Step3of3");
+            Assert.True(waterfallDialog.CancelDialogCalled);
+            Assert.False(waterfallDialog.EndDialogCalled);
         }
 
         private static WaterfallStep[] NewWaterfall()

--- a/tests/Microsoft.Bot.Builder.ApplicationInsights.Tests/TelemetryWaterfallTests.cs
+++ b/tests/Microsoft.Bot.Builder.ApplicationInsights.Tests/TelemetryWaterfallTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Tests
         [Fact]
         public void WaterfallWithActionsNull()
         {
-            Assert.ThrowsAny<ArgumentNullException>(() =>
+            Assert.Throws<ArgumentNullException>(() =>
             {
                 var telemetryClient = new Mock<IBotTelemetryClient>();
                 var waterfall = new WaterfallDialog("test") { TelemetryClient = telemetryClient.Object };


### PR DESCRIPTION
Fixes # 4089

## Description
This PR migrates all [Microsoft.Bot.Builder.ApplicationInsights](https://github.com/microsoft/botbuilder-dotnet/tree/main/tests/Microsoft.Bot.Builder.ApplicationInsights.Tests) tests from **MSTest** to **xUnit**.

## Specific Changes
- Replaced `MSTest` packages with `xUnit` in the `.csproj`.
- Changed `[TestMethod]` to `[Fact]`.
- Changed `Assert.AreEqual` to `Assert.Equal`.
- Changed `Assert.Fail` to `throw new XunitException`.
- Changed `Assert.IsTrue` to `Assert.True`.
- Changed `[ExpectedException(typeof(ArgumentNullException))]` to `Assert.Throws<ArgumentNullException>`.
- Changed `TestContext.TestName` to include directly the name of the test.

## Testing
In the following image there are the passing tests.
![image](https://user-images.githubusercontent.com/62260472/91998308-6dc3d900-ed11-11ea-8fdc-ab65ba4e3f3d.png)