### PR TITLE
[Facebook and Webex adapter functional test] Validate required variables to correct inconclusive results

### DIFF
--- a/build/yaml/botbuilder-dotnet-ci-facebook-test.yml
+++ b/build/yaml/botbuilder-dotnet-ci-facebook-test.yml
@@ -77,7 +77,6 @@ steps:
    $content.FacebookAccessToken = "$(FacebookTestBotFacebookAccessToken)";
    $content | ConvertTo-Json | Set-Content $file;
   displayName: 'Set values in appsettings.json file.'
-  condition: succeeded()
 
 - template: ci-build-steps.yml
 
@@ -89,7 +88,6 @@ steps:
     projects: '$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot\Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot.csproj'
     arguments: '--output $(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot\PublishedBot -p:TreatWarningsAsErrors=false'
     modifyOutputPath: false
-  condition: succeeded()
 
 - task: AzureCLI@1
   displayName: 'Create resources'
@@ -105,7 +103,6 @@ steps:
      :: Option 2: Use the "preexisting-rg" template:
      call az group create --location westus --name $(BotGroup)
      call az deployment group create --resource-group "$(BotGroup)" --template-file "$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot\DeploymentTemplates\template-with-preexisting-rg.json" --parameters appId="$(AppId)" appSecret="$(AppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)" appServicePlanLocation="westus" facebookVerifyToken="verifyToken" facebookAppSecret="$(FacebookTestBotFaceBookAppSecret)"  facebookAccessToken="$(FacebookTestBotFacebookAccessToken)" --name "$(BotName)"
-  condition: succeeded()
 
 - task: AzureCLI@1
   displayName: 'Deploy the bot'
@@ -114,12 +111,10 @@ steps:
     scriptLocation: inlineScript
     inlineScript: |
      call az webapp deployment source config-zip --resource-group "$(BotGroup)" --name "$(BotName)" --src "$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot\PublishedBot\PublishedBot.zip"
-  condition: succeeded()
 
 - powershell: |
    echo '##vso[task.setvariable variable=BOT_ENDPOINT]https://$(BotName).azurewebsites.net/api/messages'
   displayName: 'Set BOT_ENDPOINT environment variable'
-  condition: succeeded()
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test'
@@ -127,7 +122,6 @@ steps:
     command: test
     projects: '$(System.DefaultWorkingDirectory)\FunctionalTests\Microsoft.Bot.Builder.FunctionalTests\Microsoft.Bot.Builder.FunctionalTests.csproj'
     arguments: '-v n --configuration $(BuildConfiguration) --no-build --no-restore --filter FacebookChatTest'
-  condition: succeeded()
 
 - task: AzureCLI@1
   displayName: 'Delete Azure resources'

--- a/build/yaml/botbuilder-dotnet-ci-facebook-test.yml
+++ b/build/yaml/botbuilder-dotnet-ci-facebook-test.yml
@@ -44,10 +44,29 @@ variables:
 #  FacebookTestBotBotName: define this in Azure
 #  FacebookTestBotFacebookAccessToken: define this in Azure
 #  FacebookTestBotFacebookAppSecret: define this in Azure
-#  FacebookTestBotFacebookVerifyToken: define this in Azure
+#  FacebookTestBotFacebookVerifyToken: (optional) define this in Azure. Useful for webhook testing for un-deleted resources post-execution.
 #  FacebookTestBotSenderId: define this in Azure?: This var not needed in build 156862. Revisit this after the build's test is fixed & running.
 
 steps:
