### PR TITLE
Migrate Microsoft.Bot.ApplicationInsights.WebApi.Tests to xUnit

### DIFF
--- a/tests/integration/Microsoft.Bot.ApplicationInsights.WebApi.Tests/Microsoft.Bot.ApplicationInsights.WebApi.Tests.csproj
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.WebApi.Tests/Microsoft.Bot.ApplicationInsights.WebApi.Tests.csproj
@@ -75,7 +75,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\libraries\integration\Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi\Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi.csproj">
-      <Project>{e0223463-97c6-4108-b5a9-afba16b9d5cc}</Project>
+      <Project>{400bb78f-afdc-4b1c-ad85-be159b576fce}</Project>
       <Name>Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\..\libraries\Microsoft.Bot.Builder.ApplicationInsights\Microsoft.Bot.Builder.ApplicationInsights.csproj">

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.WebApi.Tests/Microsoft.Bot.ApplicationInsights.WebApi.Tests.csproj
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.WebApi.Tests/Microsoft.Bot.ApplicationInsights.WebApi.Tests.csproj
@@ -75,7 +75,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\libraries\integration\Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi\Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi.csproj">
-      <Project>{400bb78f-afdc-4b1c-ad85-be159b576fce}</Project>
+      <Project>{e0223463-97c6-4108-b5a9-afba16b9d5cc}</Project>
       <Name>Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\..\libraries\Microsoft.Bot.Builder.ApplicationInsights\Microsoft.Bot.Builder.ApplicationInsights.csproj">
@@ -109,11 +109,13 @@
     <PackageReference Include="Moq">
       <Version>4.13.1</Version>
     </PackageReference>
-    <PackageReference Include="MSTest.TestAdapter">
-      <Version>1.4.0</Version>
+    <PackageReference Include="xunit">
+      <Version>2.4.1</Version>
     </PackageReference>
