### PR TITLE
Migrate Microsoft.Bot.Builder.Dialogs.Debugging.Tests to xUnit

### DIFF
--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests.csproj
@@ -12,8 +12,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/identifierTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/identifierTests.cs
@@ -4,11 +4,10 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Bot.Builder.Dialogs.Debugging.Identifiers;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests
 {
-    [TestClass]
     public sealed class IdentifierTests
     {
         public static IEnumerable<ulong> Bytes => new[]
@@ -25,14 +24,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests
             from two in Items
             select new object[] { one, two };
 
-        [DataTestMethod]
-        [DynamicData(nameof(Data))]
+        [Theory]
+        [MemberData(nameof(Data), DisableDiscoveryEnumeration = true)]
         public void Identifier_Encode_Decode(ulong one, ulong two)
         {
             var item = Identifier.Encode(one, two);
             Identifier.Decode(item, out var oneX, out var twoX);
-            Assert.AreEqual(one, oneX);
-            Assert.AreEqual(two, twoX);
+            Assert.Equal(one, oneX);
+            Assert.Equal(two, twoX);
         }
     }
 }


### PR DESCRIPTION
Fixes # 4094

## Description
This PR migrates all [Microsoft.Bot.Builder.Dialogs.Debugging](https://github.com/microsoft/botbuilder-dotnet/tree/main/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests) tests from **MSTest** to **xUnit**.

## Specific Changes
- Replaced `MSTest` packages with `xUnit` in the `.csproj`.
- Changed `[DataTestMethod]` to `[Theory]`.
- Changed `[DynamicData(nameof(Data))]` to `[MemberData(nameof(Data), DisableDiscoveryEnumeration = true)]`.
- Changed `Assert.AreEqual` to `Assert.Equal`.

## Testing
In the following image there are the passing tests.
![image](https://user-images.githubusercontent.com/62260472/92028058-ce670c00-ed39-11ea-8a4b-d71fc15c5846.png)