+- powershell: |
+    $InvalidVariables = $FALSE
+    $Message = "Required variable 'REPLACE_VARIABLE' either null, empty or whitespaced. Please set up this variable in the pipeline configuration."
+
+    if(!"$env:FacebookTestBotAppId".Trim())               {$InvalidVariables = $TRUE; Write-Host $Message.replace("REPLACE_VARIABLE", "FacebookTestBotAppId")}
+    if(!"$env:FacebookTestBotAppSecret".Trim())           {$InvalidVariables = $TRUE; Write-Host $Message.replace("REPLACE_VARIABLE", "FacebookTestBotAppSecret")}
+    if(!"$env:AzureSubscription".Trim())                  {$InvalidVariables = $TRUE; Write-Host $Message.replace("REPLACE_VARIABLE", "AzureSubscription")}
+    if(!"$env:FacebookTestBotBotGroup".Trim())            {$InvalidVariables = $TRUE; Write-Host $Message.replace("REPLACE_VARIABLE", "FacebookTestBotBotGroup")}
+    if(!"$env:FacebookTestBotBotName".Trim())             {$InvalidVariables = $TRUE; Write-Host $Message.replace("REPLACE_VARIABLE", "FacebookTestBotBotName")}
+    if(!"$env:FacebookTestBotFacebookAccessToken".Trim()) {$InvalidVariables = $TRUE; Write-Host $Message.replace("REPLACE_VARIABLE", "FacebookTestBotFacebookAccessToken")}
+    if(!"$env:FacebookTestBotFacebookAppSecret".Trim())   {$InvalidVariables = $TRUE; Write-Host $Message.replace("REPLACE_VARIABLE", "FacebookTestBotFacebookAppSecret")}
+    if(!"$env:FacebookTestBotSenderId".Trim())            {$InvalidVariables = $TRUE; Write-Host $Message.replace("REPLACE_VARIABLE", "FacebookTestBotSenderId")}
+    
+    if($InvalidVariables){
+      Write-Host "##vso[task.setvariable variable=InvalidVariables;]true"
+      Write-Host "##vso[task.complete result=Failed;]DONE"
+    }
+  displayName: Validate variables
+
 - powershell: |
    # Set values in appsettings.json file.
    $file = "$(Build.SourcesDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot\appsettings.json";
@@ -58,6 +77,7 @@ steps:
    $content.FacebookAccessToken = "$(FacebookTestBotFacebookAccessToken)";
    $content | ConvertTo-Json | Set-Content $file;
   displayName: 'Set values in appsettings.json file.'
+  condition: succeeded()
 
 - template: ci-build-steps.yml
 
@@ -69,6 +89,7 @@ steps:
     projects: '$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot\Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot.csproj'
     arguments: '--output $(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot\PublishedBot -p:TreatWarningsAsErrors=false'
     modifyOutputPath: false
+  condition: succeeded()
 
 - task: AzureCLI@1
   displayName: 'Create resources'
@@ -84,6 +105,7 @@ steps:
      :: Option 2: Use the "preexisting-rg" template:
      call az group create --location westus --name $(BotGroup)
      call az deployment group create --resource-group "$(BotGroup)" --template-file "$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot\DeploymentTemplates\template-with-preexisting-rg.json" --parameters appId="$(AppId)" appSecret="$(AppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)" appServicePlanLocation="westus" facebookVerifyToken="verifyToken" facebookAppSecret="$(FacebookTestBotFaceBookAppSecret)"  facebookAccessToken="$(FacebookTestBotFacebookAccessToken)" --name "$(BotName)"
+  condition: succeeded()
 
 - task: AzureCLI@1
   displayName: 'Deploy the bot'
@@ -92,10 +114,12 @@ steps:
     scriptLocation: inlineScript
     inlineScript: |
      call az webapp deployment source config-zip --resource-group "$(BotGroup)" --name "$(BotName)" --src "$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot\PublishedBot\PublishedBot.zip"
+  condition: succeeded()
 
 - powershell: |
    echo '##vso[task.setvariable variable=BOT_ENDPOINT]https://$(BotName).azurewebsites.net/api/messages'
   displayName: 'Set BOT_ENDPOINT environment variable'
+  condition: succeeded()
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test'
@@ -103,6 +127,7 @@ steps:
     command: test
     projects: '$(System.DefaultWorkingDirectory)\FunctionalTests\Microsoft.Bot.Builder.FunctionalTests\Microsoft.Bot.Builder.FunctionalTests.csproj'
     arguments: '-v n --configuration $(BuildConfiguration) --no-build --no-restore --filter FacebookChatTest'
+  condition: succeeded()
 
 - task: AzureCLI@1
   displayName: 'Delete Azure resources'
@@ -110,4 +135,4 @@ steps:
     azureSubscription: '$(AzureSubscription)'
     scriptLocation: inlineScript
     inlineScript: 'call az group delete -n "$(BotGroup)" --yes'
