### PR TITLE
Migrate Microsoft.Bot.Streaming.Tests/Payloads folder to xUnit

### DIFF
--- a/tests/Microsoft.Bot.Streaming.Tests/Payloads/HeaderSerializerTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/Payloads/HeaderSerializerTests.cs
@@ -5,14 +5,13 @@ using System;
 using System.IO;
 using System.Text;
 using Microsoft.Bot.Streaming.Payloads;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Streaming.UnitTests.Payloads
 {
-    [TestClass]
     public class HeaderSerializerTests
     {
-        [TestMethod]
+        [Fact]
         public void HeaderSerializer_CanRoundTrip()
         {
             var header = new Header()
@@ -24,19 +23,19 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
             };
 
             var buffer = new byte[1024];
-            var offset = 0;
+            const int offset = 0;
 
             var length = HeaderSerializer.Serialize(header, buffer, offset);
 
             var result = HeaderSerializer.Deserialize(buffer, 0, length);
 
-            Assert.AreEqual(header.Type, result.Type);
-            Assert.AreEqual(header.PayloadLength, result.PayloadLength);
-            Assert.AreEqual(header.Id, result.Id);
-            Assert.AreEqual(header.End, result.End);
+            Assert.Equal(header.Type, result.Type);
+            Assert.Equal(header.PayloadLength, result.PayloadLength);
+            Assert.Equal(header.Id, result.Id);
+            Assert.Equal(header.End, result.End);
         }
 
-        [TestMethod]
+        [Fact]
         public void HeaderSerializer_SerializesToAscii()
         {
             var header = new Header()
@@ -48,146 +47,146 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
             };
 
             var buffer = new byte[1024];
-            var offset = 0;
+            const int offset = 0;
 
             var length = HeaderSerializer.Serialize(header, buffer, offset);
 
             var str = Encoding.ASCII.GetString(buffer, offset, length);
 
-            Assert.AreEqual("A.000168.68e999ca-a651-40f4-ad8f-3aaf781862b4.1\n", str);
+            Assert.Equal("A.000168.68e999ca-a651-40f4-ad8f-3aaf781862b4.1\n", str);
         }
 
-        [TestMethod]
+        [Fact]
         public void HeaderSerializer_DeserializesFromAscii()
         {
-            var header = "A.000168.68e999ca-a651-40f4-ad8f-3aaf781862b4.1\n";
+            const string header = "A.000168.68e999ca-a651-40f4-ad8f-3aaf781862b4.1\n";
             var bytes = Encoding.ASCII.GetBytes(header);
 
             var result = HeaderSerializer.Deserialize(bytes, 0, bytes.Length);
 
-            Assert.AreEqual('A', result.Type);
-            Assert.AreEqual(168, result.PayloadLength);
-            Assert.AreEqual(Guid.Parse("68e999ca-a651-40f4-ad8f-3aaf781862b4"), result.Id);
-            Assert.AreEqual(true, result.End);
+            Assert.Equal('A', result.Type);
+            Assert.Equal(168, result.PayloadLength);
+            Assert.Equal(Guid.Parse("68e999ca-a651-40f4-ad8f-3aaf781862b4"), result.Id);
+            Assert.True(result.End);
         }
 
-        [TestMethod]
+        [Fact]
         public void HeaderSerializer_DeserializeUnknownType()
         {
-            var header = "Z.000168.68e999ca-a651-40f4-ad8f-3aaf781862b4.1\n";
+            const string header = "Z.000168.68e999ca-a651-40f4-ad8f-3aaf781862b4.1\n";
             var bytes = Encoding.ASCII.GetBytes(header);
 
             var result = HeaderSerializer.Deserialize(bytes, 0, bytes.Length);
 
-            Assert.AreEqual('Z', result.Type);
-            Assert.AreEqual(168, result.PayloadLength);
+            Assert.Equal('Z', result.Type);
+            Assert.Equal(168, result.PayloadLength);
         }
 