-    <PackageReference Include="MSTest.TestFramework">
-      <Version>1.4.0</Version>
+    <PackageReference Include="xunit.runner.visualstudio">
+      <Version>2.4.2</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.WebApi.Tests/ServiceResolutionTests.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.WebApi.Tests/ServiceResolutionTests.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Integration.ApplicationInsights.WebApi.Tests
 {
-        [TestClass]
-        [TestCategory("ApplicationInsights")]
-        public class ServiceResolutionTests
+    [Trait("TestCategory", "ApplicationInsights")]
+    public class ServiceResolutionTests
         {
             /// <summary>
             /// Initializes a new instance of the <see cref="ServiceResolutionTests"/> class.

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.WebApi.Tests/TelemetryInitializerTests.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.WebApi.Tests/TelemetryInitializerTests.cs
@@ -13,18 +13,17 @@ using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi;
 using Microsoft.Bot.Schema;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Newtonsoft.Json.Linq;
+using Xunit;
 
 namespace Microsoft.Bot.ApplicationInsights.WebApi.Tests
 {
-    [TestClass]
-    [TestCategory("ApplicationInsights")]
+    [Trait("TestCategory", "ApplicationInsights")]
     public class TelemetryInitializerTests
     {
-        [TestMethod]
-        public void VerifyAllTelemtryPropoerties()
+        [Fact]
+        public void VerifyAllTelemetryProperties()
         {
             var configuration = new TelemetryConfiguration();
             var sentItems = new List<ITelemetry>();
@@ -59,21 +58,21 @@ namespace Microsoft.Bot.ApplicationInsights.WebApi.Tests
 
             telemetryClient.TrackEvent("test", new Dictionary<string, string>() { { "hello", "value" } }, new Dictionary<string, double>() { { "metric", 0.6 } });
 
-            Assert.IsTrue(sentItems.Count == 1);
+            Assert.Single(sentItems);
             var telem = sentItems[0] as EventTelemetry;
-            Assert.IsTrue(telem != null);
-            Assert.IsTrue(telem.Properties["activityId"] == activityID);
-            Assert.IsTrue(telem.Properties["activityType"] == "message");
-            Assert.IsTrue(telem.Properties["channelId"] == "CHANNELID");
-            Assert.IsTrue(telem.Properties["conversationId"] == conversationID);
-            Assert.IsTrue(telem.Context.Session.Id == sessionId);
-            Assert.IsTrue(telem.Context.User.Id == channelID + fromID);
-            Assert.IsTrue(telem.Properties["hello"] == "value");
-            Assert.IsTrue(telem.Metrics["metric"] == 0.6);
+            Assert.NotNull(telem);
+            Assert.Equal(activityID, telem.Properties["activityId"]);
+            Assert.Equal("message", telem.Properties["activityType"]);
+            Assert.Equal("CHANNELID", telem.Properties["channelId"]);
+            Assert.Equal(conversationID, telem.Properties["conversationId"]);
+            Assert.Equal(sessionId, telem.Context.Session.Id);
+            Assert.Equal(channelID + fromID, telem.Context.User.Id);
+            Assert.Equal("value", telem.Properties["hello"]);
+            Assert.Equal(0.6, telem.Metrics["metric"]);
         }
 
-        [TestMethod]
-        public void VerifyTracePropoerties()
+        [Fact]
+        public void VerifyTraceProperties()
         {
             var configuration = new TelemetryConfiguration();
             var sentItems = new List<ITelemetry>();
@@ -108,19 +107,19 @@ namespace Microsoft.Bot.ApplicationInsights.WebApi.Tests
 
             telemetryClient.TrackTrace("test");
 
-            Assert.IsTrue(sentItems.Count == 1);
+            Assert.Single(sentItems);
             var telem = sentItems[0] as TraceTelemetry;
-            Assert.IsTrue(telem != null);
-            Assert.IsTrue(telem.Properties["activityId"] == activityID);
-            Assert.IsTrue(telem.Properties["activityType"] == "message");
-            Assert.IsTrue(telem.Properties["channelId"] == "CHANNELID");
-            Assert.IsTrue(telem.Properties["conversationId"] == conversationID);
-            Assert.IsTrue(telem.Context.Session.Id == sessionId);
-            Assert.IsTrue(telem.Context.User.Id == channelID + fromID);
+            Assert.NotNull(telem);
+            Assert.Equal(activityID, telem.Properties["activityId"]);
+            Assert.Equal("message", telem.Properties["activityType"]);
+            Assert.Equal("CHANNELID", telem.Properties["channelId"]);
+            Assert.Equal(conversationID, telem.Properties["conversationId"]);
+            Assert.Equal(sessionId, telem.Context.Session.Id);
+            Assert.Equal(channelID + fromID, telem.Context.User.Id);
         }
 
-        [TestMethod]
-        public void VerifyRequestPropoerties()
+        [Fact]
+        public void VerifyRequestProperties()
         {
             var configuration = new TelemetryConfiguration();
             var sentItems = new List<ITelemetry>();
@@ -155,18 +154,18 @@ namespace Microsoft.Bot.ApplicationInsights.WebApi.Tests
 
             telemetryClient.TrackRequest("Foo", DateTimeOffset.Now, TimeSpan.FromSeconds(1.0), "response", true);
 
-            Assert.IsTrue(sentItems.Count == 1);
+            Assert.Single(sentItems);
             var telem = sentItems[0] as RequestTelemetry;
-            Assert.IsTrue(telem != null);
-            Assert.IsTrue(telem.Properties["activityId"] == activityID);
-            Assert.IsTrue(telem.Properties["activityType"] == "message");
-            Assert.IsTrue(telem.Properties["channelId"] == "CHANNELID");
-            Assert.IsTrue(telem.Properties["conversationId"] == conversationID);
-            Assert.IsTrue(telem.Context.Session.Id == sessionId);
-            Assert.IsTrue(telem.Context.User.Id == channelID + fromID);
+            Assert.NotNull(telem);
+            Assert.Equal(activityID, telem.Properties["activityId"]);
+            Assert.Equal("message", telem.Properties["activityType"]);
+            Assert.Equal("CHANNELID", telem.Properties["channelId"]);
+            Assert.Equal(conversationID, telem.Properties["conversationId"]);
+            Assert.Equal(sessionId, telem.Context.Session.Id);
+            Assert.Equal(channelID + fromID, telem.Context.User.Id);
         }
 
-        [TestMethod]
+        [Fact]
         public void VerifyDependencyProperties()
         {
             var configuration = new TelemetryConfiguration();
@@ -202,18 +201,18 @@ namespace Microsoft.Bot.ApplicationInsights.WebApi.Tests
 
             telemetryClient.TrackDependency("Foo", "Bar", "Data", DateTimeOffset.Now, TimeSpan.FromSeconds(1.0), true);
 
-            Assert.IsTrue(sentItems.Count == 1);
+            Assert.Single(sentItems);
             var telem = sentItems[0] as DependencyTelemetry;
-            Assert.IsTrue(telem != null);
-            Assert.IsTrue(telem.Properties["activityId"] == activityID);
-            Assert.IsTrue(telem.Properties["activityType"] == "message");
-            Assert.IsTrue(telem.Properties["channelId"] == "CHANNELID");
-            Assert.IsTrue(telem.Properties["conversationId"] == conversationID);
-            Assert.IsTrue(telem.Context.Session.Id == sessionId);
-            Assert.IsTrue(telem.Context.User.Id == channelID + fromID);
+            Assert.NotNull(telem);
+            Assert.Equal(activityID, telem.Properties["activityId"]);
+            Assert.Equal("message", telem.Properties["activityType"]);
+            Assert.Equal("CHANNELID", telem.Properties["channelId"]);
+            Assert.Equal(conversationID, telem.Properties["conversationId"]);
+            Assert.Equal(sessionId, telem.Context.Session.Id);
+            Assert.Equal(channelID + fromID, telem.Context.User.Id);
         }
 
-        [TestMethod]
+        [Fact]
         public void InvalidMessage_NoConversation()
         {
             var configuration = new TelemetryConfiguration();
@@ -246,16 +245,16 @@ namespace Microsoft.Bot.ApplicationInsights.WebApi.Tests
 
             telemetryClient.TrackEvent("test", new Dictionary<string, string>() { { "hello", "value" } }, new Dictionary<string, double>() { { "metric", 0.6 } });
 
-            Assert.IsTrue(sentItems.Count == 1);
+            Assert.Single(sentItems);
             var telem = sentItems[0] as EventTelemetry;
             var properties = (ISupportProperties)telem;
-            Assert.IsTrue(telem != null);
-            Assert.IsTrue(properties.Properties["activityId"] == activityID);
-            Assert.IsTrue(properties.Properties["activityType"] == "message");
-            Assert.IsTrue(telem.Properties["channelId"] == "CHANNELID");
-            Assert.IsTrue(telem.Context.User.Id == channelID + fromID);
-            Assert.IsTrue(properties.Properties["hello"] == "value");
-            Assert.IsTrue(telem.Metrics["metric"] == 0.6);
+            Assert.NotNull(telem);
+            Assert.Equal(activityID, properties.Properties["activityId"]);
+            Assert.Equal("message", properties.Properties["activityType"]);
+            Assert.Equal("CHANNELID", telem.Properties["channelId"]);
+            Assert.Equal(channelID + fromID, telem.Context.User.Id);
+            Assert.Equal("value", properties.Properties["hello"]);
+            Assert.Equal(0.6, telem.Metrics["metric"]);
         }
 
         private string GetHashedConversationId(string conversationID)

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi.Tests/Microsoft.Bot.Builder.Integration.AspNet.WebApi.Tests.csproj
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi.Tests/Microsoft.Bot.Builder.Integration.AspNet.WebApi.Tests.csproj
@@ -108,12 +108,6 @@
     <PackageReference Include="Moq">
       <Version>4.13.1</Version>
     </PackageReference>
-    <PackageReference Include="MSTest.TestAdapter">
-      <Version>1.4.0</Version>
-    </PackageReference>
-    <PackageReference Include="MSTest.TestFramework">
-      <Version>1.4.0</Version>
-    </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>
     </PackageReference>


### PR DESCRIPTION
Fixes # 4108

## Description
This PR migrates all [Microsoft.Bot.ApplicationInsights.WebApi](https://github.com/microsoft/botbuilder-dotnet/tree/main/tests/integration/Microsoft.Bot.ApplicationInsights.WebApi.Tests) tests from **MSTest** to **xUnit**.

## Specific Changes
- Replaced `MSTest` packages with `xUnit` in the `.csproj`.
- Changed `[TestCategory]` to `[Trait]`.
- Changed `[TestMethod]` to `[Fact]`.
- Improved tests Assertions.

## Testing
In the following image there are the passing tests.
![image](https://user-images.githubusercontent.com/62260472/92155283-80b3d780-edfd-11ea-9a26-972cae5baa84.png)