-  condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))
+  condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'), ne(variables.InvalidVariables, 'true'))

--- a/build/yaml/botbuilder-dotnet-ci-webex-test.yml
+++ b/build/yaml/botbuilder-dotnet-ci-webex-test.yml
@@ -27,8 +27,8 @@ trigger: # ci trigger
 pr: none # no pr trigger
 
 variables:
-  AppId: $(WebexTestBotAppId)
   AppSecret: $(WebexTestBotAppSecret)
+  AppId: $(WebexTestBotAppId)
   BotGroup: $(WebexTestBotBotGroup)
   BotName: $(WebexTestBotBotName)
   MSBuildArguments: -p:SignAssembly=false -p:delaySign=false -p:RunAnalyzersDuringBuild=false
@@ -53,6 +53,28 @@ variables:
 #  WebexTestBotWebexWebhookSecret: define this in Azure
 
 steps:
+- powershell: |
+    $InvalidVariables = $FALSE
+    $Message = "Required variable 'REPLACE_VARIABLE' either null, empty or whitespaced. Please set up this variable in the pipeline configuration."
+
+    if(!"$env:WebexTestBotAppSecret".Trim())                     {$InvalidVariables = $TRUE; Write-Host $Message.replace("REPLACE_VARIABLE", "WebexTestBotAppSecret")}
+    if(!"$env:WebexTestBotBotGroup".Trim())                      {$InvalidVariables = $TRUE; Write-Host $Message.replace("REPLACE_VARIABLE", "WebexTestBotBotGroup")}
+    if(!"$env:WebexTestBotBotName".Trim())                       {$InvalidVariables = $TRUE; Write-Host $Message.replace("REPLACE_VARIABLE", "WebexTestBotBotName")}
+    if(!"$env:WebexTestBotRefreshToken".Trim())                  {$InvalidVariables = $TRUE; Write-Host $Message.replace("REPLACE_VARIABLE", "WebexTestBotRefreshToken")}
+    if(!"$env:WebexTestBotWebexBotAccessToken".Trim())           {$InvalidVariables = $TRUE; Write-Host $Message.replace("REPLACE_VARIABLE", "WebexTestBotWebexBotAccessToken")}
+    if(!"$env:WebexTestBotWebexBotUserName".Trim())              {$InvalidVariables = $TRUE; Write-Host $Message.replace("REPLACE_VARIABLE", "WebexTestBotWebexBotUserName")}
+    if(!"$env:WebexTestBotWebexIntegrationClientId".Trim())      {$InvalidVariables = $TRUE; Write-Host $Message.replace("REPLACE_VARIABLE", "WebexTestBotWebexIntegrationClientId")}
+    if(!"$env:WebexTestBotWebexIntegrationClientSecret".Trim())  {$InvalidVariables = $TRUE; Write-Host $Message.replace("REPLACE_VARIABLE", "WebexTestBotWebexIntegrationClientSecret")}
+    if(!"$env:WebexTestBotWebexRoomId".Trim())                   {$InvalidVariables = $TRUE; Write-Host $Message.replace("REPLACE_VARIABLE", "WebexTestBotWebexRoomId")}
+    if(!"$env:WebexTestBotWebexWebhookName".Trim())              {$InvalidVariables = $TRUE; Write-Host $Message.replace("REPLACE_VARIABLE", "WebexTestBotWebexWebhookName")}
+    if(!"$env:WebexTestBotWebexWebhookSecret".Trim())            {$InvalidVariables = $TRUE; Write-Host $Message.replace("REPLACE_VARIABLE", "WebexTestBotWebexWebhookSecret")}
+
+    if($InvalidVariables){
+      Write-Host "##vso[task.setvariable variable=InvalidVariables;]true"
+      Write-Host "##vso[task.complete result=Failed;]DONE"
+    }
+  displayName: Validate variables
+
 - template: ci-build-steps.yml
 
 - task: DotNetCoreCLI@2
@@ -63,6 +85,7 @@ steps:
     projects: '$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Webex.TestBot\Microsoft.Bot.Builder.Adapters.Webex.TestBot.csproj'
     arguments: '--output $(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Webex.TestBot\PublishedBot -p:TreatWarningsAsErrors=false'
     modifyOutputPath: false
