### PR TITLE
Migrate Microsoft.Bot.Builder.TemplateManager.Tests to xUnit

### DIFF
--- a/tests/Microsoft.Bot.Builder.TemplateManager/Microsoft.Bot.Builder.TemplateManager.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.TemplateManager/Microsoft.Bot.Builder.TemplateManager.Tests.csproj
@@ -10,9 +10,12 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
-		<PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-		<PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
-		<PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/Microsoft.Bot.Builder.TemplateManager/TemplateFixture.cs
+++ b/tests/Microsoft.Bot.Builder.TemplateManager/TemplateFixture.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Bot.Schema;
+
+namespace Microsoft.Bot.Builder.TemplateManager.Tests
+{
+    public class TemplateFixture : IDisposable
+    {
+        public TemplateFixture()
+        {
+            Templates1 = new LanguageTemplateDictionary
+            {
+                ["default"] = new TemplateIdMap
+                {
+                    { "stringTemplate", (context, data) => $"default: {data.name}" },
+                    { "activityTemplate", (context, data) => { return new Activity() { Type = ActivityTypes.Message, Text = $"(Activity)default: {data.name}" }; } },
+                    { "stringTemplate2", (context, data) => $"default: Yo {data.name}" },
+                },
+                ["en"] = new TemplateIdMap
+                {
+                    { "stringTemplate", (context, data) => $"en: {data.name}" },
+                    { "activityTemplate", (context, data) => { return new Activity() { Type = ActivityTypes.Message, Text = $"(Activity)en: {data.name}" }; } },
+                    { "stringTemplate2", (context, data) => $"en: Yo {data.name}" },
+                },
+                ["fr"] = new TemplateIdMap
+                {
+                    { "stringTemplate", (context, data) => $"fr: {data.name}" },
+                    { "activityTemplate", (context, data) => { return new Activity() { Type = ActivityTypes.Message, Text = $"(Activity)fr: {data.name}" }; } },
+                    { "stringTemplate2", (context, data) => $"fr: Yo {data.name}" },
+                },
+            };
+            Templates2 = new LanguageTemplateDictionary
+            {
+                ["en"] = new TemplateIdMap
+                {
+                    { "stringTemplate2", (context, data) => $"en: StringTemplate2 override {data.name}" },
+                },
+            };
+        }
+
+        public LanguageTemplateDictionary Templates1 { get; private set; }
+
+        public LanguageTemplateDictionary Templates2 { get; private set; }
+
+        public void Dispose()
+        {
+            Templates1.Clear();
+            Templates2.Clear();
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.TemplateManager/TemplateManagerTests.cs
+++ b/tests/Microsoft.Bot.Builder.TemplateManager/TemplateManagerTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Schema;
@@ -12,11 +11,11 @@ namespace Microsoft.Bot.Builder.TemplateManager.Tests
     [Trait("TestCategory", "Template")]
     public class TemplateManagerTests : IClassFixture<TemplateFixture>
     {
-        private readonly TemplateFixture templateFixture;
+        private readonly TemplateFixture _templateFixture;
 
         public TemplateManagerTests(TemplateFixture templateFixture)
         {
-            this.templateFixture = templateFixture;
+            _templateFixture = templateFixture;
         }
 
         [Fact]
@@ -25,13 +24,14 @@ namespace Microsoft.Bot.Builder.TemplateManager.Tests
             var templateManager = new TemplateManager();
             Assert.Empty(templateManager.List());
 
-            var templateEngine1 = new DictionaryRenderer(templateFixture.Templates1);
-            var templateEngine2 = new DictionaryRenderer(templateFixture.Templates2);
+            var templateEngine1 = new DictionaryRenderer(_templateFixture.Templates1);
+            var templateEngine2 = new DictionaryRenderer(_templateFixture.Templates2);
             templateManager.Register(templateEngine1);
             Assert.Single(templateManager.List());
 
+            // Test that only one has to be registered.
             templateManager.Register(templateEngine1);
-            Assert.Equal(1, templateManager.List().Count);
+            Assert.Single(templateManager.List()); 
 
             templateManager.Register(templateEngine2);
             Assert.Equal(2, templateManager.List().Count);
@@ -43,13 +43,14 @@ namespace Microsoft.Bot.Builder.TemplateManager.Tests
             var templateManager = new TemplateManager();
             Assert.Empty(templateManager.List());
 
-            var templateEngine1 = new DictionaryRenderer(templateFixture.Templates1);
-            var templateEngine2 = new DictionaryRenderer(templateFixture.Templates2);
+            var templateEngine1 = new DictionaryRenderer(_templateFixture.Templates1);
+            var templateEngine2 = new DictionaryRenderer(_templateFixture.Templates2);
             templateManager.Register(templateEngine1);
             Assert.Single(templateManager.List());
 
+            // Test that only one has to be registered.
             templateManager.Register(templateEngine1);
-            Assert.Equal(1, templateManager.List().Count);
+            Assert.Single(templateManager.List());
 
             templateManager.Register(templateEngine2);
             Assert.Equal(2, templateManager.List().Count);
@@ -58,7 +59,7 @@ namespace Microsoft.Bot.Builder.TemplateManager.Tests
         [Fact]
         public async Task DictionaryTemplateEngine_SimpleStringBinding()
         {
-            var engine = new DictionaryRenderer(templateFixture.Templates1);
+            var engine = new DictionaryRenderer(_templateFixture.Templates1);
             var result = await engine.RenderTemplate(null, "en", "stringTemplate", new { name = "joe" });
             Assert.Equal(typeof(string), result.GetType());
             Assert.Equal("en: joe", (string)result);
@@ -67,7 +68,7 @@ namespace Microsoft.Bot.Builder.TemplateManager.Tests
         [Fact]
         public async Task DictionaryTemplateEngine_SimpleActivityBinding()
         {
-            var engine = new DictionaryRenderer(templateFixture.Templates1);
+            var engine = new DictionaryRenderer(_templateFixture.Templates1);
             var result = await engine.RenderTemplate(null, "en", "activityTemplate", new { name = "joe" });
             Assert.Equal(typeof(Activity), result.GetType());
 
@@ -83,8 +84,8 @@ namespace Microsoft.Bot.Builder.TemplateManager.Tests
                 .Use(new TranscriptLoggerMiddleware(new TraceTranscriptLogger(traceActivity: false)));
 
             var templateManager = new TemplateManager()
-                .Register(new DictionaryRenderer(templateFixture.Templates1))
-                .Register(new DictionaryRenderer(templateFixture.Templates2));
+                .Register(new DictionaryRenderer(_templateFixture.Templates1))
+                .Register(new DictionaryRenderer(_templateFixture.Templates2));
 
             await new TestFlow(adapter, async (context, cancellationToken) =>
                 {
@@ -106,8 +107,8 @@ namespace Microsoft.Bot.Builder.TemplateManager.Tests
             {
                 Renderers =
                 {
-                    new DictionaryRenderer(templateFixture.Templates1),
-                    new DictionaryRenderer(templateFixture.Templates2)
+                    new DictionaryRenderer(_templateFixture.Templates1),
+                    new DictionaryRenderer(_templateFixture.Templates2)
                 }
             };
 
@@ -128,8 +129,8 @@ namespace Microsoft.Bot.Builder.TemplateManager.Tests
                                 .Use(new TranscriptLoggerMiddleware(new TraceTranscriptLogger(traceActivity: false)));
 
             var templateManager = new TemplateManager()
-                .Register(new DictionaryRenderer(templateFixture.Templates1))
-                .Register(new DictionaryRenderer(templateFixture.Templates2));
+                .Register(new DictionaryRenderer(_templateFixture.Templates1))
+                .Register(new DictionaryRenderer(_templateFixture.Templates2));
 
             await new TestFlow(adapter, async (context, cancellationToken) =>
             {
@@ -149,8 +150,8 @@ namespace Microsoft.Bot.Builder.TemplateManager.Tests
                                 .Use(new TranscriptLoggerMiddleware(new TraceTranscriptLogger(traceActivity: false)));
 
             var templateManager = new TemplateManager()
-                .Register(new DictionaryRenderer(templateFixture.Templates1))
-                .Register(new DictionaryRenderer(templateFixture.Templates2));
+                .Register(new DictionaryRenderer(_templateFixture.Templates1))
+                .Register(new DictionaryRenderer(_templateFixture.Templates2));
 
             await new TestFlow(adapter, async (context, cancellationToken) =>
                 {
@@ -170,8 +171,8 @@ namespace Microsoft.Bot.Builder.TemplateManager.Tests
                                 .Use(new TranscriptLoggerMiddleware(new TraceTranscriptLogger(traceActivity: false)));
 
             var templateManager = new TemplateManager()
-                .Register(new DictionaryRenderer(templateFixture.Templates1))
-                .Register(new DictionaryRenderer(templateFixture.Templates2));
+                .Register(new DictionaryRenderer(_templateFixture.Templates1))
+                .Register(new DictionaryRenderer(_templateFixture.Templates2));
 
             await new TestFlow(adapter, async (context, cancellationToken) =>
                 {
@@ -191,8 +192,8 @@ namespace Microsoft.Bot.Builder.TemplateManager.Tests
                                 .Use(new TranscriptLoggerMiddleware(new TraceTranscriptLogger(traceActivity: false)));
 
             var templateManager = new TemplateManager()
-                .Register(new DictionaryRenderer(templateFixture.Templates1))
-                .Register(new DictionaryRenderer(templateFixture.Templates2));
+                .Register(new DictionaryRenderer(_templateFixture.Templates1))
+                .Register(new DictionaryRenderer(_templateFixture.Templates2));
 
             await new TestFlow(adapter, async (context, cancellationToken) =>
                 {
@@ -202,52 +203,6 @@ namespace Microsoft.Bot.Builder.TemplateManager.Tests
                 .Send("stringTemplate").AssertReply("default: joe")
                 .Send("activityTemplate").AssertReply("(Activity)default: joe")
                 .StartTestAsync();
-        }
-    }
-
-#pragma warning disable SA1402
-    public class TemplateFixture : IDisposable
-    {
-        public TemplateFixture()
-        {
-            Templates1 = new LanguageTemplateDictionary
-            {
-                ["default"] = new TemplateIdMap
-                {
-                    { "stringTemplate", (context, data) => $"default: {data.name}" },
-                    { "activityTemplate", (context, data) => { return new Activity() { Type = ActivityTypes.Message, Text = $"(Activity)default: {data.name}" }; } },
-                    { "stringTemplate2", (context, data) => $"default: Yo {data.name}" },
-                },
-                ["en"] = new TemplateIdMap
-                {
-                    { "stringTemplate", (context, data) => $"en: {data.name}" },
-                    { "activityTemplate", (context, data) => { return new Activity() { Type = ActivityTypes.Message, Text = $"(Activity)en: {data.name}" }; } },
-                    { "stringTemplate2", (context, data) => $"en: Yo {data.name}" },
-                },
-                ["fr"] = new TemplateIdMap
-                {
-                    { "stringTemplate", (context, data) => $"fr: {data.name}" },
-                    { "activityTemplate", (context, data) => { return new Activity() { Type = ActivityTypes.Message, Text = $"(Activity)fr: {data.name}" }; } },
-                    { "stringTemplate2", (context, data) => $"fr: Yo {data.name}" },
-                },
-            };
-            Templates2 = new LanguageTemplateDictionary
-            {
-                ["en"] = new TemplateIdMap
-                {
-                    { "stringTemplate2", (context, data) => $"en: StringTemplate2 override {data.name}" },
-                },
-            };
-        }
-
-        public LanguageTemplateDictionary Templates1 { get; private set; }
-
-        public LanguageTemplateDictionary Templates2 { get; private set; }
-
-        public void Dispose()
-        {
-            Templates1 = null;
-            Templates2 = null;
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.TemplateManager/TemplateManagerTests.cs
+++ b/tests/Microsoft.Bot.Builder.TemplateManager/TemplateManagerTests.cs
@@ -1,28 +1,216 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Schema;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.TemplateManager.Tests
 {
-    [TestClass]
-    [TestCategory("Template")]
-    public class TemplateManagerTests
+    [Trait("TestCategory", "Template")]
+    public class TemplateManagerTests : IClassFixture<TemplateFixture>
     {
-        private static TestContext _testContext;
-        private static LanguageTemplateDictionary templates1;
-        private static LanguageTemplateDictionary templates2;
+        private readonly TemplateFixture templateFixture;
 
-        public TestContext TestContext { get; set; }
-
-        [AssemblyInitialize]
-        public static void SetupDictionaries(TestContext testContext)
+        public TemplateManagerTests(TemplateFixture templateFixture)
         {
-            _testContext = testContext;
-            templates1 = new LanguageTemplateDictionary
+            this.templateFixture = templateFixture;
+        }
+
+        [Fact]
+        public void TemplateManager_Registration()
+        {
+            var templateManager = new TemplateManager();
+            Assert.Empty(templateManager.List());
+
+            var templateEngine1 = new DictionaryRenderer(templateFixture.Templates1);
+            var templateEngine2 = new DictionaryRenderer(templateFixture.Templates2);
+            templateManager.Register(templateEngine1);
+            Assert.Single(templateManager.List());
+
+            templateManager.Register(templateEngine1);
+            Assert.Equal(1, templateManager.List().Count);
+
+            templateManager.Register(templateEngine2);
+            Assert.Equal(2, templateManager.List().Count);
+        }
+
+        [Fact]
+        public void TemplateManager_MultiTemplate()
+        {
+            var templateManager = new TemplateManager();
+            Assert.Empty(templateManager.List());
+
+            var templateEngine1 = new DictionaryRenderer(templateFixture.Templates1);
+            var templateEngine2 = new DictionaryRenderer(templateFixture.Templates2);
+            templateManager.Register(templateEngine1);
+            Assert.Single(templateManager.List());
+
+            templateManager.Register(templateEngine1);
+            Assert.Equal(1, templateManager.List().Count);
+
+            templateManager.Register(templateEngine2);
+            Assert.Equal(2, templateManager.List().Count);
+        }
+
+        [Fact]
+        public async Task DictionaryTemplateEngine_SimpleStringBinding()
+        {
+            var engine = new DictionaryRenderer(templateFixture.Templates1);
+            var result = await engine.RenderTemplate(null, "en", "stringTemplate", new { name = "joe" });
+            Assert.Equal(typeof(string), result.GetType());
+            Assert.Equal("en: joe", (string)result);
+        }
+
+        [Fact]
+        public async Task DictionaryTemplateEngine_SimpleActivityBinding()
+        {
+            var engine = new DictionaryRenderer(templateFixture.Templates1);
+            var result = await engine.RenderTemplate(null, "en", "activityTemplate", new { name = "joe" });
+            Assert.Equal(typeof(Activity), result.GetType());
+
+            var activity = result as Activity;
+            Assert.Equal(ActivityTypes.Message, activity.Type);
+            Assert.Equal("(Activity)en: joe", activity.Text);
+        }
+
+        [Fact]
+        public async Task TemplateManager_defaultlookup()
+        {
+            TestAdapter adapter = new TestAdapter(TestAdapter.CreateConversation(nameof(TemplateManager_defaultlookup)))
+                .Use(new TranscriptLoggerMiddleware(new TraceTranscriptLogger(traceActivity: false)));
+
+            var templateManager = new TemplateManager()
+                .Register(new DictionaryRenderer(templateFixture.Templates1))
+                .Register(new DictionaryRenderer(templateFixture.Templates2));
+
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+                {
+                    var templateId = context.Activity.AsMessageActivity().Text.Trim();
+                    await templateManager.ReplyWith(context, templateId, new { name = "joe" });
+                })
+                .Send("stringTemplate").AssertReply("default: joe")
+                .Send("activityTemplate").AssertReply("(Activity)default: joe")
+                .StartTestAsync();
+        }
+
+        [Fact]
+        public async Task TemplateManager_DataDefined()
+        {
+            TestAdapter adapter = new TestAdapter(TestAdapter.CreateConversation(nameof(TemplateManager_DataDefined)))
+                .Use(new TranscriptLoggerMiddleware(new TraceTranscriptLogger(traceActivity: false)));
+
+            var templateManager = new TemplateManager()
+            {
+                Renderers =
+                {
+                    new DictionaryRenderer(templateFixture.Templates1),
+                    new DictionaryRenderer(templateFixture.Templates2)
+                }
+            };
+
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                var templateId = context.Activity.AsMessageActivity().Text.Trim();
+                await templateManager.ReplyWith(context, templateId, new { name = "joe" });
+            })
+                .Send("stringTemplate").AssertReply("default: joe")
+                .Send("activityTemplate").AssertReply("(Activity)default: joe")
+                .StartTestAsync();
+        }
+
+        [Fact]
+        public async Task TemplateManager_enLookup()
+        {
+            TestAdapter adapter = new TestAdapter(TestAdapter.CreateConversation(nameof(TemplateManager_enLookup)))
+                                .Use(new TranscriptLoggerMiddleware(new TraceTranscriptLogger(traceActivity: false)));
+
+            var templateManager = new TemplateManager()
+                .Register(new DictionaryRenderer(templateFixture.Templates1))
+                .Register(new DictionaryRenderer(templateFixture.Templates2));
+
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                context.Activity.AsMessageActivity().Locale = "en"; // force to english
+                var templateId = context.Activity.AsMessageActivity().Text.Trim();
+                await templateManager.ReplyWith(context, templateId, new { name = "joe" });
+            })
+                .Send("stringTemplate").AssertReply("en: joe")
+                .Send("activityTemplate").AssertReply("(Activity)en: joe")
+                .StartTestAsync();
+        }
+
+        [Fact]
+        public async Task TemplateManager_frLookup()
+        {
+            TestAdapter adapter = new TestAdapter(TestAdapter.CreateConversation(nameof(TemplateManager_frLookup)))
+                                .Use(new TranscriptLoggerMiddleware(new TraceTranscriptLogger(traceActivity: false)));
+
+            var templateManager = new TemplateManager()
+                .Register(new DictionaryRenderer(templateFixture.Templates1))
+                .Register(new DictionaryRenderer(templateFixture.Templates2));
+
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+                {
+                    context.Activity.AsMessageActivity().Locale = "fr"; // force to french
+                    var templateId = context.Activity.AsMessageActivity().Text.Trim();
+                    await templateManager.ReplyWith(context, templateId, new { name = "joe" });
+                })
+                .Send("stringTemplate").AssertReply("fr: joe")
+                .Send("activityTemplate").AssertReply("(Activity)fr: joe")
+                .StartTestAsync();
+        }
+
+        [Fact]
+        public async Task TemplateManager_override()
+        {
+            TestAdapter adapter = new TestAdapter(TestAdapter.CreateConversation(nameof(TemplateManager_override)))
+                                .Use(new TranscriptLoggerMiddleware(new TraceTranscriptLogger(traceActivity: false)));
+
+            var templateManager = new TemplateManager()
+                .Register(new DictionaryRenderer(templateFixture.Templates1))
+                .Register(new DictionaryRenderer(templateFixture.Templates2));
+
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+                {
+                    context.Activity.AsMessageActivity().Locale = "fr"; // force to french
+                    var templateId = context.Activity.AsMessageActivity().Text.Trim();
+                    await templateManager.ReplyWith(context, templateId, new { name = "joe" });
+                })
+                .Send("stringTemplate2").AssertReply("fr: Yo joe")
+                .Send("activityTemplate").AssertReply("(Activity)fr: joe")
+                .StartTestAsync();
+        }
+
+        [Fact]
+        public async Task TemplateManager_useTemplateEngine()
+        {
+            TestAdapter adapter = new TestAdapter(TestAdapter.CreateConversation(nameof(TemplateManager_useTemplateEngine)))
+                                .Use(new TranscriptLoggerMiddleware(new TraceTranscriptLogger(traceActivity: false)));
+
+            var templateManager = new TemplateManager()
+                .Register(new DictionaryRenderer(templateFixture.Templates1))
+                .Register(new DictionaryRenderer(templateFixture.Templates2));
+
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+                {
+                    var templateId = context.Activity.AsMessageActivity().Text.Trim();
+                    await templateManager.ReplyWith(context, templateId, new { name = "joe" });
+                })
+                .Send("stringTemplate").AssertReply("default: joe")
+                .Send("activityTemplate").AssertReply("(Activity)default: joe")
+                .StartTestAsync();
+        }
+    }
+
+#pragma warning disable SA1402
+    public class TemplateFixture : IDisposable
+    {
+        public TemplateFixture()
+        {
+            Templates1 = new LanguageTemplateDictionary
             {
                 ["default"] = new TemplateIdMap
                 {
@@ -43,7 +231,7 @@ namespace Microsoft.Bot.Builder.TemplateManager.Tests
                     { "stringTemplate2", (context, data) => $"fr: Yo {data.name}" },
                 },
             };
-            templates2 = new LanguageTemplateDictionary
+            Templates2 = new LanguageTemplateDictionary
             {
                 ["en"] = new TemplateIdMap
                 {
@@ -52,186 +240,14 @@ namespace Microsoft.Bot.Builder.TemplateManager.Tests
             };
         }
 
-        [TestMethod]
-        public void TemplateManager_Registration()
+        public LanguageTemplateDictionary Templates1 { get; private set; }
+
+        public LanguageTemplateDictionary Templates2 { get; private set; }
+
+        public void Dispose()
         {
-            var templateManager = new TemplateManager();
-            Assert.AreEqual(templateManager.List().Count, 0, "nothing registered yet");
-            var templateEngine1 = new DictionaryRenderer(templates1);
-            var templateEngine2 = new DictionaryRenderer(templates2);
-            templateManager.Register(templateEngine1);
-            Assert.AreEqual(templateManager.List().Count, 1, "one registered");
-
-            templateManager.Register(templateEngine1);
-            Assert.AreEqual(templateManager.List().Count, 1, "only  one registered");
-
-            templateManager.Register(templateEngine2);
-            Assert.AreEqual(templateManager.List().Count, 2, "two registered");
-        }
-
-        [TestMethod]
-        public void TemplateManager_MultiTemplate()
-        {
-            var templateManager = new TemplateManager();
-            Assert.AreEqual(templateManager.List().Count, 0, "nothing registered yet");
-            var templateEngine1 = new DictionaryRenderer(templates1);
-            var templateEngine2 = new DictionaryRenderer(templates2);
-            templateManager.Register(templateEngine1);
-            Assert.AreEqual(templateManager.List().Count, 1, "one registered");
-
-            templateManager.Register(templateEngine1);
-            Assert.AreEqual(templateManager.List().Count, 1, "only  one registered");
-
-            templateManager.Register(templateEngine2);
-            Assert.AreEqual(templateManager.List().Count, 2, "two registered");
-        }
-
-        [TestMethod]
-        public async Task DictionaryTemplateEngine_SimpleStringBinding()
-        {
-            var engine = new DictionaryRenderer(templates1);
-            var result = await engine.RenderTemplate(null, "en", "stringTemplate", new { name = "joe" });
-            Assert.IsInstanceOfType(result, typeof(string));
-            Assert.AreEqual("en: joe", (string)result);
-        }
-
-        [TestMethod]
-        public async Task DictionaryTemplateEngine_SimpleActivityBinding()
-        {
-            var engine = new DictionaryRenderer(templates1);
-            var result = await engine.RenderTemplate(null, "en", "activityTemplate", new { name = "joe" });
-            Assert.IsInstanceOfType(result, typeof(Activity));
-            var activity = result as Activity;
-            Assert.AreEqual(ActivityTypes.Message, activity.Type);
-            Assert.AreEqual("(Activity)en: joe", activity.Text);
-        }
-
-        [TestMethod]
-        public async Task TemplateManager_defaultlookup()
-        {
-            TestAdapter adapter = new TestAdapter(TestAdapter.CreateConversation(TestContext.TestName))
-                .Use(new TranscriptLoggerMiddleware(new TraceTranscriptLogger(traceActivity: false)));
-
-            var templateManager = new TemplateManager()
-                .Register(new DictionaryRenderer(templates1))
-                .Register(new DictionaryRenderer(templates2));
-
-            await new TestFlow(adapter, async (context, cancellationToken) =>
-                {
-                    var templateId = context.Activity.AsMessageActivity().Text.Trim();
-                    await templateManager.ReplyWith(context, templateId, new { name = "joe" });
-                })
-                .Send("stringTemplate").AssertReply("default: joe")
-                .Send("activityTemplate").AssertReply("(Activity)default: joe")
-                .StartTestAsync();
-        }
-
-        [TestMethod]
-        public async Task TemplateManager_DataDefined()
-        {
-            TestAdapter adapter = new TestAdapter(TestAdapter.CreateConversation(TestContext.TestName))
-                .Use(new TranscriptLoggerMiddleware(new TraceTranscriptLogger(traceActivity: false)));
-
-            var templateManager = new TemplateManager()
-            {
-                Renderers =
-                {
-                    new DictionaryRenderer(templates1),
-                    new DictionaryRenderer(templates2)
-                }
-            };
-
-            await new TestFlow(adapter, async (context, cancellationToken) =>
-            {
-                var templateId = context.Activity.AsMessageActivity().Text.Trim();
-                await templateManager.ReplyWith(context, templateId, new { name = "joe" });
-            })
-                .Send("stringTemplate").AssertReply("default: joe")
-                .Send("activityTemplate").AssertReply("(Activity)default: joe")
-                .StartTestAsync();
-        }
-
-        [TestMethod]
-        public async Task TemplateManager_enLookup()
-        {
-            TestAdapter adapter = new TestAdapter(TestAdapter.CreateConversation(TestContext.TestName))
-                                .Use(new TranscriptLoggerMiddleware(new TraceTranscriptLogger(traceActivity: false)));
-
-            var templateManager = new TemplateManager()
-                .Register(new DictionaryRenderer(templates1))
-                .Register(new DictionaryRenderer(templates2));
-
-            await new TestFlow(adapter, async (context, cancellationToken) =>
-            {
-                context.Activity.AsMessageActivity().Locale = "en"; // force to english
-                var templateId = context.Activity.AsMessageActivity().Text.Trim();
-                await templateManager.ReplyWith(context, templateId, new { name = "joe" });
-            })
-                .Send("stringTemplate").AssertReply("en: joe")
-                .Send("activityTemplate").AssertReply("(Activity)en: joe")
-                .StartTestAsync();
-        }
-
-        [TestMethod]
-        public async Task TemplateManager_frLookup()
-        {
-            TestAdapter adapter = new TestAdapter(TestAdapter.CreateConversation(TestContext.TestName))
-                                .Use(new TranscriptLoggerMiddleware(new TraceTranscriptLogger(traceActivity: false)));
-
-            var templateManager = new TemplateManager()
-                .Register(new DictionaryRenderer(templates1))
-                .Register(new DictionaryRenderer(templates2));
-
-            await new TestFlow(adapter, async (context, cancellationToken) =>
-                {
-                    context.Activity.AsMessageActivity().Locale = "fr"; // force to french
-                    var templateId = context.Activity.AsMessageActivity().Text.Trim();
-                    await templateManager.ReplyWith(context, templateId, new { name = "joe" });
-                })
-                .Send("stringTemplate").AssertReply("fr: joe")
-                .Send("activityTemplate").AssertReply("(Activity)fr: joe")
-                .StartTestAsync();
-        }
-
-        [TestMethod]
-        public async Task TemplateManager_override()
-        {
-            TestAdapter adapter = new TestAdapter(TestAdapter.CreateConversation(TestContext.TestName))
-                                .Use(new TranscriptLoggerMiddleware(new TraceTranscriptLogger(traceActivity: false)));
-
-            var templateManager = new TemplateManager()
-                .Register(new DictionaryRenderer(templates1))
-                .Register(new DictionaryRenderer(templates2));
-
-            await new TestFlow(adapter, async (context, cancellationToken) =>
-                {
-                    context.Activity.AsMessageActivity().Locale = "fr"; // force to french
-                    var templateId = context.Activity.AsMessageActivity().Text.Trim();
-                    await templateManager.ReplyWith(context, templateId, new { name = "joe" });
-                })
-                .Send("stringTemplate2").AssertReply("fr: Yo joe")
-                .Send("activityTemplate").AssertReply("(Activity)fr: joe")
-                .StartTestAsync();
-        }
-
-        [TestMethod]
-        public async Task TemplateManager_useTemplateEngine()
-        {
-            TestAdapter adapter = new TestAdapter(TestAdapter.CreateConversation(TestContext.TestName))
-                                .Use(new TranscriptLoggerMiddleware(new TraceTranscriptLogger(traceActivity: false)));
-
-            var templateManager = new TemplateManager()
-                .Register(new DictionaryRenderer(templates1))
-                .Register(new DictionaryRenderer(templates2));
-
-            await new TestFlow(adapter, async (context, cancellationToken) =>
-                {
-                    var templateId = context.Activity.AsMessageActivity().Text.Trim();
-                    await templateManager.ReplyWith(context, templateId, new { name = "joe" });
-                })
-                .Send("stringTemplate").AssertReply("default: joe")
-                .Send("activityTemplate").AssertReply("(Activity)default: joe")
-                .StartTestAsync();
+            Templates1 = null;
+            Templates2 = null;
         }
     }
 }


### PR DESCRIPTION
Fixes # 4098

## Description
This PR migrates all [Microsoft.Bot.Builder.TemplateManager](https://github.com/microsoft/botbuilder-dotnet/tree/main/tests/Microsoft.Bot.Builder.TemplateManager) tests from **MSTest** to **xUnit**.

## Specific Changes
- Replaced `MSTest` packages with `xUnit` in the `.csproj`.
- Changed `[TestCategory("Template")]` to `[Trait("TestCategory", "Template")]`.
- Changed `Assert.AreEqual` to `Assert.Equal`.
- Changed `TestContext.TestName` to include directly the name of the test.
- Implemented `TemplateFixture` class to share data context among tests.

## Testing
In the following image there are the passing tests.
![image](https://user-images.githubusercontent.com/62260472/92032013-e04bad80-ed3f-11ea-97ad-305f3994ca33.png)