### PR TITLE
Migrate Microsoft.Bot.Streaming.Tests project to xUnit

### DIFF
--- a/tests/Microsoft.Bot.Streaming.Tests/CancelDisassemblerTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/CancelDisassemblerTests.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Bot.Streaming.Payloads;
 using Xunit;
@@ -18,7 +16,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
         {
             var sender = new MockPayloadSender();
             var id = Guid.NewGuid();
-            char type = 'X';
+            const char type = 'X';
 
             var disassembler = new CancelDisassembler(sender, id, type);
 

--- a/tests/Microsoft.Bot.Streaming.Tests/ConcurrentStreamTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/ConcurrentStreamTests.cs
@@ -7,50 +7,49 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Streaming.Payloads;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Streaming.UnitTests
 {
-    [TestClass]
     public class ConcurrentStreamTests
     {
-        [TestMethod]
+        [Fact]
         public async Task ConsumeInSmallerChunks()
         {
             await ProducerConsumerMultithreadedTest(1024, 100, 1024, 50);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ConsumeInLargerChunks()
         {
             await ProducerConsumerMultithreadedTest(1024, 50, 1024, 100);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ConsumeLessThanProduced()
         {
             await ProducerConsumerMultithreadedTest(1024, 50, 500, 100);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ConsumeInOneChunks()
         {
             await ProducerConsumerMultithreadedTest(1024, 100, 1024, 1);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ProduceInOneChunks()
         {
             await ProducerConsumerMultithreadedTest(1024, 1, 1024, 50);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task CanReadLess()
         {
             var producerBuffer = new byte[100];
             var consumerBuffer = new byte[producerBuffer.Length];
-            int expectedReadCount = 50;
-            int readCount = 0;
+            const int expectedReadCount = 50;
+            var readCount = 0;
 
             var random = new Random();
             random.NextBytes(producerBuffer);
@@ -62,17 +61,17 @@ namespace Microsoft.Bot.Streaming.UnitTests
                 readCount = await stream.ReadAsync(consumerBuffer, 0, expectedReadCount);
             }
 
-            Assert.AreEqual(expectedReadCount, readCount);
-            CollectionAssert.AreEquivalent(producerBuffer.Take(expectedReadCount).ToArray(), consumerBuffer.Take(expectedReadCount).ToArray());
+            Assert.Equal(expectedReadCount, readCount);
+            Assert.Equal(producerBuffer.Take(expectedReadCount).ToArray(), consumerBuffer.Take(expectedReadCount).ToArray());
         }
 
-        [TestMethod]
+        [Fact]
         public async Task CanReadExact()
         {
             var producerBuffer = new byte[100];
             var consumerBuffer = new byte[producerBuffer.Length];
-            int expectedReadCount = producerBuffer.Length;
-            int readCount = 0;
+            var expectedReadCount = producerBuffer.Length;
+            var readCount = 0;
 
             var random = new Random();
             random.NextBytes(producerBuffer);
@@ -84,17 +83,17 @@ namespace Microsoft.Bot.Streaming.UnitTests
                 readCount = await stream.ReadAsync(consumerBuffer, 0, expectedReadCount);
             }
 
-            Assert.AreEqual(expectedReadCount, readCount);
-            CollectionAssert.AreEquivalent(producerBuffer.Take(expectedReadCount).ToArray(), consumerBuffer.Take(expectedReadCount).ToArray());
+            Assert.Equal(expectedReadCount, readCount);
+            Assert.Equal(producerBuffer.Take(expectedReadCount).ToArray(), consumerBuffer.Take(expectedReadCount).ToArray());
         }
 
-        [TestMethod]
+        [Fact]
         public async Task CanReadMore_GetLess()
         {
-            int expectedReadCount = 200;
+            const int expectedReadCount = 200;
             var producerBuffer = new byte[100];
             var consumerBuffer = new byte[expectedReadCount];
-            int readCount = 0;
+            var readCount = 0;
 
             var random = new Random();
             random.NextBytes(producerBuffer);
@@ -106,18 +105,18 @@ namespace Microsoft.Bot.Streaming.UnitTests
                 readCount = await stream.ReadAsync(consumerBuffer, 0, expectedReadCount);
             }
 
-            Assert.AreEqual(100, readCount);
-            CollectionAssert.AreEquivalent(producerBuffer.Take(readCount).ToArray(), consumerBuffer.Take(readCount).ToArray());
+            Assert.Equal(100, readCount);
+            Assert.Equal(producerBuffer.Take(readCount).ToArray(), consumerBuffer.Take(readCount).ToArray());
         }
 
-        [TestMethod]
+        [Fact]
         public async Task CanReadMore_GetLess_ThenMore_GivesFirstBuffer()
         {
-            int expectedReadCount = 200;
+            const int expectedReadCount = 200;
             var producerBuffer = new byte[100];
             var consumerBuffer = new byte[expectedReadCount];
-            int readCount1 = 0;
-            int readCount2 = 0;
+            var readCount1 = 0;
+            var readCount2 = 0;
 
             var random = new Random();
             random.NextBytes(producerBuffer);
@@ -135,17 +134,17 @@ namespace Microsoft.Bot.Streaming.UnitTests
                 readCount2 = await stream.ReadAsync(consumerBuffer, 50, 150);
             }
 
-            Assert.AreEqual(50, readCount1);
-            Assert.AreEqual(50, readCount2);
+            Assert.Equal(50, readCount1);
+            Assert.Equal(50, readCount2);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task CanRead_AfterMultipleWrites()
         {
-            int expectedReadCount = 200;
+            const int expectedReadCount = 200;
             var producerBuffer = new byte[100];
             var consumerBuffer = new byte[expectedReadCount];
-            int readCount = 0;
+            var readCount = 0;
 
             var random = new Random();
             random.NextBytes(producerBuffer);
@@ -159,18 +158,18 @@ namespace Microsoft.Bot.Streaming.UnitTests
             }
 
             // only get 1 buffer
-            Assert.AreEqual(100, readCount);
-            CollectionAssert.AreEquivalent(producerBuffer.Take(readCount).ToArray(), consumerBuffer.Take(readCount).ToArray());
+            Assert.Equal(100, readCount);
+            Assert.Equal(producerBuffer.Take(readCount).ToArray(), consumerBuffer.Take(readCount).ToArray());
         }
 
-        [TestMethod]
+        [Fact]
         public async Task CanReadTwice_AfterMultipleWrites()
         {
-            int expectedReadCount = 200;
+            const int expectedReadCount = 200;
             var producerBuffer = new byte[100];
             var consumerBuffer = new byte[expectedReadCount];
-            int readCount1 = 0;
-            int readCount2 = 0;
+            var readCount1 = 0;
+            var readCount2 = 0;
 
             var random = new Random();
             random.NextBytes(producerBuffer);
@@ -185,81 +184,81 @@ namespace Microsoft.Bot.Streaming.UnitTests
             }
 
             // only get 1 buffer
-            Assert.AreEqual(100, readCount1);
-            Assert.AreEqual(100, readCount2);
-            CollectionAssert.AreEquivalent(producerBuffer, consumerBuffer.Take(100).ToArray());
-            CollectionAssert.AreEquivalent(producerBuffer, consumerBuffer.Skip(100).ToArray());
+            Assert.Equal(100, readCount1);
+            Assert.Equal(100, readCount2);
+            Assert.Equal(producerBuffer, consumerBuffer.Take(100).ToArray());
+            Assert.Equal(producerBuffer, consumerBuffer.Skip(100).ToArray());
         }
 
-        [TestMethod]
+        [Fact]
         public void CanRead_IsTrue()
         {
             using (var stream = new PayloadStream(null))
             {
-                Assert.IsTrue(stream.CanRead);
+                Assert.True(stream.CanRead);
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void CanWrite_IsTrue()
         {
             using (var stream = new PayloadStream(null))
             {
-                Assert.IsTrue(stream.CanWrite);
+                Assert.True(stream.CanWrite);
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void CanSeek_IsFalse()
         {
             using (var stream = new PayloadStream(null))
             {
-                Assert.IsFalse(stream.CanSeek);
+                Assert.False(stream.CanSeek);
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void PositionSetter_Throws()
         {
             using (var stream = new PayloadStream(null))
             {
-                Assert.ThrowsException<NotSupportedException>(() =>
+                Assert.Throws<NotSupportedException>(() =>
                 {
                     stream.Position = 10;
                 });
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void SetLength_Throws()
         {
             using (var stream = new PayloadStream(null))
             {
-                Assert.ThrowsException<NotSupportedException>(() =>
+                Assert.Throws<NotSupportedException>(() =>
                 {
                     stream.SetLength(100);
                 });
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void Seek_Throws()
         {
             using (var stream = new PayloadStream(null))
             {
-                Assert.ThrowsException<NotSupportedException>(() =>
+                Assert.Throws<NotSupportedException>(() =>
                 {
                     stream.Seek(100, SeekOrigin.Begin);
                 });
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task DoneProducing_Empty_WillCauseZeroRead()
         {
-            int expectedReadCount = 200;
+            const int expectedReadCount = 200;
             var consumerBuffer = new byte[expectedReadCount];
-            int readCount = 0;
+            var readCount = 0;
 
             using (var stream = new PayloadStream(null))
             {
@@ -268,17 +267,17 @@ namespace Microsoft.Bot.Streaming.UnitTests
                 readCount = await stream.ReadAsync(consumerBuffer, 0, expectedReadCount);
             }
 
-            Assert.AreEqual(0, readCount);
+            Assert.Equal(0, readCount);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task DoneProducing_Data_WillCauseZeroRead()
         {
-            int expectedReadCount = 100;
+            const int expectedReadCount = 100;
             var producerBuffer = new byte[100];
             var consumerBuffer = new byte[expectedReadCount];
-            int readCount1 = 0;
-            int readCount2 = 0;
+            var readCount1 = 0;
+            var readCount2 = 0;
 
             var random = new Random();
             random.NextBytes(producerBuffer);
@@ -292,8 +291,8 @@ namespace Microsoft.Bot.Streaming.UnitTests
                 readCount2 = await stream.ReadAsync(consumerBuffer, readCount1, expectedReadCount);
             }
 
-            Assert.AreEqual(100, readCount1);
-            Assert.AreEqual(0, readCount2);
+            Assert.Equal(100, readCount1);
+            Assert.Equal(0, readCount2);
         }
 
         private async Task ProducerConsumerMultithreadedTest(
@@ -308,8 +307,8 @@ namespace Microsoft.Bot.Streaming.UnitTests
             var random = new Random();
             random.NextBytes(producerBuffer);
 
-            int producerPosition = 0;
-            int consumerPosition = 0;
+            var producerPosition = 0;
+            var consumerPosition = 0;
 
             using (var ct = new CancellationTokenSource())
             {
@@ -319,7 +318,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
                     {
                         while (consumerPosition < consumerBuffer.Length)
                         {
-                            int readCount = Math.Min(consumerChunkCount, consumerBuffer.Length - consumerPosition);
+                            var readCount = Math.Min(consumerChunkCount, consumerBuffer.Length - consumerPosition);
 
                             var bytesRead = await s.ReadAsync(consumerBuffer, consumerPosition, readCount, ct.Token);
 
@@ -336,7 +335,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
                     {
                         while (producerPosition < producerBuffer.Length)
                         {
-                            int writeCount = Math.Min(producerChunkCount, producerBuffer.Length - producerPosition);
+                            var writeCount = Math.Min(producerChunkCount, producerBuffer.Length - producerPosition);
 
                             await s.WriteAsync(producerBuffer, producerPosition, writeCount, ct.Token);
 
@@ -347,15 +346,15 @@ namespace Microsoft.Bot.Streaming.UnitTests
                     };
 
                     var readTask = reader();
-                    var writetask = writer();
-                    await Task.WhenAll(readTask, writetask);
+                    var writeTask = writer();
+                    await Task.WhenAll(readTask, writeTask);
                 }
             }
 
-            Assert.AreEqual(producerTotalCount, producerPosition);
+            Assert.Equal(producerTotalCount, producerPosition);
             var consumableCount = Math.Min(producerTotalCount, consumerTotalCount);
-            Assert.AreEqual(consumableCount, consumerPosition);
-            CollectionAssert.AreEquivalent(producerBuffer.Take(consumableCount).ToArray(), consumerBuffer.Take(consumableCount).ToArray());
+            Assert.Equal(consumableCount, consumerPosition);
+            Assert.Equal(producerBuffer.Take(consumableCount).ToArray(), consumerBuffer.Take(consumableCount).ToArray());
         }
     }
 }

--- a/tests/Microsoft.Bot.Streaming.Tests/ContentStreamTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/ContentStreamTests.cs
@@ -3,35 +3,34 @@
 
 using System;
 using Microsoft.Bot.Streaming.Payloads;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Streaming.UnitTests
 {
-    [TestClass]
     public class ContentStreamTests
     {
-        [TestMethod]
+        [Fact]
         public void ContentStream_ctor_NullAssembler_Throws()
         {
-            Assert.ThrowsException<ArgumentNullException>(() =>
+            Assert.Throws<ArgumentNullException>(() =>
             {
                 var c = new ContentStream(Guid.Empty, null);
             });
         }
 
-        [TestMethod]
+        [Fact]
         public void ContentStream_Id()
         {
             var id = Guid.NewGuid();
             var assembler = new PayloadStreamAssembler(null, id);
             var c = new ContentStream(id, assembler);
 
-            Assert.AreEqual(id, c.Id);
+            Assert.Equal(id, c.Id);
 
             c.Cancel();
         }
 
-        [TestMethod]
+        [Fact]
         public void ContentStream_Type()
         {
             var id = Guid.NewGuid();
@@ -41,7 +40,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
 
             c.ContentType = type;
 
-            Assert.AreEqual(type, c.ContentType);
+            Assert.Equal(type, c.ContentType);
 
             c.Cancel();
         }

--- a/tests/Microsoft.Bot.Streaming.Tests/Microsoft.Bot.Streaming.Tests.csproj
+++ b/tests/Microsoft.Bot.Streaming.Tests/Microsoft.Bot.Streaming.Tests.csproj
@@ -29,8 +29,6 @@
     <PackageReference Include="Microsoft.CodeCoverage" Version="16.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
     <PackageReference Include="NunitXml.TestLogger" Version="2.1.41" />
     <PackageReference Include="ReportGenerator" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/Microsoft.Bot.Streaming.Tests/NamedPipeTransportTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/NamedPipeTransportTests.cs
@@ -6,21 +6,26 @@ using System.Collections.Generic;
 using System.IO.Pipes;
 using System.Threading.Tasks;
 using Microsoft.Bot.Streaming.Transport.NamedPipes;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Bot.Streaming.UnitTests
 {
-    [TestClass]
     public class NamedPipeTransportTests
     {
-        public TestContext TestContext { get; set; }
+        private readonly ITestOutputHelper _output;
 
-        [TestMethod]
+        public NamedPipeTransportTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
         public void CanWriteAndRead()
         {
             var tasks = new List<Task>();
 
-            byte[] data = new byte[100];
+            var data = new byte[100];
             for (var b = 0; b < data.Length; b++)
             {
                 data[b] = (byte)b;
@@ -38,29 +43,29 @@ namespace Microsoft.Bot.Streaming.UnitTests
                 tasks.Add(Task.Run(
                     async () =>
                     {
-                        TestContext.WriteLine("Before WaitForConnectAsync");
+                        _output.WriteLine("Before WaitForConnectAsync");
                         await readStream.WaitForConnectionAsync().ConfigureAwait(false);
-                        TestContext.WriteLine("After WaitForConnectAsync");
+                        _output.WriteLine("After WaitForConnectAsync");
 
                         var readBuffer = new byte[data.Length];
                         var length = await reader.ReceiveAsync(readBuffer, 0, readBuffer.Length).ConfigureAwait(false);
 
-                        TestContext.WriteLine("After Read");
-                        Assert.AreEqual(length, data.Length);
+                        _output.WriteLine("After Read");
+                        Assert.Equal(length, data.Length);
                         for (var b = 0; b < data.Length; b++)
                         {
-                            Assert.AreEqual(readBuffer[b], data[b]);
+                            Assert.Equal(readBuffer[b], data[b]);
                         }
                     }));
 
                 tasks.Add(Task.Run(
                     async () =>
                     {
-                        TestContext.WriteLine("Before ConnectAsync");
+                        _output.WriteLine("Before ConnectAsync");
                         await writeStream.ConnectAsync(500).ConfigureAwait(false);
-                        TestContext.WriteLine("After ConnectAsync");
+                        _output.WriteLine("After ConnectAsync");
                         await writer.SendAsync(data, 0, data.Length).ConfigureAwait(false);
-                        TestContext.WriteLine("After Write");
+                        _output.WriteLine("After Write");
                     }));
 
                 Task.WaitAll(tasks.ToArray());
@@ -73,18 +78,18 @@ namespace Microsoft.Bot.Streaming.UnitTests
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void ClosedStream_Not_IsConnected()
         {
             var pipeName = Guid.NewGuid().ToString();
             var readStream = new NamedPipeServerStream(pipeName, PipeDirection.In, NamedPipeServerStream.MaxAllowedServerInstances, PipeTransmissionMode.Byte, PipeOptions.WriteThrough | PipeOptions.Asynchronous);
             var reader = new NamedPipeTransport(readStream);
 
-            Assert.AreEqual(false, reader.IsConnected);
+            Assert.False(reader.IsConnected);
             readStream.Dispose();
         }
 
-        [TestMethod]
+        [Fact]
         public void ActiveStream_IsConnected()
         {
             var pipeName = Guid.NewGuid().ToString();
@@ -100,23 +105,23 @@ namespace Microsoft.Bot.Streaming.UnitTests
                 tasks.Add(Task.Run(
                     async () =>
                     {
-                        TestContext.WriteLine("Before WaitForConnectAsync");
+                        _output.WriteLine("Before WaitForConnectAsync");
                         await readStream.WaitForConnectionAsync().ConfigureAwait(false);
-                        TestContext.WriteLine("After WaitForConnectAsync");
+                        _output.WriteLine("After WaitForConnectAsync");
                     }));
 
                 tasks.Add(Task.Run(
                     async () =>
                     {
-                        TestContext.WriteLine("Before ConnectAsync");
+                        _output.WriteLine("Before ConnectAsync");
                         await writeStream.ConnectAsync(500).ConfigureAwait(false);
-                        TestContext.WriteLine("After ConnectAsync");
+                        _output.WriteLine("After ConnectAsync");
                     }));
 
                 Task.WaitAll(tasks.ToArray());
 
-                Assert.AreEqual(true, reader.IsConnected);
-                Assert.AreEqual(true, writer.IsConnected);
+                Assert.True(reader.IsConnected);
+                Assert.True(writer.IsConnected);
             }
             finally
             {
@@ -126,7 +131,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void Dispose_DisconnectsStream()
         {
             var pipeName = Guid.NewGuid().ToString();
@@ -142,26 +147,26 @@ namespace Microsoft.Bot.Streaming.UnitTests
                 tasks.Add(Task.Run(
                     async () =>
                     {
-                        TestContext.WriteLine("Before WaitForConnectAsync");
+                        _output.WriteLine("Before WaitForConnectAsync");
                         await readStream.WaitForConnectionAsync().ConfigureAwait(false);
-                        TestContext.WriteLine("After WaitForConnectAsync");
+                        _output.WriteLine("After WaitForConnectAsync");
                     }));
 
                 tasks.Add(Task.Run(
                     async () =>
                     {
-                        TestContext.WriteLine("Before ConnectAsync");
+                        _output.WriteLine("Before ConnectAsync");
                         await writeStream.ConnectAsync(500).ConfigureAwait(false);
-                        TestContext.WriteLine("After ConnectAsync");
+                        _output.WriteLine("After ConnectAsync");
                     }));
 
                 Task.WaitAll(tasks.ToArray());
 
-                Assert.AreEqual(true, reader.IsConnected);
+                Assert.True(reader.IsConnected);
 
                 reader.Dispose();
 
-                Assert.AreEqual(false, reader.IsConnected);
+                Assert.False(reader.IsConnected);
             }
             finally
             {
@@ -170,7 +175,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void Close_DisconnectsStream()
         {
             var pipeName = Guid.NewGuid().ToString();
@@ -186,26 +191,26 @@ namespace Microsoft.Bot.Streaming.UnitTests
                 tasks.Add(Task.Run(
                     async () =>
                     {
-                        TestContext.WriteLine("Before WaitForConnectAsync");
+                        _output.WriteLine("Before WaitForConnectAsync");
                         await readStream.WaitForConnectionAsync().ConfigureAwait(false);
-                        TestContext.WriteLine("After WaitForConnectAsync");
+                        _output.WriteLine("After WaitForConnectAsync");
                     }));
 
                 tasks.Add(Task.Run(
                     async () =>
                     {
-                        TestContext.WriteLine("Before ConnectAsync");
+                        _output.WriteLine("Before ConnectAsync");
                         await writeStream.ConnectAsync(500).ConfigureAwait(false);
-                        TestContext.WriteLine("After ConnectAsync");
+                        _output.WriteLine("After ConnectAsync");
                     }));
 
                 Task.WaitAll(tasks.ToArray());
 
-                Assert.AreEqual(true, reader.IsConnected);
+                Assert.True(reader.IsConnected);
 
                 reader.Close();
 
-                Assert.AreEqual(false, reader.IsConnected);
+                Assert.False(reader.IsConnected);
             }
             finally
             {
@@ -214,7 +219,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void Read_ReturnsZeroLength_WhenClosedDuringRead()
         {
             var tasks = new List<Task>();
@@ -227,34 +232,34 @@ namespace Microsoft.Bot.Streaming.UnitTests
                 var reader = new NamedPipeTransport(readStream);
                 var writer = new NamedPipeTransport(writeStream);
 
-                TaskCompletionSource<string> waiter = new TaskCompletionSource<string>();
+                var waiter = new TaskCompletionSource<string>();
 
                 tasks.Add(Task.Run(
                     async () =>
                     {
-                        TestContext.WriteLine("Before WaitForConnectAsync");
+                        _output.WriteLine("Before WaitForConnectAsync");
                         await readStream.WaitForConnectionAsync().ConfigureAwait(false);
-                        TestContext.WriteLine("After WaitForConnectAsync");
+                        _output.WriteLine("After WaitForConnectAsync");
 
                         Task.WaitAll(Task.Run(() => waiter.SetResult("go")));
                         var readBuffer = new byte[100];
                         var length = await reader.ReceiveAsync(readBuffer, 0, readBuffer.Length).ConfigureAwait(false);
 
-                        Assert.AreEqual(0, length);
+                        Assert.Equal(0, length);
                     }));
 
                 tasks.Add(Task.Run(
                     async () =>
                     {
-                        TestContext.WriteLine("Before ConnectAsync");
+                        _output.WriteLine("Before ConnectAsync");
                         await writeStream.ConnectAsync(500).ConfigureAwait(false);
-                        TestContext.WriteLine("After ConnectAsync");
+                        _output.WriteLine("After ConnectAsync");
 
                         var r = await waiter.Task.ConfigureAwait(false);
 
                         writer.Close();
 
-                        TestContext.WriteLine("After Close");
+                        _output.WriteLine("After Close");
                     }));
 
                 Task.WaitAll(tasks.ToArray());
@@ -267,12 +272,12 @@ namespace Microsoft.Bot.Streaming.UnitTests
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void Write_ReturnsZeroLength_WhenClosedDuringWrite()
         {
             var tasks = new List<Task>();
 
-            byte[] data = new byte[100];
+            var data = new byte[100];
             for (var b = 0; b < data.Length; b++)
             {
                 data[b] = (byte)b;
@@ -282,7 +287,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
             var readStream = new NamedPipeServerStream(pipeName, PipeDirection.In, NamedPipeServerStream.MaxAllowedServerInstances, PipeTransmissionMode.Byte, PipeOptions.WriteThrough | PipeOptions.Asynchronous);
             var writeStream = new NamedPipeClientStream(".", pipeName, PipeDirection.Out, PipeOptions.WriteThrough | PipeOptions.Asynchronous);
 
-            TaskCompletionSource<string> waiter = new TaskCompletionSource<string>();
+            var waiter = new TaskCompletionSource<string>();
 
             try
             {
@@ -292,9 +297,9 @@ namespace Microsoft.Bot.Streaming.UnitTests
                 tasks.Add(Task.Run(
                     async () =>
                     {
-                        TestContext.WriteLine("Before WaitForConnectAsync");
+                        _output.WriteLine("Before WaitForConnectAsync");
                         await readStream.WaitForConnectionAsync().ConfigureAwait(false);
-                        TestContext.WriteLine("After WaitForConnectAsync");
+                        _output.WriteLine("After WaitForConnectAsync");
 
                         reader.Close();
 
@@ -304,15 +309,15 @@ namespace Microsoft.Bot.Streaming.UnitTests
                 tasks.Add(Task.Run(
                     async () =>
                     {
-                        TestContext.WriteLine("Before ConnectAsync");
+                        _output.WriteLine("Before ConnectAsync");
                         await writeStream.ConnectAsync(500).ConfigureAwait(false);
-                        TestContext.WriteLine("After ConnectAsync");
+                        _output.WriteLine("After ConnectAsync");
 
                         var r = await waiter.Task.ConfigureAwait(false);
 
                         var length = await writer.SendAsync(data, 0, data.Length).ConfigureAwait(false);
 
-                        Assert.AreEqual(0, length);
+                        Assert.Equal(0, length);
                     }));
 
                 Task.WaitAll(tasks.ToArray());

--- a/tests/Microsoft.Bot.Streaming.Tests/RequestTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/RequestTests.cs
@@ -7,50 +7,49 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
 using Microsoft.Bot.Streaming.Payloads;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
+using Xunit;
 
 namespace Microsoft.Bot.Streaming.UnitTests
 {
-    [TestClass]
     public class RequestTests
     {
-        [TestMethod]
+        [Fact]
         public void ReceiveRequest_ctor_Empty_Streams()
         {
             var r = new ReceiveRequest();
-            Assert.IsNotNull(r.Streams);
-            Assert.AreEqual(0, r.Streams.Count);
+            Assert.NotNull(r.Streams);
+            Assert.Empty(r.Streams);
         }
 
-        [TestMethod]
+        [Fact]
         public void ReceiveRequest_ctor_NullProperties()
         {
             var r = new ReceiveRequest();
-            Assert.IsNull(r.Verb);
-            Assert.IsNull(r.Path);
+            Assert.Null(r.Verb);
+            Assert.Null(r.Path);
         }
 
-        [TestMethod]
+        [Fact]
         public void Request_NullProperties()
         {
             var r = new StreamingRequest();
-            Assert.IsNull(r.Verb);
-            Assert.IsNull(r.Path);
+            Assert.Null(r.Verb);
+            Assert.Null(r.Path);
         }
 
-        [TestMethod]
+        [Fact]
         public void Request_AddStream_Null_Throws()
         {
             var r = new StreamingRequest();
 
-            Assert.ThrowsException<ArgumentNullException>(() =>
+            Assert.Throws<ArgumentNullException>(() =>
             {
                 r.AddStream(null);
             });
         }
 
-        [TestMethod]
+        [Fact]
         public void Request_AddStream_Success()
         {
             var r = new StreamingRequest();
@@ -58,12 +57,12 @@ namespace Microsoft.Bot.Streaming.UnitTests
 
             r.AddStream(s);
 
-            Assert.IsNotNull(r.Streams);
-            Assert.AreEqual(1, r.Streams.Count);
-            Assert.AreEqual(s, r.Streams[0].Content);
+            Assert.NotNull(r.Streams);
+            Assert.Single(r.Streams);
+            Assert.Equal(s, r.Streams[0].Content);
         }
 
-        [TestMethod]
+        [Fact]
         public void Request_AddStream_ExistingList_Success()
         {
             var r = new StreamingRequest();
@@ -74,80 +73,80 @@ namespace Microsoft.Bot.Streaming.UnitTests
 
             r.AddStream(s);
 
-            Assert.IsNotNull(r.Streams);
-            Assert.AreEqual(2, r.Streams.Count);
-            Assert.AreEqual(s2, r.Streams[0].Content);
-            Assert.AreEqual(s, r.Streams[1].Content);
+            Assert.NotNull(r.Streams);
+            Assert.Equal(2, r.Streams.Count);
+            Assert.Equal(s2, r.Streams[0].Content);
+            Assert.Equal(s, r.Streams[1].Content);
         }
 
-        [TestMethod]
+        [Fact]
         public void Request_Create_Get_Success()
         {
             var r = StreamingRequest.CreateGet();
 
-            Assert.AreEqual(StreamingRequest.GET, r.Verb);
-            Assert.IsNull(r.Path);
-            Assert.IsNull(r.Streams);
+            Assert.Equal(StreamingRequest.GET, r.Verb);
+            Assert.Null(r.Path);
+            Assert.Null(r.Streams);
         }
 
-        [TestMethod]
+        [Fact]
         public void Request_Create_Post_Success()
         {
             var r = StreamingRequest.CreatePost();
 
-            Assert.AreEqual(StreamingRequest.POST, r.Verb);
-            Assert.IsNull(r.Path);
-            Assert.IsNull(r.Streams);
+            Assert.Equal(StreamingRequest.POST, r.Verb);
+            Assert.Null(r.Path);
+            Assert.Null(r.Streams);
         }
 
-        [TestMethod]
+        [Fact]
         public void Request_Create_Delete_Success()
         {
             var r = StreamingRequest.CreateDelete();
 
-            Assert.AreEqual(StreamingRequest.DELETE, r.Verb);
-            Assert.IsNull(r.Path);
-            Assert.IsNull(r.Streams);
+            Assert.Equal(StreamingRequest.DELETE, r.Verb);
+            Assert.Null(r.Path);
+            Assert.Null(r.Streams);
         }
 
-        [TestMethod]
+        [Fact]
         public void Request_Create_Put_Success()
         {
             var r = StreamingRequest.CreatePut();
 
-            Assert.AreEqual(StreamingRequest.PUT, r.Verb);
-            Assert.IsNull(r.Path);
-            Assert.IsNull(r.Streams);
+            Assert.Equal(StreamingRequest.PUT, r.Verb);
+            Assert.Null(r.Path);
+            Assert.Null(r.Streams);
         }
 
-        [TestMethod]
+        [Fact]
         public void Request_Create_WithBody_Success()
         {
             var s = new StringContent("hi");
             var r = StreamingRequest.CreateRequest(StreamingRequest.POST, "123", s);
 
-            Assert.AreEqual(StreamingRequest.POST, r.Verb);
-            Assert.AreEqual("123", r.Path);
-            Assert.IsNotNull(r.Streams);
-            Assert.AreEqual(1, r.Streams.Count);
-            Assert.AreEqual(s, r.Streams[0].Content);
+            Assert.Equal(StreamingRequest.POST, r.Verb);
+            Assert.Equal("123", r.Path);
+            Assert.NotNull(r.Streams);
+            Assert.Single(r.Streams);
+            Assert.Equal(s, r.Streams[0].Content);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task RequestExtensions_SetBodyString_Success()
         {
             var r = new StreamingRequest();
             r.SetBody("123");
 
-            Assert.IsNotNull(r.Streams);
-            Assert.AreEqual(1, r.Streams.Count);
-            Assert.AreEqual(typeof(StringContent), r.Streams[0].Content.GetType());
+            Assert.NotNull(r.Streams);
+            Assert.Single(r.Streams);
+            Assert.Equal(typeof(StringContent), r.Streams[0].Content.GetType());
 
             var s = await r.Streams[0].Content.ReadAsStringAsync().ConfigureAwait(false);
-            Assert.AreEqual("123", s);
+            Assert.Equal("123", s);
         }
 
-        [TestMethod]
+        [Fact]
         public void RequestExtensions_SetBodyString_Null_Does_Not_Throw()
         {
             Exception ex = null;
@@ -163,27 +162,27 @@ namespace Microsoft.Bot.Streaming.UnitTests
             }
             finally
             {
-                Assert.AreEqual(ex, null);
+                Assert.Null(ex);
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task RequestExtensions_SetBody_Success()
         {
             var r = new StreamingRequest();
             var a = new Activity() { Text = "hi", Type = "message" };
             r.SetBody(a);
 
-            Assert.IsNotNull(r.Streams);
-            Assert.AreEqual(1, r.Streams.Count);
-            Assert.AreEqual(typeof(StringContent), r.Streams[0].Content.GetType());
+            Assert.NotNull(r.Streams);
+            Assert.Single(r.Streams);
+            Assert.Equal(typeof(StringContent), r.Streams[0].Content.GetType());
 
             var s = JsonConvert.DeserializeObject<Activity>(await r.Streams[0].Content.ReadAsStringAsync().ConfigureAwait(false));
-            Assert.AreEqual(a.Text, s.Text);
-            Assert.AreEqual(a.Type, s.Type);
+            Assert.Equal(a.Text, s.Text);
+            Assert.Equal(a.Type, s.Type);
         }
 
-        [TestMethod]
+        [Fact]
         public void RequestExtensions_SetBody_Null_Does_Not_Throw()
         {
             var r = new StreamingRequest();
@@ -199,7 +198,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
             }
             finally
             {
-                Assert.AreEqual(ex, null);
+                Assert.Null(ex);
             }
         }
     }

--- a/tests/Microsoft.Bot.Streaming.Tests/ResponseTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/ResponseTests.cs
@@ -8,49 +8,48 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
 using Microsoft.Bot.Streaming.Payloads;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
+using Xunit;
 
 namespace Microsoft.Bot.Streaming.UnitTests
 {
-    [TestClass]
     public class ResponseTests
     {
-        [TestMethod]
+        [Fact]
         public void ReceiveResponse_Streams_Zero()
         {
             var r = new ReceiveResponse();
-            Assert.IsNotNull(r.Streams);
-            Assert.AreEqual(0, r.Streams.Count);
+            Assert.NotNull(r.Streams);
+            Assert.Empty(r.Streams);
         }
 
-        [TestMethod]
+        [Fact]
         public void ReceiveResponse_NullProperties()
         {
             var r = new ReceiveResponse();
-            Assert.AreEqual(0, r.StatusCode);
+            Assert.Equal(0, r.StatusCode);
         }
 
-        [TestMethod]
+        [Fact]
         public void Response_NullProperties()
         {
             var r = new StreamingResponse();
-            Assert.AreEqual(0, r.StatusCode);
-            Assert.IsNull(r.Streams);
+            Assert.Equal(0, r.StatusCode);
+            Assert.Null(r.Streams);
         }
 
-        [TestMethod]
+        [Fact]
         public void Response_AddStream_Null_Throws()
         {
             var r = new StreamingResponse();
 
-            Assert.ThrowsException<ArgumentNullException>(() =>
+            Assert.Throws<ArgumentNullException>(() =>
             {
                 r.AddStream(null);
             });
         }
 
-        [TestMethod]
+        [Fact]
         public void Response_AddStream_Success()
         {
             var r = new StreamingResponse();
@@ -58,12 +57,12 @@ namespace Microsoft.Bot.Streaming.UnitTests
 
             r.AddStream(s);
 
-            Assert.IsNotNull(r.Streams);
-            Assert.AreEqual(1, r.Streams.Count);
-            Assert.AreEqual(s, r.Streams[0].Content);
+            Assert.NotNull(r.Streams);
+            Assert.Single(r.Streams);
+            Assert.Equal(s, r.Streams[0].Content);
         }
 
-        [TestMethod]
+        [Fact]
         public void Response_AddStream_ExistingList_Success()
         {
             var r = new StreamingResponse();
@@ -74,75 +73,75 @@ namespace Microsoft.Bot.Streaming.UnitTests
 
             r.AddStream(s);
 
-            Assert.IsNotNull(r.Streams);
-            Assert.AreEqual(2, r.Streams.Count);
-            Assert.AreEqual(s2, r.Streams[0].Content);
-            Assert.AreEqual(s, r.Streams[1].Content);
+            Assert.NotNull(r.Streams);
+            Assert.Equal(2, r.Streams.Count);
+            Assert.Equal(s2, r.Streams[0].Content);
+            Assert.Equal(s, r.Streams[1].Content);
         }
 
-        [TestMethod]
+        [Fact]
         public void Response_NotFound_Success()
         {
             var r = StreamingResponse.NotFound();
 
-            Assert.AreEqual((int)HttpStatusCode.NotFound, r.StatusCode);
-            Assert.IsNull(r.Streams);
+            Assert.Equal((int)HttpStatusCode.NotFound, r.StatusCode);
+            Assert.Null(r.Streams);
         }
 
-        [TestMethod]
+        [Fact]
         public void Response_Forbidden_Success()
         {
             var r = StreamingResponse.Forbidden();
 
-            Assert.AreEqual((int)HttpStatusCode.Forbidden, r.StatusCode);
-            Assert.IsNull(r.Streams);
+            Assert.Equal((int)HttpStatusCode.Forbidden, r.StatusCode);
+            Assert.Null(r.Streams);
         }
 
-        [TestMethod]
+        [Fact]
         public void Response_OK_Success()
         {
             var r = StreamingResponse.OK();
 
-            Assert.AreEqual((int)HttpStatusCode.OK, r.StatusCode);
-            Assert.IsNull(r.Streams);
+            Assert.Equal((int)HttpStatusCode.OK, r.StatusCode);
+            Assert.Null(r.Streams);
         }
 
-        [TestMethod]
+        [Fact]
         public void Response_InternalServerError_Success()
         {
             var r = StreamingResponse.InternalServerError();
 
-            Assert.AreEqual((int)HttpStatusCode.InternalServerError, r.StatusCode);
-            Assert.IsNull(r.Streams);
+            Assert.Equal((int)HttpStatusCode.InternalServerError, r.StatusCode);
+            Assert.Null(r.Streams);
         }
 
-        [TestMethod]
+        [Fact]
         public void Response_Create_WithBody_Success()
         {
             var s = new StringContent("hi");
             var r = StreamingResponse.CreateResponse(HttpStatusCode.OK, s);
 
-            Assert.AreEqual((int)HttpStatusCode.OK, r.StatusCode);
-            Assert.IsNotNull(r.Streams);
-            Assert.AreEqual(1, r.Streams.Count);
-            Assert.AreEqual(s, r.Streams[0].Content);
+            Assert.Equal((int)HttpStatusCode.OK, r.StatusCode);
+            Assert.NotNull(r.Streams);
+            Assert.Single(r.Streams);
+            Assert.Equal(s, r.Streams[0].Content);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ResponseExtensions_SetBodyString_Success()
         {
             var r = new StreamingResponse();
             r.SetBody("123");
 
-            Assert.IsNotNull(r.Streams);
-            Assert.AreEqual(1, r.Streams.Count);
-            Assert.AreEqual(typeof(StringContent), r.Streams[0].Content.GetType());
+            Assert.NotNull(r.Streams);
+            Assert.Single(r.Streams);
+            Assert.Equal(typeof(StringContent), r.Streams[0].Content.GetType());
 
             var s = await r.Streams[0].Content.ReadAsStringAsync().ConfigureAwait(false);
-            Assert.AreEqual("123", s);
+            Assert.Equal("123", s);
         }
 
-        [TestMethod]
+        [Fact]
         public void ResponseExtensions_SetBodyString_Null_Does_Not_Throw()
         {
             var r = new StreamingResponse();
@@ -158,27 +157,27 @@ namespace Microsoft.Bot.Streaming.UnitTests
             }
             finally
             {
-                Assert.AreEqual(ex, null);
+                Assert.Null(ex);
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ResponseExtensions_SetBody_Success()
         {
             var r = new StreamingResponse();
             var a = new Activity() { Text = "hi", Type = "message" };
             r.SetBody(a);
 
-            Assert.IsNotNull(r.Streams);
-            Assert.AreEqual(1, r.Streams.Count);
-            Assert.AreEqual(typeof(StringContent), r.Streams[0].Content.GetType());
+            Assert.NotNull(r.Streams);
+            Assert.Single(r.Streams);
+            Assert.Equal(typeof(StringContent), r.Streams[0].Content.GetType());
 
             var s = JsonConvert.DeserializeObject<Activity>(await r.Streams[0].Content.ReadAsStringAsync().ConfigureAwait(false));
-            Assert.AreEqual(a.Text, s.Text);
-            Assert.AreEqual(a.Type, s.Type);
+            Assert.Equal(a.Text, s.Text);
+            Assert.Equal(a.Type, s.Type);
         }
 
-        [TestMethod]
+        [Fact]
         public void ResponseExtensions_SetBody_Null_Does_Not_Throw()
         {
             var r = new StreamingResponse();
@@ -194,11 +193,11 @@ namespace Microsoft.Bot.Streaming.UnitTests
             }
             finally
             {
-                Assert.AreEqual(ex, null);
+                Assert.Null(ex);
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void ReceiveBase_ReadBodyAsString_NoContent_EmptyString()
         {
             var r = new ReceiveResponse();
@@ -206,7 +205,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
 
             var result = r.ReadBodyAsString();
 
-            Assert.AreEqual(string.Empty, result);
+            Assert.Equal(string.Empty, result);
         }
     }
 }

--- a/tests/Microsoft.Bot.Streaming.Tests/SendOperationsTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/SendOperationsTests.cs
@@ -12,15 +12,14 @@ using Microsoft.Bot.Streaming.Payloads;
 using Microsoft.Bot.Streaming.PayloadTransport;
 using Microsoft.Bot.Streaming.Transport;
 using Microsoft.Bot.Streaming.UnitTests.Mocks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using Xunit;
 
 namespace Microsoft.Bot.Streaming.UnitTests
 {
-    [TestClass]
     public class SendOperationsTests
     {
-        [TestMethod]
+        [Fact]
         public async Task SendRequestAsync_WaitsTillAllDataSent()
         {
             var payLoadSender = new PayloadSender();
@@ -49,7 +48,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task RequestDisassembler_WithVariableStream_Sends()
         {
             var sender = new PayloadSender();
@@ -64,10 +63,10 @@ namespace Microsoft.Bot.Streaming.UnitTests
 
             await ops.SendRequestAsync(Guid.NewGuid(), request);
 
-            Assert.AreEqual(5, transport.Buffers.Count);
+            Assert.Equal(5, transport.Buffers.Count);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task RequestDisassembler_WithJsonStream_Sends()
         {
             var sender = new PayloadSender();
@@ -80,14 +79,14 @@ namespace Microsoft.Bot.Streaming.UnitTests
 
             await ops.SendRequestAsync(Guid.NewGuid(), request);
 
-            Assert.AreEqual(4, transport.Buffers.Count);
+            Assert.Equal(4, transport.Buffers.Count);
         }
 
         // Creates a stream that throws if read from after Disposal. Otherwise returns a buffer of byte data
         private Stream GetMockedStream(int length)
         {
-            int read = 0;
-            int isStreamDisposed = 1;
+            var read = 0;
+            var isStreamDisposed = 1;
             var mockedStream = new Mock<Stream>(MockBehavior.Strict);
             mockedStream.SetupGet(a => a.Length).Returns(length);
             mockedStream.SetupGet(a => a.CanSeek).Returns(false);

--- a/tests/Microsoft.Bot.Streaming.Tests/StreamingRequestHandlerTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/StreamingRequestHandlerTests.cs
@@ -10,7 +10,6 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
-using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
 using Microsoft.Bot.Streaming;
 using Microsoft.Bot.Streaming.Payloads;
@@ -219,7 +218,7 @@ namespace Microsoft.Bot.Builder.Streaming.Tests
             // Arrange
             var handler = new StreamingRequestHandler(new MockBot(), new BotFrameworkHttpAdapter(), Guid.NewGuid().ToString());
             var conversationId = Guid.NewGuid().ToString();
-            var serviceUrl = "urn:FakeName:fakeProtocol://fakePath";
+            const string serviceUrl = "urn:FakeName:fakeProtocol://fakePath";
             var membersAdded = new List<ChannelAccount>();
             var member = new ChannelAccount
             {


### PR DESCRIPTION
_**Note: This PR must be merged after # 326**_

Fixes# 4106

## Description
This PR migrates all [Microsoft.Bot.Streaming.Tests](https://github.com/microsoft/botbuilder-dotnet/tree/main/tests/Microsoft.Bot.Streaming.Tests) tests from **MSTest** to **xUnit**.

## Detailed Changes
- Removed MSTest packages from the .csproj.
- Replaced `[TestMethod]` with `[Fact]`.
- Changed Asserts.
- Used constants instead of variables where applicable.
- Used `var` instead of the specific type.

Also, we did the following changes in: 
- **_ConcurrentStreamTests_**:
    - Replaced `CollectionAssert.AreEquivalent` with `Assert.Equal`. This was possible because the arrays we compare are ordered.
- **_NamedPipeTransportTests_**:
    - Removed `TestContext` and replaced it with `ITestOutputHelper`.
    - Added a constructor to the test class and assigned the _output property.
    - Replaced `TestContext.WriteLine` with `_output.WriteLine`.

## Testing
The following image shows the tests passing after the changes.
![image](https://user-images.githubusercontent.com/44245136/92150354-ae951e00-edf5-11ea-8d40-425254657fee.png)