+  condition: succeeded()
 
 - task: AzureCLI@1
   displayName: 'Create Azure Resources'
@@ -78,6 +101,7 @@ steps:
      :: Option 2: Use the "preexisting-rg" template:
      ::call az group create --location westus --name $(BotGroup)
      ::call az deployment group create --resource-group "$(BotGroup)" --template-file "$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Webex.TestBot\DeploymentTemplates\template-with-preexisting-rg.json" --parameters appId="$(AppId)" appSecret="$(AppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)" appServicePlanLocation="westus" webexPublicAddress="$(WebexPublicAddress)" webexAccessToken="$(WebexTestBotWebexBotAccessToken)" webexSecret="$(WebexTestBotWebexWebhookSecret)" webexWebhookName="$(WebexTestBotWebexWebhookName)" --name "$(BotName)"
+  condition: succeeded()
 
 - task: AzureCLI@1
   displayName: 'Deploy the bot'
@@ -86,6 +110,7 @@ steps:
     scriptLocation: inlineScript
     inlineScript: |
      call az webapp deployment source config-zip --resource-group "$(BotGroup)" --name "$(BotName)" --src "$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Webex.TestBot\PublishedBot\PublishedBot.zip"
+  condition: succeeded()
 
 - task: AzureCLI@1
   displayName: 'Zip Deploy Bot'
@@ -93,6 +118,7 @@ steps:
     azureSubscription: '$(AzureSubscription)'
     scriptLocation: inlineScript
     inlineScript: 'call az webapp deployment source config-zip --resource-group "$(BotGroup)" --name "$(BotName)" --src "$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Webex.TestBot\PublishedBot\PublishedBot.zip"'
+    condition: succeeded()
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test'
@@ -106,6 +132,7 @@ steps:
     WebexTestBotWebexIntegrationClientId: $(WebexTestBotWebexIntegrationClientId)
     WebexTestBotWebexIntegrationClientSecret: $(WebexTestBotWebexIntegrationClientSecret)
     WebexTestBotWebexBotUserName: $(WebexTestBotWebexBotUserName)
+  condition: succeeded()
 
 - task: AzureCLI@1
   displayName: 'Delete Resources'
@@ -113,4 +140,4 @@ steps:
     azureSubscription: '$(AzureSubscription)'
     scriptLocation: inlineScript
     inlineScript: 'call az group delete -n "$(BotGroup)" --yes'
-  condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'))
+  condition: and(always(), ne(variables['DeleteResourceGroup'], 'false'), ne(variables.InvalidVariables, 'true'))

--- a/build/yaml/botbuilder-dotnet-ci-webex-test.yml
+++ b/build/yaml/botbuilder-dotnet-ci-webex-test.yml
@@ -27,8 +27,8 @@ trigger: # ci trigger
 pr: none # no pr trigger
 
 variables:
-  AppSecret: $(WebexTestBotAppSecret)
   AppId: $(WebexTestBotAppId)
+  AppSecret: $(WebexTestBotAppSecret)
   BotGroup: $(WebexTestBotBotGroup)
   BotName: $(WebexTestBotBotName)
   MSBuildArguments: -p:SignAssembly=false -p:delaySign=false -p:RunAnalyzersDuringBuild=false
@@ -85,7 +85,6 @@ steps:
     projects: '$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Webex.TestBot\Microsoft.Bot.Builder.Adapters.Webex.TestBot.csproj'
     arguments: '--output $(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Webex.TestBot\PublishedBot -p:TreatWarningsAsErrors=false'
     modifyOutputPath: false
-  condition: succeeded()
 
 - task: AzureCLI@1
   displayName: 'Create Azure Resources'
@@ -101,7 +100,6 @@ steps:
      :: Option 2: Use the "preexisting-rg" template:
      ::call az group create --location westus --name $(BotGroup)
      ::call az deployment group create --resource-group "$(BotGroup)" --template-file "$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Webex.TestBot\DeploymentTemplates\template-with-preexisting-rg.json" --parameters appId="$(AppId)" appSecret="$(AppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)" appServicePlanLocation="westus" webexPublicAddress="$(WebexPublicAddress)" webexAccessToken="$(WebexTestBotWebexBotAccessToken)" webexSecret="$(WebexTestBotWebexWebhookSecret)" webexWebhookName="$(WebexTestBotWebexWebhookName)" --name "$(BotName)"