-        [TestMethod]
+        [Fact]
         public void HeaderSerializer_Deserialize_LengthTooShort_Throws()
         {
-            var header = "A.000168.68e999ca-a651-40f4-ad8f-3aaf781862b4.1\n";
+            const string header = "A.000168.68e999ca-a651-40f4-ad8f-3aaf781862b4.1\n";
             var bytes = Encoding.ASCII.GetBytes(header);
 
-            Assert.ThrowsException<ArgumentException>(() =>
+            Assert.Throws<ArgumentException>(() =>
             {
-                var result = HeaderSerializer.Deserialize(bytes, 0, 5);
+                HeaderSerializer.Deserialize(bytes, 0, 5);
             });
         }
 
-        [TestMethod]
+        [Fact]
         public void HeaderSerializer_Deserialize_LengthTooLong_Throws()
         {
-            var header = "A.000168.68e999ca-a651-40f4-ad8f-3aaf781862b4.1\n";
+            const string header = "A.000168.68e999ca-a651-40f4-ad8f-3aaf781862b4.1\n";
             var bytes = Encoding.ASCII.GetBytes(header);
 
-            Assert.ThrowsException<ArgumentException>(() =>
+            Assert.Throws<ArgumentException>(() =>
             {
-                var result = HeaderSerializer.Deserialize(bytes, 0, 55);
+                HeaderSerializer.Deserialize(bytes, 0, 55);
             });
         }
 
-        [TestMethod]
+        [Fact]
         public void HeaderSerializer_Deserialize_BadTypeDelimeter_Throws()
         {
-            var header = "Ax000168.68e999ca-a651-40f4-ad8f-3aaf781862b4.1\n";
+            const string header = "Ax000168.68e999ca-a651-40f4-ad8f-3aaf781862b4.1\n";
             var bytes = Encoding.ASCII.GetBytes(header);
 
-            Assert.ThrowsException<InvalidDataException>(() =>
+            Assert.Throws<InvalidDataException>(() =>
             {
-                var result = HeaderSerializer.Deserialize(bytes, 0, bytes.Length);
+                HeaderSerializer.Deserialize(bytes, 0, bytes.Length);
             });
         }
 
-        [TestMethod]
+        [Fact]
         public void HeaderSerializer_Deserialize_BadLengthDelimeter_Throws()
         {
-            var header = "A.000168x68e999ca-a651-40f4-ad8f-3aaf781862b4.1\n";
+            const string header = "A.000168x68e999ca-a651-40f4-ad8f-3aaf781862b4.1\n";
             var bytes = Encoding.ASCII.GetBytes(header);
 
-            Assert.ThrowsException<InvalidDataException>(() =>
+            Assert.Throws<InvalidDataException>(() =>
             {
-                var result = HeaderSerializer.Deserialize(bytes, 0, bytes.Length);
+                HeaderSerializer.Deserialize(bytes, 0, bytes.Length);
             });
         }
 
-        [TestMethod]
+        [Fact]
         public void HeaderSerializer_Deserialize_BadIdDelimeter_Throws()
         {
-            var header = "A.000168.68e999ca-a651-40f4-ad8f-3aaf781862b4x1\n";
+            const string header = "A.000168.68e999ca-a651-40f4-ad8f-3aaf781862b4x1\n";
             var bytes = Encoding.ASCII.GetBytes(header);
 
-            Assert.ThrowsException<InvalidDataException>(() =>
+            Assert.Throws<InvalidDataException>(() =>
             {
-                var result = HeaderSerializer.Deserialize(bytes, 0, bytes.Length);
+                HeaderSerializer.Deserialize(bytes, 0, bytes.Length);
             });
         }
 
-        [TestMethod]
+        [Fact]
         public void HeaderSerializer_Deserialize_BadTerminator_Throws()
         {
-            var header = "A.000168.68e999ca-a651-40f4-ad8f-3aaf781862b4.1c";
+            const string header = "A.000168.68e999ca-a651-40f4-ad8f-3aaf781862b4.1c";
             var bytes = Encoding.ASCII.GetBytes(header);
 
-            Assert.ThrowsException<InvalidDataException>(() =>
+            Assert.Throws<InvalidDataException>(() =>
             {
-                var result = HeaderSerializer.Deserialize(bytes, 0, bytes.Length);
+                HeaderSerializer.Deserialize(bytes, 0, bytes.Length);
             });
         }
 
-        [TestMethod]
+        [Fact]
         public void HeaderSerializer_Deserialize_BadLength_Throws()
         {
-            var header = "A.00p168.68e999ca-a651-40f4-ad8f-3aaf781862b4.1\n";
+            const string header = "A.00p168.68e999ca-a651-40f4-ad8f-3aaf781862b4.1\n";
             var bytes = Encoding.ASCII.GetBytes(header);
 
-            Assert.ThrowsException<InvalidDataException>(() =>
+            Assert.Throws<InvalidDataException>(() =>
             {
-                var result = HeaderSerializer.Deserialize(bytes, 0, bytes.Length);
+                HeaderSerializer.Deserialize(bytes, 0, bytes.Length);
             });
         }
 
-        [TestMethod]
+        [Fact]
         public void HeaderSerializer_Deserialize_BadId_Throws()
         {
-            var header = "A.000168.68e9p9ca-a651-40f4-ad8f-3aaf781862b4.1\n";
+            const string header = "A.000168.68e9p9ca-a651-40f4-ad8f-3aaf781862b4.1\n";
             var bytes = Encoding.ASCII.GetBytes(header);
 
-            Assert.ThrowsException<InvalidDataException>(() =>
+            Assert.Throws<InvalidDataException>(() =>
             {
-                var result = HeaderSerializer.Deserialize(bytes, 0, bytes.Length);
+                HeaderSerializer.Deserialize(bytes, 0, bytes.Length);
             });
         }
 
-        [TestMethod]
+        [Fact]
         public void HeaderSerializer_Deserialize_BadEnd_Throws()
         {
-            var header = "A.000168.68e999ca-a651-40f4-ad8f-3aaf781862b4.z\n";
+            const string header = "A.000168.68e999ca-a651-40f4-ad8f-3aaf781862b4.z\n";
             var bytes = Encoding.ASCII.GetBytes(header);
 
-            Assert.ThrowsException<InvalidDataException>(() =>
+            Assert.Throws<InvalidDataException>(() =>
             {
-                var result = HeaderSerializer.Deserialize(bytes, 0, bytes.Length);
+                HeaderSerializer.Deserialize(bytes, 0, bytes.Length);
             });
         }
     }

--- a/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadAssemblerTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadAssemblerTests.cs
@@ -3,42 +3,41 @@
 
 using System;
 using Microsoft.Bot.Streaming.Payloads;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Streaming.UnitTests.Payloads
 {
-    [TestClass]
     public class PayloadAssemblerTests
     {
-        [TestMethod]
+        [Fact]
         public void PayloadAssembler_ctor_Id()
         {
             var id = Guid.NewGuid();
             var a = new PayloadStreamAssembler(new StreamManager(), id);
 
-            Assert.AreEqual(id, a.Id);
+            Assert.Equal(id, a.Id);
         }
 
-        [TestMethod]
+        [Fact]
         public void PayloadAssembler_ctor_End_false()
         {
             var id = Guid.NewGuid();
             var a = new PayloadStreamAssembler(new StreamManager(), id);
 
-            Assert.IsFalse(a.End);
+            Assert.False(a.End);
         }
 
-        [TestMethod]
+        [Fact]
         public void PayloadAssembler_GetStream()
         {
             var id = Guid.NewGuid();
             var a = new PayloadStreamAssembler(new StreamManager(), id);
             var s = a.GetPayloadAsStream();
 
-            Assert.IsNotNull(a);
+            Assert.NotNull(s);
         }
 
-        [TestMethod]
+        [Fact]
         public void PayloadAssembler_GetStream_DoesNotMakeNewEachTime()
         {
             var id = Guid.NewGuid();
@@ -46,23 +45,23 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
             var s = a.GetPayloadAsStream();
             var s2 = a.GetPayloadAsStream();
 
-            Assert.AreEqual(s, s2);
+            Assert.Equal(s, s2);
         }
 
-        [TestMethod]
+        [Fact]
         public void PayloadAssembler_OnReceive_SetsEnd()
         {
             var id = Guid.NewGuid();
             var a = new PayloadStreamAssembler(new StreamManager(), id);
 
-            var header = new Header() { End = true };
+            var header = new Header { End = true };
 
             a.OnReceive(header, new PayloadStream(a), 100);
 
-            Assert.IsTrue(a.End);
+            Assert.True(a.End);
         }
 
-        [TestMethod]
+        [Fact]
         public void PayloadAssembler_Close__DoesNotSetEnd()
         {
             var id = Guid.NewGuid();
@@ -70,7 +69,7 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
 
             a.Close();
 
-            Assert.IsFalse(a.End);
+            Assert.False(a.End);
         }
     }
 }

--- a/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadReceiverTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadReceiverTests.cs
@@ -5,14 +5,13 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Bot.Streaming.PayloadTransport;
 using Microsoft.Bot.Streaming.UnitTests.Mocks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Streaming.UnitTests.Payloads
 {
-    [TestClass]
     public class PayloadReceiverTests
     {
-        [TestMethod]
+        [Fact]
         public async Task PayloadReceiver_ReceivePacketsAsync_ReceiveShortHeader_Throws()
         {
             var disconnectEvent = new TaskCompletionSource<string>();
@@ -26,7 +25,7 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
             var receiver = new PayloadReceiver();
             receiver.Disconnected += (sender, e) =>
             {
-                Assert.AreEqual("Stream closed while reading header bytes", e.Reason);
+                Assert.Equal("Stream closed while reading header bytes", e.Reason);
                 disconnectEvent.SetResult("done");
             };
 
@@ -34,7 +33,7 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
 
             var result = await disconnectEvent.Task;
 
-            Assert.AreEqual("done", result);
+            Assert.Equal("done", result);
         }
     }
 }

--- a/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadSenderTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadSenderTests.cs
@@ -9,14 +9,13 @@ using System.Threading.Tasks;
 using Microsoft.Bot.Streaming.Payloads;
 using Microsoft.Bot.Streaming.PayloadTransport;
 using Microsoft.Bot.Streaming.UnitTests.Mocks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Streaming.UnitTests.Payloads
 {
-    [TestClass]
     public class PayloadSenderTests
     {
-        [TestMethod]
+        [Fact]
         public async Task PayloadSender_WhenLengthNotSet_Sends()
         {
             var sender = new PayloadSender();
@@ -32,22 +31,22 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
             };
 
             var stream = new MemoryStream(new byte[100]);
-            TaskCompletionSource<string> done = new TaskCompletionSource<string>();
+            var done = new TaskCompletionSource<string>();
 
             sender.SendPayload(header, stream, false, (Header sentHeader) =>
             {
-                Assert.AreEqual(100, sentHeader.PayloadLength);
-                Assert.IsFalse(sentHeader.End);
+                Assert.Equal(100, sentHeader.PayloadLength);
+                Assert.False(sentHeader.End);
                 done.SetResult("done");
                 return Task.CompletedTask;
             });
 
             await done.Task;
 
-            Assert.AreEqual(2, transport.Buffers.Count);
+            Assert.Equal(2, transport.Buffers.Count);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task PayloadSender_WhenLengthNotSet_AndNoData_SendsZeroLengthEnd()
         {
             var sender = new PayloadSender();
@@ -64,22 +63,22 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
 
             var stream = new MemoryStream(new byte[100]);
             stream.Position = 100;
-            TaskCompletionSource<string> done = new TaskCompletionSource<string>();
+            var done = new TaskCompletionSource<string>();
 
             sender.SendPayload(header, stream, false, (Header sentHeader) =>
             {
-                Assert.AreEqual(0, sentHeader.PayloadLength);
-                Assert.IsTrue(sentHeader.End);
+                Assert.Equal(0, sentHeader.PayloadLength);
+                Assert.True(sentHeader.End);
                 done.SetResult("done");
                 return Task.CompletedTask;
             });
 
             await done.Task;
 
-            Assert.AreEqual(1, transport.Buffers.Count);
+            Assert.Single(transport.Buffers);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task PayloadSender_WhenLengthSet_Sends()
         {
             var sender = new PayloadSender();
@@ -95,23 +94,23 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
             };
 
             var stream = new MemoryStream(new byte[100]);
-            TaskCompletionSource<string> done = new TaskCompletionSource<string>();
+            var done = new TaskCompletionSource<string>();
 
             sender.SendPayload(header, stream, true, (Header sentHeader) =>
             {
-                Assert.AreEqual(55, sentHeader.PayloadLength);
-                Assert.IsFalse(sentHeader.End);
+                Assert.Equal(55, sentHeader.PayloadLength);
+                Assert.False(sentHeader.End);
                 done.SetResult("done");
                 return Task.CompletedTask;
             });
 
             await done.Task;
 
-            Assert.AreEqual(2, transport.Buffers.Count);
-            Assert.AreEqual(55, stream.Position);
+            Assert.Equal(2, transport.Buffers.Count);
+            Assert.Equal(55, stream.Position);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task HttpContentStreamDisassembler_StringContent_SendsAsFixedLength()
         {
             var sender = new PayloadSender();
@@ -123,16 +122,14 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
                 Content = new StringContent("blah blah blah", Encoding.ASCII),
             };
 
-            TaskCompletionSource<string> done = new TaskCompletionSource<string>();
-
             var disassembler = new ResponseMessageStreamDisassembler(sender, content);
 
             await disassembler.DisassembleAsync();
 
-            Assert.AreEqual(2, transport.Buffers.Count);
+            Assert.Equal(2, transport.Buffers.Count);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task HttpContentStreamDisassembler_ObjectContent_SendsAsFixedLength()
         {
             var sender = new PayloadSender();
@@ -148,10 +145,10 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
 
             await disassembler.DisassembleAsync();
 
-            Assert.AreEqual(2, transport.Buffers.Count);
+            Assert.Equal(2, transport.Buffers.Count);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task HttpContentStreamDisassembler_StreamContent_SendsAsVariableLength()
         {
             var sender = new PayloadSender();
@@ -171,10 +168,10 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
 
             await disassembler.DisassembleAsync();
 
-            Assert.AreEqual(3, transport.Buffers.Count);
+            Assert.Equal(3, transport.Buffers.Count);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task RequestDisassembler_SendsAsFixedLength()
         {
             var sender = new PayloadSender();
@@ -185,10 +182,10 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
 
             await disassembler.DisassembleAsync();
 
-            Assert.AreEqual(2, transport.Buffers.Count);
+            Assert.Equal(2, transport.Buffers.Count);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ResponseDisassembler_SendsAsFixedLength()
         {
             var sender = new PayloadSender();
@@ -199,7 +196,7 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
 
             await disassembler.DisassembleAsync();
 
-            Assert.AreEqual(2, transport.Buffers.Count);
+            Assert.Equal(2, transport.Buffers.Count);
         }
     }
 }

--- a/tests/Microsoft.Bot.Streaming.Tests/Payloads/StreamManagerTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/Payloads/StreamManagerTests.cs
@@ -3,119 +3,119 @@
 
 using System;
 using Microsoft.Bot.Streaming.Payloads;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
+using Xunit.Sdk;
 
 namespace Microsoft.Bot.Streaming.UnitTests.Payloads
 {
-    [TestClass]
     public class StreamManagerTests
     {
-        [TestMethod]
+        [Fact]
         public void StreamManager_ctor_nullCancelOk()
         {
             var m = new StreamManager(null);
-            Assert.IsNotNull(m);
+            Assert.NotNull(m);
         }
 
-        [TestMethod]
+        [Fact]
         public void StreamManager_GetPayloadAssembler_NotExists_Ok()
         {
-            var m = new StreamManager((c) => { });
+            var m = new StreamManager(c => { });
             var id = Guid.NewGuid();
 
             var a = m.GetPayloadAssembler(id);
 
-            Assert.IsNotNull(a);
-            Assert.AreEqual(id, a.Id);
+            Assert.NotNull(a);
+            Assert.Equal(id, a.Id);
         }
 
-        [TestMethod]
+        [Fact]
         public void StreamManager_GetPayloadAssembler_Exists_Ok()
         {
-            var m = new StreamManager((c) => { });
+            var m = new StreamManager(c => { });
             var id = Guid.NewGuid();
 
             var a = m.GetPayloadAssembler(id);
             var a2 = m.GetPayloadAssembler(id);
 
-            Assert.AreEqual(a, a2);
+            Assert.Equal(a, a2);
         }
 
-        [TestMethod]
+        [Fact]
         public void StreamManager_GetPayloadStream_NotExists_Ok()
         {
-            var m = new StreamManager((c) => { });
+            var m = new StreamManager(c => { });
             var id = Guid.NewGuid();
 
-            var a = m.GetPayloadStream(new Header() { Id = id });
+            var a = m.GetPayloadStream(new Header { Id = id });
 
-            Assert.IsNotNull(a);
+            Assert.NotNull(a);
         }
 
-        [TestMethod]
+        [Fact]
         public void StreamManager_GetPayloadAStream_Exists_Ok()
         {
-            var m = new StreamManager((c) => { });
+            var m = new StreamManager(c => { });
             var id = Guid.NewGuid();
 
-            var a = m.GetPayloadStream(new Header() { Id = id });
-            var a2 = m.GetPayloadStream(new Header() { Id = id });
+            var a = m.GetPayloadStream(new Header { Id = id });
+            var a2 = m.GetPayloadStream(new Header { Id = id });
 
-            Assert.AreEqual(a, a2);
+            Assert.Equal(a, a2);
         }
 
-        [TestMethod]
+        [Fact]
         public void StreamManager_GetPayloadAStream__StreamsMatch()
         {
-            var m = new StreamManager((c) => { });
+            var m = new StreamManager(c => { });
             var id = Guid.NewGuid();
 
             var a = m.GetPayloadAssembler(id);
-            var s = m.GetPayloadStream(new Header() { Id = id });
+            var s = m.GetPayloadStream(new Header { Id = id });
 
-            Assert.AreEqual(a.GetPayloadAsStream(), s);
+            Assert.Equal(a.GetPayloadAsStream(), s);
         }
 
-        [TestMethod]
+        [Fact]
         public void StreamManager_OnReceive_NotExists_NoOp()
         {
-            var m = new StreamManager((c) => { });
+            var m = new StreamManager(c => { });
             var id = Guid.NewGuid();
 
-            m.OnReceive(new Header() { Id = id }, null, 100);
+            m.OnReceive(new Header { Id = id }, null, 100);
         }
 
-        [TestMethod]
+        [Fact]
         public void StreamManager_OnReceive_Exists()
         {
-            var m = new StreamManager((c) => { });
+            var m = new StreamManager(c => { });
             var id = Guid.NewGuid();
 
             var a = m.GetPayloadAssembler(id);
             var s = a.GetPayloadAsStream();
 
-            m.OnReceive(new Header() { Id = id, End = true }, s, 100);
+            m.OnReceive(new Header { Id = id, End = true }, s, 100);
 
-            Assert.IsTrue(a.End);
+            Assert.True(a.End);
         }
 
-        [TestMethod]
+        [Fact]
         public void StreamManager_CloseStream_NotExists_NoOp()
         {
-            var m = new StreamManager((c) =>
+            var m = new StreamManager(c =>
             {
-                Assert.Fail();
+                throw new XunitException("Should have failed");
             });
             var id = Guid.NewGuid();
 
             m.CloseStream(id);
         }
 
-        [TestMethod]
+        [Fact]
         public void StreamManager_CloseStream_NotEnd_Closed()
         {
-            bool closed = false;
-            var m = new StreamManager((c) =>
+            var closed = false;
+            var m = new StreamManager(c =>
             {
                 closed = true;
             });
@@ -125,14 +125,14 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
 
             m.CloseStream(id);
 
-            Assert.IsTrue(closed);
+            Assert.True(closed);
         }
 
-        [TestMethod]
+        [Fact]
         public void StreamManager_CloseStream_End_NoOp()
         {
-            bool closed = false;
-            var m = new StreamManager((c) =>
+            var closed = false;
+            var m = new StreamManager(c =>
             {
                 closed = true;
             });
@@ -142,11 +142,11 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
             var s = a.GetPayloadAsStream();
 
             // set it as ended
-            a.OnReceive(new Header() { End = true }, s, 1);
+            a.OnReceive(new Header { End = true }, s, 1);
 
             m.CloseStream(id);
 
-            Assert.IsFalse(closed);
+            Assert.False(closed);
         }
     }
 }


### PR DESCRIPTION
Addresses # 4106

## Description
This PR migrates all [Microsoft.Bot.Streaming.Tests/Payloads](https://github.com/microsoft/botbuilder-dotnet/tree/main/tests/Microsoft.Bot.Streaming.Tests/Payloads) tests from **MSTest** to **xUnit**.

## Detailed Changes
- Replaced `[TestMethod]` with `[Fact]`.
- Changed Asserts.
- Replaced `Assert.Fail()` with `throw new XunitException("Should have failed")`.
- Used constants instead of variables where applicable.
- Used `var` instead of the specific type.
- Removed redundant parenthesis.

## Testing
The following image shows the tests passing after the changes.
![image](https://user-images.githubusercontent.com/44245136/92144884-c1a3f000-eded-11ea-8ae4-7df169b01f91.png)
