### PR TITLE
Add missing XML documentation to Bot.Builder.Dialogs.Adaptive/Actions

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ActionScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ActionScope.cs
@@ -15,8 +15,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class ActionScope : Dialog, IDialogDependencies
     {
+        /// <summary>
+        /// Defines the path for the off set key.
+        /// </summary>
         protected const string OFFSETKEY = "this.offset";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActionScope"/> class.
+        /// </summary>
+        /// <param name="actions">The actions to execute.</param>
         public ActionScope(IEnumerable<Dialog> actions = null)
         {
             if (actions != null)
@@ -33,6 +40,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         public List<Dialog> Actions { get; set; } = new List<Dialog>();
 #pragma warning restore CA2227 // Collection properties should be read only
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default)
         {
             if (this.Actions.Any())
@@ -45,12 +60,30 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             }
         }
 
+        /// <summary>
+        /// Called when the dialog is _continued_, where it is the active dialog and the
+        /// user replies with a new activity.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> ContinueDialogAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
         {
             // We're being continued after an interruption so just run next action
             return await OnNextActionAsync(dc, null, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Called when a child dialog completed this turn, returning control to this dialog.
+        /// </summary>
+        /// <param name="dc">The dialog context for the current turn of the conversation.</param>
+        /// <param name="reason">Reason why the dialog resumed.</param>
+        /// <param name="result">Optional, value returned from the dialog that was called. The type
+        /// of the value returned is dependent on the child dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> ResumeDialogAsync(DialogContext dc, DialogReason reason, object result = null, CancellationToken cancellationToken = default)
         {
             if (result is ActionScopeResult actionScopeResult)
@@ -61,6 +94,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             return await OnNextActionAsync(dc, result, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Gets a unique string which represents the version of this dialog.  If the version
+        /// changes between turns the dialog system will emit a DialogChanged event.
+        /// </summary>
+        /// <returns>Unique string which should only change when dialog has changed in a
+        /// way that should restart the dialog.</returns>
         public override string GetVersion()
         {
             StringBuilder sb = new StringBuilder();
@@ -76,6 +115,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             return StringUtils.Hash(sb.ToString());
         }
 
+        /// <summary>
+        /// Enumerate child dialog dependencies so they can be added to the containers dialog set.
+        /// </summary>
+        /// <returns>dialog enumeration.</returns>
         public virtual IEnumerable<Dialog> GetDependencies()
         {
             foreach (var action in Actions)
@@ -84,6 +127,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             }
         }
 
+        /// <summary>
+        /// Called when a returning control to this dialog with an <see cref="ActionScopeResult"/>.
+        /// </summary>
+        /// <param name="dc">The dialog context for the current turn of the conversation.</param>
+        /// <param name="actionScopeResult">Contains the actions scope result.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected virtual async Task<DialogTurnResult> OnActionScopeResultAsync(DialogContext dc, ActionScopeResult actionScopeResult, CancellationToken cancellationToken = default)
         {
             switch (actionScopeResult.ActionScopeCommand)
@@ -102,6 +153,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             }
         }
 
+        /// <summary>
+        /// Called when a returning control to this dialog with an <see cref="ActionScopeResult"/>
+        /// with the property ActionCommand set to <c>GoToAction</c>.
+        /// </summary>
+        /// <param name="dc">The dialog context for the current turn of the conversation.</param>
+        /// <param name="actionScopeResult">Contains the actions scope result.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected virtual async Task<DialogTurnResult> OnGotoActionAsync(DialogContext dc, ActionScopeResult actionScopeResult, CancellationToken cancellationToken = default)
         {
             // Look for action to goto in our scope
@@ -125,18 +185,46 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             }
         }
 
+        /// <summary>
+        /// Called when a returning control to this dialog with an <see cref="ActionScopeResult"/>
+        /// with the property ActionCommand set to <c>BreakLoop</c>.
+        /// </summary>
+        /// <param name="dc">The dialog context for the current turn of the conversation.</param>
+        /// <param name="actionScopeResult">Contains the actions scope result.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected virtual async Task<DialogTurnResult> OnBreakLoopAsync(DialogContext dc, ActionScopeResult actionScopeResult, CancellationToken cancellationToken = default)
         {
             // default is to simply end the dialog and propagate to parent to handle
             return await dc.EndDialogAsync(actionScopeResult, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Called when a returning control to this dialog with an <see cref="ActionScopeResult"/>
+        /// with the property ActionCommand set to <c>ContinueLoop</c>.
+        /// </summary>
+        /// <param name="dc">The dialog context for the current turn of the conversation.</param>
+        /// <param name="actionScopeResult">Contains the actions scope result.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <remarks>Default is to simply end the dialog and propagate to parent to handle.</remarks>
         protected virtual async Task<DialogTurnResult> OnContinueLoopAsync(DialogContext dc, ActionScopeResult actionScopeResult, CancellationToken cancellationToken = default)
         {
             // default is to simply end the dialog and propagate to parent to handle
             return await dc.EndDialogAsync(actionScopeResult, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Called when the dialog continues to the next action.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="result">Optional, value returned from the dialog that was called. The type
+        /// of the value returned is dependent on the child dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected virtual async Task<DialogTurnResult> OnNextActionAsync(DialogContext dc, object result = null, CancellationToken cancellationToken = default)
         {
             // Check for any plan changes
@@ -173,6 +261,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             return await this.OnEndOfActionsAsync(dc, result, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Called when the dialog's action ends.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="result">Optional, value returned from the dialog that was called. The type
+        /// of the value returned is dependent on the child dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected virtual async Task<DialogTurnResult> OnEndOfActionsAsync(DialogContext dc, object result = null, CancellationToken cancellationToken = default)
         {
             if (result is CancellationToken)
@@ -184,6 +281,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             return await dc.EndDialogAsync(result, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Starts a new dialog and pushes it onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="offset">Optional, value returned from the dialog that was called. The type
+        /// of the value returned is dependent on the child dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected virtual async Task<DialogTurnResult> BeginActionAsync(DialogContext dc, int offset, CancellationToken cancellationToken = default)
         {
             // get the action for the offset
@@ -209,6 +315,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             return await dc.BeginDialogAsync(action.Id, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Builds the compute Id for the dialog.
+        /// </summary>
+        /// <returns>A string representing the compute Id.</returns>
         protected override string OnComputeId()
         {
             return $"ActionScope[{StringUtils.EllipsisHash(string.Join(",", Actions.Select(a => a.Id)), 50)}]";

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ActionScopeCommands.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ActionScopeCommands.cs
@@ -3,6 +3,9 @@
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 {
+    /// <summary>
+    /// Represents the possible action scope commands.
+    /// </summary>
 #pragma warning disable CA1052 // Static holder types should be Static or NotInheritable (we can't change this without breaking binary compat)
     public class ActionScopeCommands
 #pragma warning restore CA1052 // Static holder types should be Static or NotInheritable

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ActionScopeResult.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ActionScopeResult.cs
@@ -7,6 +7,9 @@ using System.Text;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 {
+    /// <summary>
+    /// Represent the Id and Scope command for an action scope.
+    /// </summary>
     public class ActionScopeResult
     {
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BaseInvokeDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BaseInvokeDialog.cs
@@ -15,7 +15,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public abstract class BaseInvokeDialog : Dialog, IDialogDependencies
     {
-        // Expression for dialogId to call (allowing dynamic expression)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BaseInvokeDialog"/> class.
+        /// Expression for dialogId to call (allowing dynamic expression).
+        /// </summary>
+        /// <param name="dialogIdToCall">Optional, id of the dialog to call.</param>
+        /// <param name="bindingOptions">Optional, binding options for the dialog to call.</param>
         public BaseInvokeDialog(string dialogIdToCall = null, object bindingOptions = null)
             : base()
         {
@@ -56,6 +61,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         [JsonProperty("activityProcessed")]
         public BoolExpression ActivityProcessed { get; set; } = true;
 
+        /// <summary>
+        /// Enumerate child dialog dependencies so they can be added to the containers dialog set.
+        /// </summary>
+        /// <returns>Dialog enumeration.</returns>
         public virtual IEnumerable<Dialog> GetDependencies()
         {
             if (Dialog?.Value != null)
@@ -66,6 +75,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             yield break;
         }
 
+        /// <summary>
+        /// Builds the compute Id for the dialog.
+        /// </summary>
+        /// <returns>A string representing the compute Id.</returns>
         protected override string OnComputeId()
         {
             return $"{this.GetType().Name}[{Dialog?.ToString()}]";

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BeginDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BeginDialog.cs
@@ -15,9 +15,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class BeginDialog : BaseInvokeDialog
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.BeginDialog";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BeginDialog"/> class.
+        /// </summary>
+        /// <param name="dialogIdToCall">Optional, id of the dialog to call.</param>
+        /// <param name="options">Optional, object with additional options.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public BeginDialog(string dialogIdToCall = null, object options = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(dialogIdToCall, options)
@@ -46,6 +56,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         [JsonProperty("resultProperty")]
         public StringExpression ResultProperty { get; set; }
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options is CancellationToken)
@@ -70,6 +88,16 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             return await dc.BeginDialogAsync(dialog.Id, options: boundOptions, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Called when a child dialog completed this turn, returning control to this dialog.
+        /// </summary>
+        /// <param name="dc">The dialog context for the current turn of the conversation.</param>
+        /// <param name="reason">Reason why the dialog resumed.</param>
+        /// <param name="result">Optional, value returned from the dialog that was called. The type
+        /// of the value returned is dependent on the child dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> ResumeDialogAsync(DialogContext dc, DialogReason reason, object result = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (this.ResultProperty != null)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BeginSkill.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BeginSkill.cs
@@ -19,12 +19,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class BeginSkill : SkillDialog
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.BeginSkill";
 
         // Used to cache DialogOptions for multi-turn calls across servers
         private readonly string _dialogOptionsStateKey = $"{typeof(BeginSkill).FullName}.DialogOptionsData";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BeginSkill"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public BeginSkill([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(new SkillDialogOptions())
@@ -128,6 +136,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         [JsonProperty("allowInterruptions")]
         public BoolExpression AllowInterruptions { get; set; }
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default)
         {
             if (Disabled != null && Disabled.GetValue(dc.State))
@@ -167,6 +183,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             return await base.BeginDialogAsync(dc, new BeginSkillDialogOptions { Activity = activity }, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Called when the dialog is _continued_, where it is the active dialog and the
+        /// user replies with a new activity.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override Task<DialogTurnResult> ContinueDialogAsync(DialogContext dc, CancellationToken cancellationToken = default)
         {
             LoadDialogOptions(dc.Context, dc.ActiveDialog);
@@ -182,24 +206,55 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             return base.ContinueDialogAsync(dc, cancellationToken);
         }
 
+        /// <summary>
+        /// Called when the dialog should re-prompt the user for input.
+        /// </summary>
+        /// <param name="turnContext">The context object for this turn.</param>
+        /// <param name="instance">State information for this dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override Task RepromptDialogAsync(ITurnContext turnContext, DialogInstance instance, CancellationToken cancellationToken = default)
         {
             LoadDialogOptions(turnContext, instance);
             return base.RepromptDialogAsync(turnContext, instance, cancellationToken);
         }
 
+        /// <summary>
+        /// Called when a child dialog completed this turn, returning control to this dialog.
+        /// </summary>
+        /// <param name="dc">The dialog context for the current turn of the conversation.</param>
+        /// <param name="reason">Reason why the dialog resumed.</param>
+        /// <param name="result">Optional, value returned from the dialog that was called. The type
+        /// of the value returned is dependent on the child dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override Task<DialogTurnResult> ResumeDialogAsync(DialogContext dc, DialogReason reason, object result = null, CancellationToken cancellationToken = default)
         {
             LoadDialogOptions(dc.Context, dc.ActiveDialog);
             return base.ResumeDialogAsync(dc, reason, result, cancellationToken);
         }
 
+        /// <summary>
+        /// Called when the dialog is ending.
+        /// </summary>
+        /// <param name="turnContext">The context object for this turn.</param>
+        /// <param name="instance">State information associated with the instance of this dialog on the dialog stack.</param>
+        /// <param name="reason">Reason why the dialog ended.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override Task EndDialogAsync(ITurnContext turnContext, DialogInstance instance, DialogReason reason, CancellationToken cancellationToken = default)
         {
             LoadDialogOptions(turnContext, instance);
             return base.EndDialogAsync(turnContext, instance, reason, cancellationToken);
         }
 
+        /// <summary>
+        /// Builds the compute Id for the dialog.
+        /// </summary>
+        /// <returns>A string representing the compute Id.</returns>
         protected override string OnComputeId()
         {
             var appId = SkillAppId?.ToString() ?? string.Empty;
@@ -217,6 +272,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             return $"{GetType().Name}['{appId}','{activity}']";
         }
 
+        /// <summary>
+        /// Called before an event is bubbled to its parent.
+        /// </summary>
+        /// <param name="dc">The dialog context for the current turn of conversation.</param>
+        /// <param name="e">The event being raised.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns> Whether the event is handled by the current dialog and further processing should stop.</returns>
         protected override async Task<bool> OnPreBubbleEventAsync(DialogContext dc, DialogEvent e, CancellationToken cancellationToken)
         {
             if (e.Name == DialogEvents.ActivityReceived && dc.Context.Activity.Type == ActivityTypes.Message)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BreakLoop.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BreakLoop.cs
@@ -15,9 +15,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class BreakLoop : Dialog
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.BreakLoop";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BreakLoop"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         public BreakLoop([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
         {
             this.RegisterSourceLocation(callerPath, callerLine);
@@ -33,8 +41,16 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         /// A boolean expression. 
         /// </value>
         [JsonProperty("disabled")]
-        public BoolExpression Disabled { get; set; } 
+        public BoolExpression Disabled { get; set; }
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options is CancellationToken)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/CancelAllDialogs.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/CancelAllDialogs.cs
@@ -15,9 +15,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class CancelAllDialogs : CancelAllDialogsBase
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.CancelAllDialogs";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CancelAllDialogs"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public CancelAllDialogs([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(cancelAll: true)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/CancelAllDialogsBase.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/CancelAllDialogsBase.cs
@@ -18,6 +18,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     {
         private bool cancelAll;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CancelAllDialogsBase"/> class.
+        /// </summary>
+        /// <param name="cancelAll">Set to <c>true</c> to cancel all dialogs; <c>false</c> otherwise.</param>
         [JsonConstructor]
         public CancelAllDialogsBase(bool cancelAll)
         {
@@ -62,6 +66,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         [JsonProperty("eventValue")]
         public ValueExpression EventValue { get; set; }
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options is CancellationToken)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/CancelDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/CancelDialog.cs
@@ -15,9 +15,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class CancelDialog : CancelAllDialogsBase
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.CancelDialog";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CancelDialog"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public CancelDialog([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(cancelAll: false)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/Case.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/Case.cs
@@ -7,10 +7,18 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 {
+    /// <summary>
+    /// Cases of action scope.
+    /// </summary>
 #pragma warning disable CA1716 // Identifiers should not match keywords (by design and we can't change this without breaking binary compat)
     public class Case : ActionScope
 #pragma warning restore CA1716 // Identifiers should not match keywords
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Case"/> class.
+        /// </summary>
+        /// <param name="value">Optional, case's string value.</param>
+        /// <param name="actions">Optional, numerable list of dialog actions.</param>
         public Case(string value = null, IEnumerable<Dialog> actions = null)
             : base(actions)
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/CodeAction.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/CodeAction.cs
@@ -12,10 +12,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 {
     using CodeActionHandler = System.Func<Microsoft.Bot.Builder.Dialogs.DialogContext, object, System.Threading.Tasks.Task<Microsoft.Bot.Builder.Dialogs.DialogTurnResult>>;
 
+    /// <summary>
+    /// Class representing a dialog code action.
+    /// </summary>
     public class CodeAction : Dialog
     {
         private readonly CodeActionHandler codeHandler;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CodeAction"/> class.
+        /// </summary>
+        /// <param name="codeHandler">Code handler for the action.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         public CodeAction(CodeActionHandler codeHandler, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base()
         {
@@ -33,8 +42,16 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         /// A boolean expression. 
         /// </value>
         [JsonProperty("disabled")]
-        public BoolExpression Disabled { get; set; } 
+        public BoolExpression Disabled { get; set; }
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options is CancellationToken)
@@ -50,6 +67,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             return await this.codeHandler(dc, options).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Builds the compute Id for the dialog.
+        /// </summary>
+        /// <returns>A string representing the compute Id.</returns>
         protected override string OnComputeId()
         {
             return $"{this.GetType().Name}({StringUtils.Ellipsis(codeHandler.ToString(), 50)})";

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ContinueLoop.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ContinueLoop.cs
@@ -15,9 +15,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class ContinueLoop : Dialog
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.ContinueLoop";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ContinueLoop"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         public ContinueLoop([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
         {
             this.RegisterSourceLocation(callerPath, callerLine);
@@ -33,8 +41,16 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         /// A boolean expression. 
         /// </value>
         [JsonProperty("disabled")]
-        public BoolExpression Disabled { get; set; } 
+        public BoolExpression Disabled { get; set; }
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options is CancellationToken)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/DebugBreak.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/DebugBreak.cs
@@ -13,11 +13,22 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 {
+    /// <summary>
+    /// Break the debug.
+    /// </summary>
     public class DebugBreak : Dialog
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.DebugBreak";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DebugBreak"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         public DebugBreak([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
         {
             this.RegisterSourceLocation(callerPath, callerLine);
@@ -33,8 +44,16 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         /// A boolean expression. 
         /// </value>
         [JsonProperty("disabled")]
-        public BoolExpression Disabled { get; set; } 
+        public BoolExpression Disabled { get; set; }
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options is CancellationToken)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/DeleteActivity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/DeleteActivity.cs
@@ -15,9 +15,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class DeleteActivity : Dialog
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.DeleteActivity";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeleteActivity"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public DeleteActivity([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
         {
@@ -43,6 +51,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         [JsonProperty("activityId")]
         public StringExpression ActivityId { get; set; }
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options is CancellationToken)
@@ -67,6 +83,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Builds the compute Id for the dialog.
+        /// </summary>
+        /// <returns>A string representing the compute Id.</returns>
         protected override string OnComputeId()
         {
             return $"{this.GetType().Name}('{ActivityId?.ToString()}')";

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/DeleteProperties.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/DeleteProperties.cs
@@ -17,9 +17,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class DeleteProperties : Dialog
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.DeleteProperties";
-        
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeleteProperties"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public DeleteProperties([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base()
@@ -53,6 +61,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         public List<StringExpression> Properties { get; set; } = new List<StringExpression>();
 #pragma warning restore CA2227 // Collection properties should be read only
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options is CancellationToken)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/DeleteProperty.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/DeleteProperty.cs
@@ -15,9 +15,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class DeleteProperty : Dialog
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.DeleteProperty";
-        
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeleteProperty"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public DeleteProperty([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base()
@@ -25,6 +33,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             this.RegisterSourceLocation(callerPath, callerLine);
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeleteProperty"/> class.
+        /// </summary>
+        /// <param name="property">Property to delete from memory.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         public DeleteProperty(string property, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base()
         {
@@ -59,6 +73,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         [JsonProperty("property")]
         public StringExpression Property { get; set; }
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options is CancellationToken)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/DynamicBeginDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/DynamicBeginDialog.cs
@@ -18,6 +18,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class DynamicBeginDialog : BeginDialog
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicBeginDialog"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public DynamicBeginDialog([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
         {
@@ -35,6 +40,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         protected Dictionary<string, object> Properties { get; set; } = new Dictionary<string, object>();
 #pragma warning restore CA2227 // Collection properties should be read only
 
+        /// <summary>
+        /// BindOptions - evaluate expressions in options.
+        /// </summary>
+        /// <param name="dc">dialog context.</param>
+        /// <param name="options">options to bind.</param>
+        /// <returns>merged options with expressions bound to values.</returns>
         protected override object BindOptions(DialogContext dc, object options)
         {
             // use overflow properties of deserialized object instead of the passed in option.

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/EditActions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/EditActions.cs
@@ -17,6 +17,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class EditActions : Dialog, IDialogDependencies
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.EditActions";
 
@@ -64,11 +67,23 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         [JsonProperty("changeType")]
         public EnumExpression<ActionChangeType> ChangeType { get; set; } = new EnumExpression<ActionChangeType>();
 
+        /// <summary>
+        /// Enumerate child dialog dependencies so they can be added to the containers dialogset.
+        /// </summary>
+        /// <returns>dialog enumeration.</returns>
         public virtual IEnumerable<Dialog> GetDependencies()
         {
             return this.Actions;
         }
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (this.Disabled != null && this.Disabled.GetValue(dc.State) == true)
@@ -101,6 +116,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             }
         }
 
+        /// <summary>
+        /// Builds the compute Id for the dialog.
+        /// </summary>
+        /// <returns>A string representing the compute Id.</returns>
         protected override string OnComputeId()
         {
             var idList = Actions.Select(s => s.Id);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/EditArray.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/EditArray.cs
@@ -19,6 +19,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class EditArray : Dialog
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.EditArray";
 
@@ -61,6 +64,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EditArray"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public EditArray([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base()
@@ -68,6 +76,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             this.RegisterSourceLocation(callerPath, callerLine);
         }
 
+        /// <summary>
+        /// Possibles array change actions type.
+        /// </summary>
         [JsonConverter(typeof(StringEnumConverter), /*camelCase*/ true)]
         public enum ArrayChangeType
         {
@@ -145,6 +156,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         [JsonProperty("value")]
         public ValueExpression Value { get; set; } = new ValueExpression();
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options is CancellationToken)
@@ -234,6 +253,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             return await dc.EndDialogAsync(result, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Builds the compute Id for the dialog.
+        /// </summary>
+        /// <returns>A string representing the compute Id.</returns>
         protected override string OnComputeId()
         {
             return $"{this.GetType().Name}[{ChangeType?.ToString() + ": " + ItemsProperty?.ToString()}]";

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/EmitEvent.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/EmitEvent.cs
@@ -15,9 +15,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class EmitEvent : Dialog
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.EmitEvent";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EmitEvent"/> class.
+        /// </summary>
+        /// <param name="eventName">Name of the event to emit.</param>
+        /// <param name="eventValue">Memory property path to use to get the value to send as part of the event.</param>
+        /// <param name="bubble">Value indicating whether the event should bubble to parents or not.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public EmitEvent(string eventName = null, object eventValue = null, bool bubble = false, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base()
@@ -76,6 +87,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         [JsonProperty("bubbleEvent")]
         public BoolExpression BubbleEvent { get; set; }
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options is CancellationToken)
@@ -110,6 +129,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             return await dc.EndDialogAsync(handled, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Builds the compute Id for the dialog.
+        /// </summary>
+        /// <returns>A string representing the compute Id.</returns>
         protected override string OnComputeId()
         {
             return $"{this.GetType().Name}[{EventName?.ToString() ?? string.Empty}]";

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/EndDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/EndDialog.cs
@@ -16,9 +16,18 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class EndDialog : Dialog
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.EndDialog";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EndDialog"/> class.
+        /// </summary>
+        /// <param name="value">Optional, value expression for the result to be returned to the caller.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public EndDialog(object value = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base()
@@ -50,8 +59,16 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         /// A value expression for the result to be returned to the caller.
         /// </value>
         [JsonProperty("value")]
-        public ValueExpression Value { get; set; } 
+        public ValueExpression Value { get; set; }
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options is CancellationToken)
@@ -87,6 +104,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             return await EndParentDialogAsync(dc, result: null, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Ends the parent dialog.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="result">Optional, value returned from the previous dialog on the stack.
+        /// The type of the value returned is dependent on the previous dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected async Task<DialogTurnResult> EndParentDialogAsync(DialogContext dc, object result = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (result is CancellationToken)
@@ -106,6 +132,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             }
         }
 
+        /// <summary>
+        /// Builds the compute Id for the dialog.
+        /// </summary>
+        /// <returns>A string representing the compute Id.</returns>
         protected override string OnComputeId()
         {
             return $"{this.GetType().Name}({this.Value?.ToString() ?? string.Empty})";

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/EndTurn.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/EndTurn.cs
@@ -15,9 +15,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class EndTurn : Dialog
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.EndTurn";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EndTurn"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public EndTurn([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base()
@@ -36,8 +44,16 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         /// A boolean expression. 
         /// </value>
         [JsonProperty("disabled")]
-        public BoolExpression Disabled { get; set; } 
+        public BoolExpression Disabled { get; set; }
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options is CancellationToken)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ForEach.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ForEach.cs
@@ -16,9 +16,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class Foreach : ActionScope
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.Foreach";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Foreach"/> class.
+        /// </summary>
+        /// <param name="sourceFilePath">Optional, full path of the source file that contains the caller.</param>
+        /// <param name="sourceLineNumber">optional, line number in the source file at which the method is called.</param>
         [JsonConstructor]
         public Foreach([CallerFilePath] string sourceFilePath = "", [CallerLineNumber] int sourceLineNumber = 0)
             : base()
@@ -65,6 +73,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         [JsonProperty("value")]
         public StringExpression Value { get; set; } = "dialog.foreach.value";
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options is CancellationToken)
@@ -81,21 +97,55 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             return await this.NextItemAsync(dc, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Called when a returning control to this dialog with an <see cref="ActionScopeResult"/>
+        /// with the property ActionCommand set to <c>BreakLoop</c>.
+        /// </summary>
+        /// <param name="dc">The dialog context for the current turn of the conversation.</param>
+        /// <param name="actionScopeResult">Contains the actions scope result.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override async Task<DialogTurnResult> OnBreakLoopAsync(DialogContext dc, ActionScopeResult actionScopeResult, CancellationToken cancellationToken = default)
         {
             return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Called when a returning control to this dialog with an <see cref="ActionScopeResult"/>
+        /// with the property ActionCommand set to <c>ContinueLoop</c>.
+        /// </summary>
+        /// <param name="dc">The dialog context for the current turn of the conversation.</param>
+        /// <param name="actionScopeResult">Contains the actions scope result.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override async Task<DialogTurnResult> OnContinueLoopAsync(DialogContext dc, ActionScopeResult actionScopeResult, CancellationToken cancellationToken = default)
         {
             return await this.NextItemAsync(dc, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Called when the dialog's action ends.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="result">Optional, value returned from the dialog that was called. The type
+        /// of the value returned is dependent on the child dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override async Task<DialogTurnResult> OnEndOfActionsAsync(DialogContext dc, object result = null, CancellationToken cancellationToken = default)
         {
             return await this.NextItemAsync(dc, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Calls the next item in the stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected virtual async Task<DialogTurnResult> NextItemAsync(DialogContext dc, CancellationToken cancellationToken = default)
         {
             // Get list information
@@ -119,6 +169,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             }
         }
 
+        /// <summary>
+        /// Builds the compute Id for the dialog.
+        /// </summary>
+        /// <returns>A string representing the compute Id.</returns>
         protected override string OnComputeId()
         {
             return $"{this.GetType().Name}({this.ItemsProperty?.ToString()})";

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ForEachPage.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ForEachPage.cs
@@ -19,9 +19,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class ForeachPage : ActionScope
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.ForeachPage";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ForeachPage"/> class.
+        /// </summary>
+        /// <param name="sourceFilePath">Optional, full path of the source file that contains the caller.</param>
+        /// <param name="sourceLineNumber">optional, line number in the source file at which the method is called.</param>
         [JsonConstructor]
         public ForeachPage([CallerFilePath] string sourceFilePath = "", [CallerLineNumber] int sourceLineNumber = 0)
             : base()
@@ -41,21 +49,42 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         [JsonProperty("disabled")]
         public BoolExpression Disabled { get; set; }
 
-        // Expression used to compute the list that should be enumerated.
+        /// <summary>
+        /// Gets or sets the item properties list.
+        /// </summary>
+        /// <value>Expression used to compute the item property list that should be enumerated.</value>
         [JsonProperty("itemsProperty")]
         public StringExpression ItemsProperty { get; set; }
 
-        // Expression used to compute the list that should be enumerated.
+        /// <summary>
+        /// Gets or sets the pages list.
+        /// </summary>
+        /// <value>Expression used to compute the pages list that should be enumerated.</value>.
         [JsonProperty("page")]
         public StringExpression Page { get; set; } = "dialog.foreach.page";
 
-        // Expression used to compute the list that should be enumerated.
+        /// <summary>
+        /// Gets or sets the page indexes list.
+        /// </summary>
+        /// <value>Expression used to compute the page indexes list that should be enumerated.</value>.
         [JsonProperty("pageIndex")]
         public StringExpression PageIndex { get; set; } = "dialog.foreach.pageindex";
 
+        /// <summary>
+        /// Gets or sets the page size.
+        /// </summary>
+        /// <value><see cref="IntExpression"/> with the size of the page.</value>.
         [JsonProperty("pageSize")]
         public IntExpression PageSize { get; set; } = 10;
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options is CancellationToken)
@@ -72,21 +101,53 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             return await NextPageAsync(dc, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Called when the dialog's action ends.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="result">Optional, value returned from the dialog that was called. The type
+        /// of the value returned is dependent on the child dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override async Task<DialogTurnResult> OnEndOfActionsAsync(DialogContext dc, object result = null, CancellationToken cancellationToken = default)
         {
             return await NextPageAsync(dc, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Called when a returning control to this dialog with an <see cref="ActionScopeResult"/>
+        /// with the property ActionCommand set to <c>BreakLoop</c>.
+        /// </summary>
+        /// <param name="dc">The dialog context for the current turn of the conversation.</param>
+        /// <param name="actionScopeResult">Contains the actions scope result.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override async Task<DialogTurnResult> OnBreakLoopAsync(DialogContext dc, ActionScopeResult actionScopeResult, CancellationToken cancellationToken = default)
         {
             return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Called when a returning control to this dialog with an <see cref="ActionScopeResult"/>
+        /// with the property ActionCommand set to <c>ContinueLoop</c>.
+        /// </summary>
+        /// <param name="dc">The dialog context for the current turn of the conversation.</param>
+        /// <param name="actionScopeResult">Contains the actions scope result.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <remarks>Default is to simply end the dialog and propagate to parent to handle.</remarks>
         protected override async Task<DialogTurnResult> OnContinueLoopAsync(DialogContext dc, ActionScopeResult actionScopeResult, CancellationToken cancellationToken = default)
         {
             return await this.NextPageAsync(dc, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Builds the compute Id for the dialog.
+        /// </summary>
+        /// <returns>A string representing the compute Id.</returns>
         protected override string OnComputeId()
         {
             return $"{this.GetType().Name}({this.ItemsProperty?.ToString()})";

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/GetActivityMembers.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/GetActivityMembers.cs
@@ -15,9 +15,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class GetActivityMembers : Dialog
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.GetActivityMembers";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GetActivityMembers"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public GetActivityMembers([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base()
@@ -55,6 +63,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         [JsonProperty("activityId")]
         public StringExpression ActivityId { get; set; }
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options is CancellationToken)
@@ -92,6 +108,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             return await dc.EndDialogAsync(result, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Builds the compute Id for the dialog.
+        /// </summary>
+        /// <returns>A string representing the compute Id.</returns>
         protected override string OnComputeId()
         {
             return $"{this.GetType().Name}[{this.ActivityId?.ToString() ?? string.Empty},{this.Property?.ToString() ?? string.Empty}]";

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/GetConversationMembers.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/GetConversationMembers.cs
@@ -15,9 +15,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class GetConversationMembers : Dialog
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.GetConversationMembers";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GetConversationMembers"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public GetConversationMembers([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base()
@@ -46,6 +54,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         [JsonProperty("property")]
         public StringExpression Property { get; set; }
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options is CancellationToken)
@@ -74,6 +90,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             return await dc.EndDialogAsync(result, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Builds the compute Id for the dialog.
+        /// </summary>
+        /// <returns>A string representing the compute Id.</returns>
         protected override string OnComputeId()
         {
             return $"{this.GetType().Name}[{this.Property?.ToString() ?? string.Empty}]";

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/GotoAction.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/GotoAction.cs
@@ -15,9 +15,18 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class GotoAction : Dialog
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.GotoAction";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GotoAction"/> class.
+        /// </summary>
+        /// <param name="actionId">Optional, action's unique identifier.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         public GotoAction(string actionId = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
         {
             this.RegisterSourceLocation(callerPath, callerLine);
@@ -40,8 +49,16 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         /// A boolean expression. 
         /// </value>
         [JsonProperty("disabled")]
-        public BoolExpression Disabled { get; set; } 
+        public BoolExpression Disabled { get; set; }
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options is CancellationToken)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/HttpRequest.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/HttpRequest.cs
@@ -27,9 +27,21 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class HttpRequest : Dialog
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.HttpRequest";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HttpRequest"/> class.
+        /// </summary>
+        /// <param name="method">The HTTP method, for example POST, GET, DELETE or PUT.</param>
+        /// <param name="url">URL for the request.</param>
+        /// <param name="headers">Optional, the headers of the request.</param>
+        /// <param name="body">Optional, the raw body of the request.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         public HttpRequest(HttpMethod method, string url, Dictionary<string, StringExpression> headers = null, object body = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
         {
             this.RegisterSourceLocation(callerPath, callerLine);
@@ -39,6 +51,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             this.Body = JToken.FromObject(body);
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HttpRequest"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public HttpRequest([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base()
@@ -46,6 +63,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             this.RegisterSourceLocation(callerPath, callerLine);
         }
 
+        /// <summary>
+        /// List of possible response types.
+        /// </summary>
 #pragma warning disable CA1717 // Only FlagsAttribute enums should have plural names (we can't change this without breaking binary compat).
         public enum ResponseTypes
 #pragma warning restore CA1717 // Only FlagsAttribute enums should have plural names
@@ -188,6 +208,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         [JsonProperty("resultProperty")]
         public StringExpression ResultProperty { get; set; }
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options is CancellationToken)
@@ -377,6 +405,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             return await dc.EndDialogAsync(result: requestResult, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Builds the compute Id for the dialog.
+        /// </summary>
+        /// <returns>A string representing the compute Id.</returns>
         protected override string OnComputeId()
         {
             return $"{this.GetType().Name}[{Method} {Url?.ToString()}]";
@@ -389,10 +421,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         public class Result
 #pragma warning restore CA1034 // Nested types should not be visible
         {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="Result"/> class.
+            /// </summary>
             public Result()
             {
             }
 
+            /// <summary>
+            /// Initializes a new instance of the <see cref="Result"/> class.
+            /// </summary>
+            /// <param name="headers">HTTP headers from the response to the http operation.</param>
             public Result(HttpHeaders headers)
             {
                 this.Headers = headers.ToDictionary(t => t.Key, t => t.Value.First());

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/IfCondition.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/IfCondition.cs
@@ -17,12 +17,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class IfCondition : Dialog, IDialogDependencies
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.IfCondition";
 
         private ActionScope trueScope;
         private ActionScope falseScope;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IfCondition"/> class.
+        /// </summary>
+        /// <param name="sourceFilePath">Optional, source file full path.</param>
+        /// <param name="sourceLineNumber">Optional, line number in source file.</param>
         [JsonConstructor]
         public IfCondition([CallerFilePath] string sourceFilePath = "", [CallerLineNumber] int sourceLineNumber = 0)
             : base()
@@ -54,16 +62,28 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         [JsonProperty("disabled")]
         public BoolExpression Disabled { get; set; }
 
+        /// <summary>
+        /// Gets or sets the list of actions.
+        /// </summary>
+        /// <value>A <see cref="List{T}"/> of Dialog actions.</value>
         [JsonProperty("actions")]
 #pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public List<Dialog> Actions { get; set; } = new List<Dialog>();
 #pragma warning restore CA2227 // Collection properties should be read only
 
+        /// <summary>
+        /// Gets or sets a list actions for false scope.
+        /// </summary>
+        /// <value>A <see cref="List{T}"/> of Dialog actions.</value>
         [JsonProperty("elseActions")]
 #pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public List<Dialog> ElseActions { get; set; } = new List<Dialog>();
 #pragma warning restore CA2227 // Collection properties should be read only
 
+        /// <summary>
+        /// Gets the true scope.
+        /// </summary>
+        /// <value>An <see cref="ActionScope"/> with the action scope.</value>
         protected ActionScope TrueScope
         {
             get
@@ -77,6 +97,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             }
         }
 
+        /// <summary>
+        /// Gets the false scope.
+        /// </summary>
+        /// <value>An <see cref="ActionScope"/> with the action scope.</value>
         protected ActionScope FalseScope
         {
             get
@@ -90,12 +114,24 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             }
         }
 
+        /// <summary>
+        /// Enumerate child dialog dependencies so they can be added to the containers dialog set.
+        /// </summary>
+        /// <returns>Dialog enumeration.</returns>
         public virtual IEnumerable<Dialog> GetDependencies()
         {
             yield return this.TrueScope;
             yield return this.FalseScope;
         }
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options is CancellationToken)
@@ -123,6 +159,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Builds the compute Id for the dialog.
+        /// </summary>
+        /// <returns>A string representing the compute Id.</returns>
         protected override string OnComputeId()
         {
             var idList = Actions.Select(s => s.Id);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/LogAction.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/LogAction.cs
@@ -18,9 +18,18 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class LogAction : Dialog
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.LogAction";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LogAction"/> class.
+        /// </summary>
+        /// <param name="text">Optional, LG expression to log.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public LogAction(string text = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
         {
@@ -68,6 +77,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         [JsonProperty]
         public StringExpression Label { get; set; }
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options is CancellationToken)
@@ -100,6 +117,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Builds the compute Id for the dialog.
+        /// </summary>
+        /// <returns>A string representing the compute Id.</returns>
         protected override string OnComputeId()
         {
             return $"{this.GetType().Name}({Text?.ToString()})";

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/RepeatDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/RepeatDialog.cs
@@ -16,9 +16,18 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class RepeatDialog : BaseInvokeDialog
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.RepeatDialog";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RepeatDialog"/> class.
+        /// </summary>
+        /// <param name="options">Optional, object with additional options.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public RepeatDialog(object options = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(null, options)
@@ -48,8 +57,16 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         /// A boolean expression. 
         /// </value>
         [JsonProperty("disabled")]
-        public BoolExpression Disabled { get; set; } 
+        public BoolExpression Disabled { get; set; }
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options is CancellationToken)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ReplaceDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ReplaceDialog.cs
@@ -15,9 +15,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class ReplaceDialog : BaseInvokeDialog
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.ReplaceDialog";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReplaceDialog"/> class.
+        /// </summary>
+        /// <param name="dialogIdToCall">Optional, id of the dialog to call.</param>
+        /// <param name="options">Optional, configurable options for the dialog.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public ReplaceDialog(string dialogIdToCall = null, object options = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(dialogIdToCall, options)
@@ -37,6 +47,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         [JsonProperty("disabled")]
         public BoolExpression Disabled { get; set; }
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options is CancellationToken)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SendActivity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SendActivity.cs
@@ -19,15 +19,30 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class SendActivity : Dialog
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.SendActivity";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SendActivity"/> class.
+        /// </summary>
+        /// <param name="activity"><see cref="Activity"/> to send.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         public SendActivity(Activity activity, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
         {
             this.RegisterSourceLocation(callerPath, callerLine);
             this.Activity = new StaticActivityTemplate(activity);
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SendActivity"/> class.
+        /// </summary>
+        /// <param name="text">Optional, template to evaluate to create the activity.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public SendActivity(string text = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
         {
@@ -56,6 +71,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         [JsonProperty("activity")]
         public ITemplate<Activity> Activity { get; set; }
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options is CancellationToken)
@@ -90,6 +113,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             return await dc.EndDialogAsync(response, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Builds the compute Id for the dialog.
+        /// </summary>
+        /// <returns>A string representing the compute Id.</returns>
         protected override string OnComputeId()
         {
             if (Activity is ActivityTemplate at)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SetProperties.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SetProperties.cs
@@ -17,9 +17,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class SetProperties : Dialog
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.SetProperties";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SetProperties"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public SetProperties([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base()
@@ -50,6 +58,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         public List<PropertyAssignment> Assignments { get; set; } = new List<PropertyAssignment>();
 #pragma warning restore CA2227 // Collection properties should be read only
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options is CancellationToken)
@@ -84,6 +100,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Builds the compute Id for the dialog.
+        /// </summary>
+        /// <returns>A string representing the compute Id.</returns>
         protected override string OnComputeId()
         {
             return $"{this.GetType().Name}[{StringUtils.Ellipsis(string.Join(",", this.Assignments), 50)}]";

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SetProperty.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SetProperty.cs
@@ -16,9 +16,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class SetProperty : Dialog
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.SetProperty";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SetProperty"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public SetProperty([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base()
@@ -56,6 +64,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         [JsonProperty("value")]
         public ValueExpression Value { get; set; }
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options is CancellationToken)
@@ -92,6 +108,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Builds the compute Id for the dialog.
+        /// </summary>
+        /// <returns>A string representing the compute Id.</returns>
         protected override string OnComputeId()
         {
             return $"{this.GetType().Name}[{this.Property?.ToString() ?? string.Empty}]";

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SignOutUser.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SignOutUser.cs
@@ -15,9 +15,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class SignOutUser : Dialog
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.SignOutUser";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SignOutUser"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public SignOutUser([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
         {
@@ -50,6 +58,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         [JsonProperty("connectionName")]
         public StringExpression ConnectionName { get; set; }
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options is CancellationToken)
@@ -75,6 +91,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Builds the compute Id for the dialog.
+        /// </summary>
+        /// <returns>A string representing the compute Id.</returns>
         protected override string OnComputeId()
         {
             return $"{this.GetType().Name}({ConnectionName?.ToString()}, {UserId?.ToString()})";

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SwitchCondition.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SwitchCondition.cs
@@ -17,6 +17,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class SwitchCondition : Dialog, IDialogDependencies
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.SwitchCondition";
 
@@ -24,6 +27,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 
         private ActionScope defaultScope;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SwitchCondition"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public SwitchCondition([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base()
@@ -74,6 +82,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         public List<Case> Cases { get; set; } = new List<Case>();
 #pragma warning restore CA2227 // Collection properties should be read only
 
+        /// <summary>
+        /// Gets the default scope.
+        /// </summary>
+        /// <value>An <see cref="ActionScope"/> with the scope.</value>
         protected ActionScope DefaultScope
         {
             get
@@ -87,6 +99,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             }
         }
 
+        /// <summary>
+        /// Enumerate child dialog dependencies so they can be added to the containers dialog set.
+        /// </summary>
+        /// <returns>Dialog enumeration.</returns>
         public virtual IEnumerable<Dialog> GetDependencies()
         {
             yield return this.DefaultScope;
@@ -100,6 +116,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             }
         }
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options is CancellationToken)
@@ -169,6 +193,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             return await dc.ReplaceDialogAsync(actionScope.Id, null, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Builds the compute Id for the dialog.
+        /// </summary>
+        /// <returns>A string representing the compute Id.</returns>
         protected override string OnComputeId()
         {
             return $"{this.GetType().Name}({this.Condition?.ToString()})";

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/TelemetryTrackEventAction.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/TelemetryTrackEventAction.cs
@@ -17,9 +17,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class TelemetryTrackEventAction : Dialog
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.TelemetryTrackEventAction";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TelemetryTrackEventAction"/> class.
+        /// </summary>
+        /// <param name="eventName">Name to use for the event.</param>
+        /// <param name="properties">Optional, properties to attach to the tracked event.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public TelemetryTrackEventAction(string eventName, Dictionary<string, StringExpression> properties = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
         {
@@ -58,6 +68,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         public Dictionary<string, StringExpression> Properties { get; set; }
 #pragma warning restore CA2227 // Collection properties should be read only
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options is CancellationToken)
@@ -80,6 +98,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Builds the compute Id for the dialog.
+        /// </summary>
+        /// <returns>A string representing the compute Id.</returns>
         protected override string OnComputeId()
         {
             return $"{this.GetType().Name}({EventName?.ToString()})";

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/TraceActivity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/TraceActivity.cs
@@ -16,9 +16,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class TraceActivity : Dialog
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.TraceActivity";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TraceActivity"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public TraceActivity([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
         {
@@ -69,8 +77,16 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         /// </summary>
         /// <value>The label to use. (default will use Name or parent dialog.id).</value>
         [JsonProperty]
-        public StringExpression Label { get; set; } 
+        public StringExpression Label { get; set; }
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options is CancellationToken)
@@ -108,6 +124,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             return await dc.EndDialogAsync(traceActivity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Builds the compute Id for the dialog.
+        /// </summary>
+        /// <returns>A string representing the compute Id.</returns>
         protected override string OnComputeId()
         {
             return $"{this.GetType().Name}({Name?.ToString()})";

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/UpdateActivity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/UpdateActivity.cs
@@ -18,15 +18,30 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public class UpdateActivity : Dialog
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.UpdateActivity";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UpdateActivity"/> class.
+        /// </summary>
+        /// <param name="activity">Replacement <see cref="Activity"/>.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         public UpdateActivity(Activity activity, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
         {
             this.RegisterSourceLocation(callerPath, callerLine);
             this.Activity = new StaticActivityTemplate(activity);
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UpdateActivity"/> class.
+        /// </summary>
+        /// <param name="text">Optional, the template to evaluate to create the replacement activity.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public UpdateActivity(string text = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
         {
@@ -62,6 +77,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         [JsonProperty("activityId")]
         public StringExpression ActivityId { get; set; }
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options is CancellationToken)
@@ -96,6 +119,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             return await dc.EndDialogAsync(response, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Builds the compute Id for the dialog.
+        /// </summary>
+        /// <returns>A string representing the compute Id.</returns>
         protected override string OnComputeId()
         {
             if (Activity is ActivityTemplate at)


### PR DESCRIPTION
Adresses # 4321

## Description
This PR adds the missing XML documentation to all all visible classes, methods, properties and parameters in [Bot.Builder.Dialogs.Adaptive/Actions](https://github.com/microsoft/botbuilder-dotnet/tree/main/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions), removing 182 errors.

Note: the NoWarn property is removed in the last PR of the series adding the documentation to avoid build failures.

## Testing
Below you can see the amount of errors shown before and after the changes, when de NoWarn-CS1591 property is removed.
![image](https://user-images.githubusercontent.com/38112957/92276954-5c70fd00-eec8-11ea-8428-641ee6a95002.png)