-  condition: succeeded()
 
 - task: AzureCLI@1
   displayName: 'Deploy the bot'
@@ -110,7 +108,6 @@ steps:
     scriptLocation: inlineScript
     inlineScript: |
      call az webapp deployment source config-zip --resource-group "$(BotGroup)" --name "$(BotName)" --src "$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Webex.TestBot\PublishedBot\PublishedBot.zip"
-  condition: succeeded()
 
 - task: AzureCLI@1
   displayName: 'Zip Deploy Bot'
@@ -118,7 +115,6 @@ steps:
     azureSubscription: '$(AzureSubscription)'
     scriptLocation: inlineScript
     inlineScript: 'call az webapp deployment source config-zip --resource-group "$(BotGroup)" --name "$(BotName)" --src "$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Webex.TestBot\PublishedBot\PublishedBot.zip"'
-    condition: succeeded()
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test'
@@ -132,7 +128,6 @@ steps:
     WebexTestBotWebexIntegrationClientId: $(WebexTestBotWebexIntegrationClientId)
     WebexTestBotWebexIntegrationClientSecret: $(WebexTestBotWebexIntegrationClientSecret)
     WebexTestBotWebexBotUserName: $(WebexTestBotWebexBotUserName)
-  condition: succeeded()
 
 - task: AzureCLI@1
   displayName: 'Delete Resources'


### PR DESCRIPTION
Fixes Issue# 4545

## Description

> The functional tests currently run and end as Inconclusive, which hides the actual state of the tests. We need to determine if the failures are test issues and if they are, fix them.

The inconclusive result of Facebook's and Webex's tests are a product of required environment variables being un-reachable, which skips the actual functional tests. Our tests ran successfully whenever all environment variables were set up correctly, and we could only replicate the issue's reported behavior when leaving variables null purposefully.

It should be noted that the current inconclusive response is not an issue of the test's implementation. Changing the inconclusive assertions to failures would lead to false negatives, since the tests did not fail, but were **unable to be run**.

Our proposed solution is to integrate a required variable validating task to run prior to all other tasks in the pipeline. This keeps the tests intact and **saves waiting for the pipeline to run until failure** due to missing, empty or white-spaced variables, making those occurrences **easier to catch and correct**.

We validate for required variables manually on each case, leaving room for custom behavior. It should be noted that we also left the _FacebookTestBotFacebookVerifyToken_ variable on _[botbuilder-dotnet-ci-facebook-test.yml](https://github.com/microsoft/botbuilder-dotnet/blob/main/build/yaml/botbuilder-dotnet-ci-facebook-test.yml)_ unvalidated as it was detected that it was not required for the test to run.

## Specific Changes

- Adds a required variable validation task and skip conditions to subsequent tasks to _[botbuilder-dotnet-ci-webex-test.yml](https://github.com/microsoft/botbuilder-dotnet/blob/main/build/yaml/botbuilder-dotnet-ci-webex-test.yml)_ and _[botbuilder-dotnet-ci-facebook-test.yml](https://github.com/microsoft/botbuilder-dotnet/blob/main/build/yaml/botbuilder-dotnet-ci-facebook-test.yml)_.
- Added an optional clarification and description to _FacebookTestBotFacebookVerifyToken_ variable signature on _[botbuilder-dotnet-ci-facebook-test.yml](https://github.com/microsoft/botbuilder-dotnet/blob/main/build/yaml/botbuilder-dotnet-ci-facebook-test.yml)_ since the variable was detected to not be required.

## Testing

The following image showcases the new task in action. First we deleted required variables, then the task outputs which variables were missing.

![image](https://user-images.githubusercontent.com/64803884/92025680-48959180-ed36-11ea-8b22-21fe9c08791f.png)

We also checked that both Facebook's and Webex's tests were running correctly, which we can corroborate with the following images.

- Facebook:
![image](https://user-images.githubusercontent.com/64803884/92025917-97dbc200-ed36-11ea-94f0-a2be6396a3c9.png)

- Webex:
![image](https://user-images.githubusercontent.com/64803884/92025903-94483b00-ed36-11ea-9f73-1e7cc91ffb8f.png)



