### PR TITLE
Migrate Microsoft.Bot.Builder.Dialogs.Declarative.Tests project to xUnit

### DIFF
--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/JsonLoadFixture.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/JsonLoadFixture.cs
@@ -1,0 +1,27 @@
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System;
+using System.IO;
+using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
+
+namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
+{
+    public class JsonLoadFixture : IDisposable
+    {
+        public JsonLoadFixture()
+        {
+            var projPath = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, PathUtils.NormalizePath($@"..\..\..\..\..\tests\Microsoft.Bot.Builder.TestBot.Json\Microsoft.Bot.Builder.TestBot.Json.csproj")));
+            
+            ResourceExplorer = new ResourceExplorer()
+                .LoadProject(projPath, monitorChanges: false);
+        }
+
+        public ResourceExplorer ResourceExplorer { get; set; }
+
+        public void Dispose()
+        {
+            ResourceExplorer.Dispose();
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/JsonLoadTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/JsonLoadTests.cs
@@ -1,34 +1,25 @@
 ﻿// Licensed under the MIT License.
 // Copyright (c) Microsoft Corporation. All rights reserved.
 
-using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Builder.AI.QnA;
 using Microsoft.Bot.Builder.AI.QnA.Dialogs;
 using Microsoft.Bot.Builder.Dialogs.Adaptive;
-using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Bot.Schema;
 using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
 {
-    public class JsonLoadTests : IDisposable
+    public class JsonLoadTests : IClassFixture<JsonLoadFixture>
     {
-        private static ResourceExplorer _resourceExplorer;
+        // private static ResourceExplorer _resourceExplorer;
+        private readonly JsonLoadFixture _jsonLoadFixture;
 
-        public JsonLoadTests()
+        public JsonLoadTests(JsonLoadFixture jsonLoadFixture)
         {
-            var projPath = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, PathUtils.NormalizePath($@"..\..\..\..\..\tests\Microsoft.Bot.Builder.TestBot.Json\Microsoft.Bot.Builder.TestBot.Json.csproj")));
-            _resourceExplorer = new ResourceExplorer()
-                .LoadProject(projPath, monitorChanges: false);
-        }
-
-        public void Dispose()
-        {
-            _resourceExplorer.Dispose();
+            _jsonLoadFixture = jsonLoadFixture;
         }
 
         [Fact]
@@ -389,7 +380,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
         private TestFlow BuildQnAMakerTestFlow(string testName)
         {
             var adapter = InitializeAdapter(testName);
-            var dialog = _resourceExplorer.LoadType<AdaptiveDialog>("QnAMakerBot.main.dialog");
+            var dialog = _jsonLoadFixture.ResourceExplorer.LoadType<AdaptiveDialog>("QnAMakerBot.main.dialog");
             var qnaMakerDialog = (QnAMakerDialog)dialog.Triggers[0].Actions[0];
 
             dialog.Triggers[0].Actions[0] = qnaMakerDialog;
@@ -400,7 +391,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
         private TestFlow BuildQnAMakerTestFlow_IsTest_True(string testName)
         {
             var adapter = InitializeAdapter(testName);
-            var dialog = _resourceExplorer.LoadType<AdaptiveDialog>("QnAMakerBot.main.dialog");
+            var dialog = _jsonLoadFixture.ResourceExplorer.LoadType<AdaptiveDialog>("QnAMakerBot.main.dialog");
             var qnaMakerDialog = (QnAMakerDialog)dialog.Triggers[0].Actions[0];
             qnaMakerDialog.IsTest = true;
             dialog.Triggers[0].Actions[0] = qnaMakerDialog;
@@ -411,7 +402,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
         private TestFlow BuildQnAMakerTestFlow_RankerType_QuestionOnly(string testName)
         {
             var adapter = InitializeAdapter(testName);
-            var dialog = _resourceExplorer.LoadType<AdaptiveDialog>("QnAMakerBot.main.dialog");
+            var dialog = _jsonLoadFixture.ResourceExplorer.LoadType<AdaptiveDialog>("QnAMakerBot.main.dialog");
             var qnAMakerDialog = (QnAMakerDialog)dialog.Triggers[0].Actions[0];
             var qnaMakerDialog = qnAMakerDialog;
             qnaMakerDialog.RankerType = RankerTypes.QuestionOnly;
@@ -437,7 +428,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
         private TestFlow GetTestFlow(Dialog dialog, TestAdapter adapter)
         {
             var dm = new DialogManager(dialog)
-                .UseResourceExplorer(_resourceExplorer)
+                .UseResourceExplorer(_jsonLoadFixture.ResourceExplorer)
                 .UseLanguageGeneration();
             dm.InitialTurnState.Add<IQnAMakerClient>(new MockQnAMakerClient());
 
@@ -450,7 +441,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
         private TestFlow BuildTestFlow(string resourceName, string testName, bool sendTrace = false)
         {
             var adapter = InitializeAdapter(testName, sendTrace);
-            var dialog = _resourceExplorer.LoadType<Dialog>(resourceName);
+            var dialog = _jsonLoadFixture.ResourceExplorer.LoadType<Dialog>(resourceName);
             return GetTestFlow(dialog, adapter);
         }
     }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/JsonLoadTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/JsonLoadTests.cs
@@ -11,35 +11,30 @@ using Microsoft.Bot.Builder.AI.QnA.Dialogs;
 using Microsoft.Bot.Builder.Dialogs.Adaptive;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Bot.Schema;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
 {
-    [TestClass]
-    public class JsonLoadTests
+    public class JsonLoadTests : IDisposable
     {
-        private static ResourceExplorer resourceExplorer;
+        private static ResourceExplorer _resourceExplorer;
 
-        public TestContext TestContext { get; set; }
-
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext context)
+        public JsonLoadTests()
         {
-            string projPath = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, PathUtils.NormalizePath($@"..\..\..\..\..\tests\Microsoft.Bot.Builder.TestBot.Json\Microsoft.Bot.Builder.TestBot.Json.csproj")));
-            resourceExplorer = new ResourceExplorer()
+            var projPath = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, PathUtils.NormalizePath($@"..\..\..\..\..\tests\Microsoft.Bot.Builder.TestBot.Json\Microsoft.Bot.Builder.TestBot.Json.csproj")));
+            _resourceExplorer = new ResourceExplorer()
                 .LoadProject(projPath, monitorChanges: false);
         }
 
-        [ClassCleanup]
-        public static void ClassCleanup()
+        public void Dispose()
         {
-            resourceExplorer.Dispose();
+            _resourceExplorer.Dispose();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task JsonDialogLoad_DoubleReference()
         {
-            await BuildTestFlow(@"DoubleReference.dialog")
+            await BuildTestFlow(@"DoubleReference.dialog", nameof(JsonDialogLoad_DoubleReference))
                 .SendConversationUpdate()
                 .AssertReply("what is your name?")
                 .Send("c")
@@ -47,10 +42,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task JsonDialogLoad_CycleDetection()
         {
-            await BuildTestFlow(@"Root.dialog")
+            await BuildTestFlow(@"Root.dialog", nameof(JsonDialogLoad_CycleDetection))
                 .SendConversationUpdate()
                 .AssertReply("Hello")
                 .Send("Hello what?")
@@ -60,10 +55,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task JsonDialogLoad_Actions()
         {
-            await BuildTestFlow(@"Actions.main.dialog")
+            await BuildTestFlow(@"Actions.main.dialog", nameof(JsonDialogLoad_Actions))
                 .SendConversationUpdate()
                 .AssertReply("Action 1")
                 .AssertReply("Action 2")
@@ -71,10 +66,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task JsonDialogLoad_EndTurn()
         {
-            await BuildTestFlow("EndTurn.main.dialog")
+            await BuildTestFlow("EndTurn.main.dialog", nameof(JsonDialogLoad_EndTurn))
             .Send("hello")
                 .AssertReply("What's up?")
             .Send("Nothing")
@@ -82,10 +77,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task JsonDialogLoad_IfProperty()
         {
-            await BuildTestFlow("IfCondition.main.dialog")
+            await BuildTestFlow("IfCondition.main.dialog", nameof(JsonDialogLoad_IfProperty))
             .SendConversationUpdate()
             .AssertReply("Hello, I'm Zoidberg. What is your name?")
             .Send("Carlos")
@@ -93,19 +88,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task JsonDialogLoad_SwitchCondition_Number()
         {
-            await BuildTestFlow("SwitchCondition.main.dialog")
+            await BuildTestFlow("SwitchCondition.main.dialog", nameof(JsonDialogLoad_SwitchCondition_Number))
             .Send("Hi")
             .AssertReply("Age is 22!")
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task JsonDialogLoad_TextInputWithoutProperty()
         {
-            await BuildTestFlow("TextInput.WithoutProperty.main.dialog")
+            await BuildTestFlow("TextInput.WithoutProperty.main.dialog", nameof(JsonDialogLoad_TextInputWithoutProperty))
             .SendConversationUpdate()
                 .AssertReply("Hello, I'm Zoidberg. What is your name?")
             .Send("Carlos")
@@ -113,10 +108,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
                 .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task JsonDialogLoad_TextInput()
         {
-            await BuildTestFlow("TextInput.main.dialog")
+            await BuildTestFlow("TextInput.main.dialog", nameof(JsonDialogLoad_TextInput))
             .SendConversationUpdate()
                 .AssertReply("Hello, I'm Zoidberg. What is your name?")
             .Send("Cancel")
@@ -130,10 +125,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
                 .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task JsonDialogLoad_NumberInput()
         {
-            await BuildTestFlow("NumberInput.main.dialog")
+            await BuildTestFlow("NumberInput.main.dialog", nameof(JsonDialogLoad_NumberInput))
             .SendConversationUpdate()
                 .AssertReply("What is your age?")
             .Send("Blablabla")
@@ -146,10 +141,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
                 .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task JsonDialogLoad_RepeatDialog()
         {
-            await BuildTestFlow("RepeatDialog.main.dialog")
+            await BuildTestFlow("RepeatDialog.main.dialog", nameof(JsonDialogLoad_RepeatDialog))
             .SendConversationUpdate()
                 .AssertReply("RepeatDialog.main.dialog starting")
                 .AssertReply("Hello, what is your name?")
@@ -161,34 +156,34 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task JsonDialogLoad_TraceAndLog()
         {
-            await BuildTestFlow("TraceAndLog.main.dialog", sendTrace: true)
+            await BuildTestFlow("TraceAndLog.main.dialog", nameof(JsonDialogLoad_TraceAndLog), true)
             .SendConversationUpdate()
                 .AssertReply("Hello, what is your name?")
             .Send("Carlos")
                 .AssertReply(activity =>
                 {
                     var trace = (Activity)activity;
-                    Assert.AreEqual("https://www.botframework.com/schemas/botState", trace.ValueType, "value type should be memory");
-                    Assert.AreEqual(ActivityTypes.Trace, trace.Type, "should be trace of memory dumpactivity");
+                    Assert.Equal("https://www.botframework.com/schemas/botState", trace.ValueType);
+                    Assert.Equal(ActivityTypes.Trace, trace.Type);
                 })
                 .AssertReply(activity =>
                 {
                     var trace = (Activity)activity;
-                    Assert.AreEqual(ActivityTypes.Trace, trace.Type, "should be trace activity");
-                    Assert.AreEqual("memory", trace.ValueType, "value type should be memory");
-                    Assert.AreEqual("Carlos", (string)((dynamic)trace.Value)["name"], "value should be user object with name='Carlos'");
+                    Assert.Equal(ActivityTypes.Trace, trace.Type);
+                    Assert.Equal("memory", trace.ValueType);
+                    Assert.Equal("Carlos", (string)((dynamic)trace.Value)["name"]);
                 })
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task JsonDialogLoad_DoActions()
         {
-            await BuildTestFlow("DoActions.main.dialog")
-            .Send(new Activity(ActivityTypes.ConversationUpdate, membersAdded: new List<ChannelAccount>() { new ChannelAccount("bot", "Bot") }))
+            await BuildTestFlow("DoActions.main.dialog", nameof(JsonDialogLoad_DoActions))
+            .Send(new Activity(ActivityTypes.ConversationUpdate, membersAdded: new List<ChannelAccount> { new ChannelAccount("bot", "Bot") }))
             .SendConversationUpdate()
                 .AssertReply("Hello, I'm Zoidberg. What is your name?")
             .Send("Carlos")
@@ -205,13 +200,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task JsonDialogLoad_BeginDialog()
         {
-            await BuildTestFlow("BeginDialog.main.dialog")
+            await BuildTestFlow("BeginDialog.main.dialog", nameof(JsonDialogLoad_BeginDialog))
             .Send(new Activity(
                 ActivityTypes.ConversationUpdate,
-                membersAdded: new List<ChannelAccount>() { new ChannelAccount("bot", "Bot") }))
+                membersAdded: new List<ChannelAccount> { new ChannelAccount("bot", "Bot") }))
             .SendConversationUpdate()
                 .AssertReply("Hello, I'm Zoidberg. What is your name?")
             .Send("Carlos")
@@ -228,10 +223,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task JsonDialogLoad_ChoiceInputDialog()
         {
-            await BuildTestFlow("ChoiceInput.main.dialog")
+            await BuildTestFlow("ChoiceInput.main.dialog", nameof(JsonDialogLoad_ChoiceInputDialog))
             .SendConversationUpdate()
                 .AssertReply("Please select a value from below:\n\n   1. Test1\n   2. Test2\n   3. Test3")
             .Send("Test1")
@@ -239,10 +234,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task JsonDialogLoad_ExternalLanguage()
         {
-            await BuildTestFlow("ExternalLanguage.main.dialog")
+            await BuildTestFlow("ExternalLanguage.main.dialog", nameof(JsonDialogLoad_ExternalLanguage))
             .SendConversationUpdate()
                 .AssertReplyOneOf(new string[]
                 {
@@ -274,10 +269,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task JsonDialogLoad_ToDoBot()
         {
-            await BuildTestFlow("ToDoBot.main.dialog")
+            await BuildTestFlow("ToDoBot.main.dialog", nameof(JsonDialogLoad_ToDoBot))
             .Send(new Activity(ActivityTypes.ConversationUpdate, membersAdded: new List<ChannelAccount>() { new ChannelAccount("bot", "Bot") }))
             .SendConversationUpdate()
                 .AssertReply("Hi! I'm a ToDo bot. Say \"add a todo named first\" to get started.")
@@ -310,10 +305,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task JsonDialogLoad_HttpRequest()
         {
-            await BuildTestFlow("HttpRequest.main.dialog")
+            await BuildTestFlow("HttpRequest.main.dialog", nameof(JsonDialogLoad_HttpRequest))
             .Send(new Activity(ActivityTypes.ConversationUpdate, membersAdded: new List<ChannelAccount>() { new ChannelAccount("bot", "Bot") }))
             .AssertReply("Welcome! Here is a http request sample, please enter a name for you visual pet.")
             .Send("TestPetName")
@@ -327,14 +322,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task JsonDialogLoad_QnAMakerDialog_ActiveLearning_WithProperResponse()
         {
             var suggestionList = new List<string> { "Q1", "Q2", "Q3" };
             var suggestionActivity = QnACardBuilder.GetSuggestionsCard(suggestionList, "Did you mean:", "None of the above.");
             var qnAMakerCardEqualityComparer = new QnAMakerCardEqualityComparer();
 
-            await BuildQnAMakerTestFlow()
+            await BuildQnAMakerTestFlow(nameof(JsonDialogLoad_QnAMakerDialog_ActiveLearning_WithProperResponse))
             .Send("Q11")
                 .AssertReply(suggestionActivity, equalityComparer: qnAMakerCardEqualityComparer)
             .Send("Q1")
@@ -342,15 +337,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task JsonDialogLoad_QnAMakerDialog_ActiveLearning_WithNoResponse()
         {
             var suggestionList = new List<string> { "Q1", "Q2", "Q3" };
             var suggestionActivity = QnACardBuilder.GetSuggestionsCard(suggestionList, "Did you mean:", "None of the above.");
             var qnAMakerCardEqualityComparer = new QnAMakerCardEqualityComparer();
-            var noAnswerActivity = "Answers not found in kb.";
+            const string noAnswerActivity = "Answers not found in kb.";
 
-            await BuildQnAMakerTestFlow()
+            await BuildQnAMakerTestFlow(nameof(JsonDialogLoad_QnAMakerDialog_ActiveLearning_WithNoResponse))
             .Send("Q11")
                 .AssertReply(suggestionActivity, equalityComparer: qnAMakerCardEqualityComparer)
             .Send("Q12")
@@ -358,14 +353,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task JsonDialogLoad_QnAMakerDialog_ActiveLearning_WithNoneOfAboveQuery()
         {
             var suggestionList = new List<string> { "Q1", "Q2", "Q3" };
             var suggestionActivity = QnACardBuilder.GetSuggestionsCard(suggestionList, "Did you mean:", "None of the above.");
             var qnAMakerCardEqualityComparer = new QnAMakerCardEqualityComparer();
 
-            await BuildQnAMakerTestFlow()
+            await BuildQnAMakerTestFlow(nameof(JsonDialogLoad_QnAMakerDialog_ActiveLearning_WithNoneOfAboveQuery))
             .Send("Q11")
                 .AssertReply(suggestionActivity, equalityComparer: qnAMakerCardEqualityComparer)
             .Send("None of the above.")
@@ -373,28 +368,28 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task JsonDialogLoad_QnAMakerDialog_IsTest_True()
         {
-            await BuildQnAMakerTestFlow_IsTest_True()
+            await BuildQnAMakerTestFlow_IsTest_True(nameof(JsonDialogLoad_QnAMakerDialog_IsTest_True))
             .Send("Surface book 2 price")
                 .AssertReply("Surface book 2 price is $1400.")
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task JsonDialogLoad_QnAMakerDialog_RankerType_QuestionOnly()
         {
-            await BuildQnAMakerTestFlow_RankerType_QuestionOnly()
+            await BuildQnAMakerTestFlow_RankerType_QuestionOnly(nameof(JsonDialogLoad_QnAMakerDialog_RankerType_QuestionOnly))
             .Send("What ranker do you want to use?")
                 .AssertReply("We are using QuestionOnly ranker.")
             .StartTestAsync();
         }
 
-        private TestFlow BuildQnAMakerTestFlow()
+        private TestFlow BuildQnAMakerTestFlow(string testName)
         {
-            var adapter = InitializeAdapter();
-            var dialog = resourceExplorer.LoadType<AdaptiveDialog>("QnAMakerBot.main.dialog");
+            var adapter = InitializeAdapter(testName);
+            var dialog = _resourceExplorer.LoadType<AdaptiveDialog>("QnAMakerBot.main.dialog");
             var qnaMakerDialog = (QnAMakerDialog)dialog.Triggers[0].Actions[0];
 
             dialog.Triggers[0].Actions[0] = qnaMakerDialog;
@@ -402,10 +397,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
             return GetTestFlow(dialog, adapter);
         }
 
-        private TestFlow BuildQnAMakerTestFlow_IsTest_True()
+        private TestFlow BuildQnAMakerTestFlow_IsTest_True(string testName)
         {
-            var adapter = InitializeAdapter();
-            var dialog = resourceExplorer.LoadType<AdaptiveDialog>("QnAMakerBot.main.dialog");
+            var adapter = InitializeAdapter(testName);
+            var dialog = _resourceExplorer.LoadType<AdaptiveDialog>("QnAMakerBot.main.dialog");
             var qnaMakerDialog = (QnAMakerDialog)dialog.Triggers[0].Actions[0];
             qnaMakerDialog.IsTest = true;
             dialog.Triggers[0].Actions[0] = qnaMakerDialog;
@@ -413,10 +408,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
             return GetTestFlow(dialog, adapter);
         }
 
-        private TestFlow BuildQnAMakerTestFlow_RankerType_QuestionOnly()
+        private TestFlow BuildQnAMakerTestFlow_RankerType_QuestionOnly(string testName)
         {
-            var adapter = InitializeAdapter();
-            var dialog = resourceExplorer.LoadType<AdaptiveDialog>("QnAMakerBot.main.dialog");
+            var adapter = InitializeAdapter(testName);
+            var dialog = _resourceExplorer.LoadType<AdaptiveDialog>("QnAMakerBot.main.dialog");
             var qnAMakerDialog = (QnAMakerDialog)dialog.Triggers[0].Actions[0];
             var qnaMakerDialog = qnAMakerDialog;
             qnaMakerDialog.RankerType = RankerTypes.QuestionOnly;
@@ -425,12 +420,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
             return GetTestFlow(dialog, adapter);
         }
 
-        private TestAdapter InitializeAdapter(bool sendTrace = false)
+        private TestAdapter InitializeAdapter(string testName, bool sendTrace = false)
         {
             var storage = new MemoryStorage();
             var convoState = new ConversationState(storage);
             var userState = new UserState(storage);
-            var adapter = new TestAdapter(TestAdapter.CreateConversation(TestContext.TestName), sendTrace);
+            var adapter = new TestAdapter(TestAdapter.CreateConversation(testName), sendTrace);
             adapter
                 .UseStorage(storage)
                 .UseBotState(userState, convoState)
@@ -442,20 +437,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
         private TestFlow GetTestFlow(Dialog dialog, TestAdapter adapter)
         {
             var dm = new DialogManager(dialog)
-                .UseResourceExplorer(resourceExplorer)
+                .UseResourceExplorer(_resourceExplorer)
                 .UseLanguageGeneration();
             dm.InitialTurnState.Add<IQnAMakerClient>(new MockQnAMakerClient());
 
             return new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
-                await dm.OnTurnAsync(turnContext, cancellationToken: cancellationToken).ConfigureAwait(false);
+                await dm.OnTurnAsync(turnContext, cancellationToken).ConfigureAwait(false);
             });
         }
 
-        private TestFlow BuildTestFlow(string resourceName, bool sendTrace = false)
+        private TestFlow BuildTestFlow(string resourceName, string testName, bool sendTrace = false)
         {
-            var adapter = InitializeAdapter(sendTrace);
-            var dialog = resourceExplorer.LoadType<Dialog>(resourceName);
+            var adapter = InitializeAdapter(testName, sendTrace);
+            var dialog = _resourceExplorer.LoadType<Dialog>(resourceName);
             return GetTestFlow(dialog, adapter);
         }
     }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests.csproj
@@ -12,10 +12,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.13" />
     <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/QnAMakerUtils/QnAMakerCardEqualityComparer.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/QnAMakerUtils/QnAMakerCardEqualityComparer.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Collections.Generic;
-using System.Text;
 using Microsoft.Bot.Schema;
 
 namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/Recognizers/RuleRecognizer.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/Recognizers/RuleRecognizer.cs
@@ -13,9 +13,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests.Recognizers
 
         public Task<RecognizerResult> RecognizeAsync(ITurnContext turnContext, CancellationToken cancellationToken)
         {
-            string intent = DefaultIntent;
+            var intent = DefaultIntent;
 
-            if (Rules.TryGetValue(turnContext.Activity.Text, out string value))
+            if (Rules.TryGetValue(turnContext.Activity.Text, out var value))
             {
                 intent = value;
             }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/ResourceFixture.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/ResourceFixture.cs
@@ -1,0 +1,24 @@
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System;
+using System.IO;
+
+namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
+{
+    public class ResourceFixture : IDisposable
+    {
+        public ResourceFixture()
+        {
+            var path = Path.GetFullPath(PathUtils.NormalizePath(Path.Combine(Environment.CurrentDirectory, @"..\..")));
+            foreach (var file in Directory.EnumerateFiles(path, "*.dialog", SearchOption.AllDirectories))
+            {
+                File.Delete(file);
+            }
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/ResourceTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/ResourceTests.cs
@@ -14,17 +14,8 @@ using Xunit.Sdk;
 
 namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
 {
-    public class ResourceTests
+    public class ResourceTests : IClassFixture<ResourceFixture>
     {
-        public ResourceTests()
-        {
-            var path = Path.GetFullPath(PathUtils.NormalizePath(Path.Combine(Environment.CurrentDirectory, @"..\..")));
-            foreach (var file in Directory.EnumerateFiles(path, "*.dialog", SearchOption.AllDirectories))
-            {
-                File.Delete(file);
-            }
-        }
-
         [Fact]
         public void TestFolderSource()
         {

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/ResourceTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/ResourceTests.cs
@@ -9,22 +9,14 @@ using Microsoft.Bot.Builder.Dialogs.Adaptive;
 using Microsoft.Bot.Builder.Dialogs.Debugging;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Debugging;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
-using Microsoft.VisualStudio.TestPlatform.Utilities;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Newtonsoft.Json;
+using Xunit;
+using Xunit.Sdk;
 
 namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
 {
-    [TestClass]
     public class ResourceTests
     {
-        private static JsonSerializerSettings jsonSerializerSettings =
-            new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, Formatting = Formatting.Indented };
-
-        public TestContext TestContext { get; set; }
-
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext context)
+        public ResourceTests()
         {
             var path = Path.GetFullPath(PathUtils.NormalizePath(Path.Combine(Environment.CurrentDirectory, @"..\..")));
             foreach (var file in Directory.EnumerateFiles(path, "*.dialog", SearchOption.AllDirectories))
@@ -33,7 +25,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestFolderSource()
         {
             var path = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, PathUtils.NormalizePath(@"..\..\..")));
@@ -43,15 +35,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
 
                 var resources = explorer.GetResources(".dialog").ToArray();
 
-                Assert.AreEqual(4, resources.Length);
-                Assert.AreEqual($".dialog", Path.GetExtension(resources[0].Id));
+                Assert.Equal(4, resources.Length);
+                Assert.Equal($".dialog", Path.GetExtension(resources[0].Id));
 
                 resources = explorer.GetResources("foo").ToArray();
-                Assert.AreEqual(0, resources.Length);
+                Assert.Empty(resources);
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestMissingResourceThrows()
         {
             var path = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, PathUtils.NormalizePath(@"..\..\..")));
@@ -61,21 +53,21 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
                 try
                 {
                     explorer.GetResource("bogus.dialog");
-                    Assert.Fail($"should have thrown exception");
+                    throw new XunitException("should have thrown exception");
                 }
                 catch (ArgumentException err)
                 {
-                    Assert.IsTrue(err.Message.Contains("bogus"));
-                    Assert.AreEqual("bogus.dialog", err.ParamName);
+                    Assert.Contains("bogus", err.Message);
+                    Assert.Equal("bogus.dialog", err.ParamName);
                 }
                 catch (Exception err2)
                 {
-                    Assert.Fail($"Unknown exception {err2.GetType().Name} thrown");
+                    throw new XunitException($"Unknown exception {err2.GetType().Name} thrown");
                 }
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestResourceDialogIdAssignment()
         {
             var path = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, PathUtils.NormalizePath(@"..\..\..")));
@@ -83,37 +75,37 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
             {
                 explorer.AddResourceProvider(new FolderResourceProvider(explorer, path));
                 var dlg1 = explorer.LoadType<Dialog>("test.dialog") as AdaptiveDialog;
-                Assert.AreEqual("test.dialog", dlg1.Id, "resource .id should be used as default dialog.id if none assigned");
+                Assert.Equal("test.dialog", dlg1.Id);
 
-                Assert.AreEqual("1234567890", dlg1.Triggers[0].Actions[0].Id);
-                Assert.AreEqual("test3.dialog", dlg1.Triggers[0].Actions[1].Id);
+                Assert.Equal("1234567890", dlg1.Triggers[0].Actions[0].Id);
+                Assert.Equal("test3.dialog", dlg1.Triggers[0].Actions[1].Id);
 
                 var dlg2 = explorer.LoadType<Dialog>("test2.dialog");
-                Assert.AreEqual("1234567890", dlg2.Id, "id in the .dialog file should be honored");
+                Assert.Equal("1234567890", dlg2.Id);
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestFolderSource_Shallow()
         {
             var path = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, PathUtils.NormalizePath(@"..\..\..")));
             using (var explorer = new ResourceExplorer())
             {
-                explorer.AddFolder(path, includeSubFolders: false);
+                explorer.AddFolder(path, false);
 
                 var resources = explorer.GetResources("dialog").ToArray();
-                Assert.AreEqual(0, resources.Length, "shallow folder shouldn't list the dialog resources");
+                Assert.Empty(resources);
 
                 resources = explorer.GetResources("schema").ToArray();
-                Assert.IsTrue(resources.Length > 0, "shallow folder should list the root files");
+                Assert.True(resources.Length > 0, "shallow folder should list the root files");
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestFolderSource_NewFiresChanged()
         {
-            string testId = "NewFiresChanged.dialog";
-            string testDialogFile = Path.Combine(Environment.CurrentDirectory, testId);
+            const string testId = "NewFiresChanged.dialog";
+            var testDialogFile = Path.Combine(Environment.CurrentDirectory, testId);
 
             File.Delete(testDialogFile);
 
@@ -124,7 +116,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
 
                 AssertResourceNull(explorer, testId);
 
-                TaskCompletionSource<bool> changeFired = new TaskCompletionSource<bool>();
+                var changeFired = new TaskCompletionSource<bool>();
 
                 explorer.Changed += (e, resources) =>
                 {
@@ -143,26 +135,26 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestFolderSource_WriteFiresChanged()
         {
-            string testId = "WriteFiresChanged.dialog";
-            string testDialogFile = Path.Combine(Environment.CurrentDirectory, testId);
+            const string testId = "WriteFiresChanged.dialog";
+            var testDialogFile = Path.Combine(Environment.CurrentDirectory, testId);
 
             File.Delete(testDialogFile);
-            string contents = "{}";
+            var contents = "{}";
             File.WriteAllText(testDialogFile, contents);
 
             var path = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, PathUtils.NormalizePath(@"..\..\..")));
             using (var explorer = new ResourceExplorer())
             {
-                explorer.AddResourceProvider(new FolderResourceProvider(explorer, path, monitorChanges: true));
+                explorer.AddResourceProvider(new FolderResourceProvider(explorer, path, true));
 
                 AssertResourceFound(explorer, testId);
 
                 await AssertResourceContents(explorer, testId, contents);
 
-                TaskCompletionSource<bool> changeFired = new TaskCompletionSource<bool>();
+                var changeFired = new TaskCompletionSource<bool>();
 
                 explorer.Changed += (e, resources) =>
                 {
@@ -184,11 +176,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestFolderSource_DeleteFiresChanged()
         {
-            string testId = "DeleteFiresChanged.dialog";
-            string testDialogFile = Path.Combine(Environment.CurrentDirectory, testId);
+            const string testId = "DeleteFiresChanged.dialog";
+            var testDialogFile = Path.Combine(Environment.CurrentDirectory, testId);
 
             File.Delete(testDialogFile);
             File.WriteAllText(testDialogFile, "{}");
@@ -196,11 +188,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
             var path = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, PathUtils.NormalizePath(@"..\..\..")));
             using (var explorer = new ResourceExplorer())
             {
-                explorer.AddResourceProvider(new FolderResourceProvider(explorer, path, monitorChanges: true));
+                explorer.AddResourceProvider(new FolderResourceProvider(explorer, path, true));
 
                 AssertResourceFound(explorer, testId);
 
-                TaskCompletionSource<bool> changeFired = new TaskCompletionSource<bool>();
+                var changeFired = new TaskCompletionSource<bool>();
 
                 explorer.Changed += (e, resources) =>
                 {
@@ -219,13 +211,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ResourceExplorer_ReadTokenRange_AssignId()
         {
             var path = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, PathUtils.NormalizePath(@"..\..\..")));
             var sourceContext = new ResourceSourceContext();
-            var resourcesFolder = "resources";
-            var resourceId = "test.dialog";
+            const string resourcesFolder = "resources";
+            const string resourceId = "test.dialog";
 
             using (var explorer = new ResourceExplorer())
             {
@@ -238,27 +230,27 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
                 var (jToken, range) = await explorer.ReadTokenRangeAsync(resource, sourceContext).ConfigureAwait(false);
 
                 // Verify correct range
-                var expectedRange = new SourceRange()
+                var expectedRange = new SourceRange
                 {
                     StartPoint = new SourcePoint(0, 0),
                     EndPoint = new SourcePoint(13, 1),
                     Path = Path.Join(Path.Join(path, resourcesFolder), resourceId)
                 };
 
-                Assert.AreEqual(expectedRange, range);
+                Assert.Equal(expectedRange, range);
 
                 // Verify ID was added
-                Assert.AreEqual(resourceId, sourceContext.DefaultIdMap[jToken]);
+                Assert.Equal(resourceId, sourceContext.DefaultIdMap[jToken]);
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ResourceExplorer_ReadTokenRangeAdvance_AssignId()
         {
             var path = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, PathUtils.NormalizePath(@"..\..\..")));
             var sourceContext = new ResourceSourceContext();
-            var resourcesFolder = "resources";
-            var resourceId = "test.dialog";
+            const string resourcesFolder = "resources";
+            const string resourceId = "test.dialog";
 
             using (var explorer = new ResourceExplorer())
             {
@@ -268,29 +260,29 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
                 var resource = explorer.GetResource(resourceId);
 
                 // Read token range using resource explorer
-                var (jToken, range) = await explorer.ReadTokenRangeAsync(resource, sourceContext, advanceJsonReader: true).ConfigureAwait(false);
+                var (jToken, range) = await explorer.ReadTokenRangeAsync(resource, sourceContext, true).ConfigureAwait(false);
 
                 // Verify correct range
-                var expectedRange = new SourceRange()
+                var expectedRange = new SourceRange
                 {
                     StartPoint = new SourcePoint(1, 1),
                     EndPoint = new SourcePoint(13, 1),
                     Path = Path.Join(Path.Join(path, resourcesFolder), resourceId)
                 };
 
-                Assert.AreEqual(expectedRange, range);
+                Assert.Equal(expectedRange, range);
 
                 // Verify ID was added
-                Assert.AreEqual(resourceId, sourceContext.DefaultIdMap[jToken]);
+                Assert.Equal(resourceId, sourceContext.DefaultIdMap[jToken]);
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ResourceExplorer_LoadType_VerifyTokenRangeAndIdAssigned()
         {
             var path = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, PathUtils.NormalizePath(@"..\..\..")));
-            var resourcesFolder = "resources";
-            var resourceId = "test.dialog";
+            const string resourcesFolder = "resources";
+            const string resourceId = "test.dialog";
 
             using (var explorer = new ResourceExplorer())
             {
@@ -301,26 +293,26 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
                 var dialog = await explorer.LoadTypeAsync<Dialog>(resource).ConfigureAwait(false);
 
                 // Verify correct range
-                var expectedRange = new SourceRange()
+                var expectedRange = new SourceRange
                 {
                     StartPoint = new SourcePoint(1, 1),
                     EndPoint = new SourcePoint(13, 1),
                     Path = Path.Join(Path.Join(path, resourcesFolder), resourceId)
                 };
 
-                Assert.AreEqual(expectedRange, dialog.Source);
+                Assert.Equal(expectedRange, dialog.Source);
 
                 // Verify that the correct id was assigned
-                Assert.AreEqual(resourceId, dialog.Id);
+                Assert.Equal(resourceId, dialog.Id);
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ResourceExplorer_LoadType_VerifyTokenRangeAndIdHonored()
         {
             var path = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, PathUtils.NormalizePath(@"..\..\..")));
-            var resourcesFolder = "resources";
-            var resourceId = "testWithId.dialog";
+            const string resourcesFolder = "resources";
+            const string resourceId = "testWithId.dialog";
 
             using (var explorer = new ResourceExplorer())
             {
@@ -331,42 +323,42 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
                 var dialog = await explorer.LoadTypeAsync<Dialog>(resource).ConfigureAwait(false);
 
                 // Verify correct range
-                var expectedRange = new SourceRange()
+                var expectedRange = new SourceRange
                 {
                     StartPoint = new SourcePoint(1, 1),
                     EndPoint = new SourcePoint(14, 1),
                     Path = Path.Join(Path.Join(path, resourcesFolder), resourceId)
                 };
 
-                Assert.AreEqual(expectedRange, dialog.Source);
+                Assert.Equal(expectedRange, dialog.Source);
 
                 // Verify that the correct id was set
-                Assert.AreEqual("explicit-id", dialog.Id);
+                Assert.Equal("explicit-id", dialog.Id);
             }
         }
 
         private static void AssertResourceFound(ResourceExplorer explorer, string id)
         {
             var dialog = explorer.GetResource(id);
-            Assert.IsNotNull(dialog, $"getResource({id}) should return resource");
+            Assert.NotNull(dialog);
             var dialogs = explorer.GetResources("dialog");
-            Assert.IsTrue(dialogs.Where(d => d.Id == id).Any(), $"getResources({id}) should return resource");
+            Assert.True(dialogs.Any(d => d.Id == id), $"getResources({id}) should return resource");
         }
 
         private static void AssertResourceNull(ResourceExplorer explorer, string id)
         {
             try
             {
-                var dialog = explorer.GetResource(id);
-                Assert.Fail($"GetResource({id}) should throw");
+                explorer.GetResource(id);
+                throw new XunitException($"GetResource({id}) should throw");
             }
             catch (ArgumentException err)
             {
-                Assert.AreEqual(err.ParamName, id, "Should throw error with resource id in it");
+                Assert.Equal(err.ParamName, id);
             }
 
             var dialogs = explorer.GetResources("dialog");
-            Assert.IsFalse(dialogs.Where(d => d.Id == id).Any(), $"getResources({id}) should not return resource");
+            Assert.False(dialogs.Any(d => d.Id == id), $"getResources({id}) should not return resource");
         }
 
         private async Task AssertResourceContents(ResourceExplorer explorer, string id, string contents)
@@ -374,11 +366,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
             var resource = explorer.GetResource(id);
 
             var text = await resource.ReadTextAsync();
-            Assert.AreEqual(contents, text, $"getResource({id}) contents not the same ");
-            resource = explorer.GetResources("dialog").Where(d => d.Id == id).Single();
+            Assert.Equal(contents, text);
+            resource = explorer.GetResources("dialog").Single(d => d.Id == id);
 
             text = await resource.ReadTextAsync();
-            Assert.AreEqual(contents, text, $"getResources({id}) contents not the same");
+            Assert.Equal(contents, text);
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/SchemaMergeTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/SchemaMergeTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
     /// </remarks>
     public class SchemaMergeTests
     {
-        public SchemaMergeTests()
+        static SchemaMergeTests()
         {
             // static field initialization
             var projectPath = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, PathUtils.NormalizePath(@"..\..\..")));
@@ -68,7 +68,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
                     var error = process.StandardError.ReadToEnd();
                     process.WaitForExit();
 
-                    Assert.Equal(error, string.Empty);
+                    Assert.Equal(string.Empty, error);
                 }
             }
             catch (Exception err)

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/SchemaMergeTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/SchemaMergeTests.cs
@@ -10,10 +10,11 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Schema;
+using Xunit;
+using Xunit.Sdk;
 
 namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
 {
@@ -25,19 +26,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
     /// npm i -g @microsoft/botframework-cli
     /// bf plugins:install @microsoft/bf-dialog
     /// </remarks>
-    [TestClass]
     public class SchemaMergeTests
     {
-        public static ResourceExplorer ResourceExplorer { get; set; }
-
-        public static JSchema Schema { get; set; }
-
-        public static IEnumerable<object[]> Dialogs { get; set; }
-
-        public TestContext TestContext { get; set; }
-
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext context)
+        public SchemaMergeTests()
         {
             // static field initialization
             var projectPath = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, PathUtils.NormalizePath(@"..\..\..")));
@@ -77,60 +68,66 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
                     var error = process.StandardError.ReadToEnd();
                     process.WaitForExit();
 
-                    Assert.AreEqual(error, string.Empty);
+                    Assert.Equal(error, string.Empty);
                 }
             }
             catch (Exception err)
             {
-                Assert.Fail(err.Message);
+                throw new XunitException(err.Message);
             }
 
-            Assert.IsTrue(File.Exists(schemaPath));
+            Assert.True(File.Exists(schemaPath));
             var json = File.ReadAllText(schemaPath);
             Schema = JSchema.Parse(json);
         }
 
-        [DataTestMethod]
-        [DynamicData(nameof(Dialogs))]
+        public static ResourceExplorer ResourceExplorer { get; set; }
+
+        public static JSchema Schema { get; set; }
+
+        public static IEnumerable<object[]> Dialogs { get; set; }
+
+        [Theory]
+        [MemberData(nameof(Dialogs))]
         public async Task TestDialogResourcesAreValidForSchema(Resource resource)
         {
             if (Schema == null)
             {
-                Assert.Fail("missing schema file");
+                throw new XunitException("missing schema file");
             }
 
-            FileResource fileResource = resource as FileResource;
+            var fileResource = resource as FileResource;
 
             // load the merged app schema file (validating it's truly a jsonschema doc
             // and use it to validate all .dialog files are valid to this schema
             var json = await resource.ReadTextAsync();
-            var jtoken = (JToken)JsonConvert.DeserializeObject(json);
-            var jobj = jtoken as JObject;
-            var schema = jobj["$schema"]?.ToString();
+            var jToken = (JToken)JsonConvert.DeserializeObject(json);
+            var jObj = jToken as JObject;
+            var schema = jObj["$schema"]?.ToString();
 
             try
             {
                 // everything should have $schema
-                Assert.IsNotNull(schema, "Missing $schema");
+                Assert.NotNull(schema);
 
                 var folder = Path.GetDirectoryName(fileResource.FullName);
 
                 // NOTE: Some schemas are not local.  We don't validate against those because they often depend on the SDK itself
                 if (!schema.StartsWith("http"))
                 {
-                    Assert.IsTrue(File.Exists(Path.Combine(folder, PathUtils.NormalizePath(schema))), $"$schema {schema}");
+                    Assert.True(File.Exists(Path.Combine(folder, PathUtils.NormalizePath(schema))), $"$schema {schema}");
 
                     // NOTE: Microsoft.SendActivity in this file fails validation even though it is valid.  
                     // Bug filed with Newtonsoft: https://stackoverflow.com/questions/63493078/why-does-validation-fail-in-code-but-work-in-newtonsoft-web-validator
                     if (!fileResource.FullName.Contains("Action_SendActivity.test.dialog"))
                     {
-                        jtoken.Validate(Schema);
+                        jToken.Validate(Schema);
                     }
                 }
             }
             catch (JSchemaValidationException err)
             {
-                Assert.Fail($"{fileResource.FullName}\n{err.Message}", $"Dialog is not valid for the $schema {schema}");
+                throw new XunitException($"{fileResource.FullName}\n{err.Message}");
             }
         }
     }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/Startup.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/Startup.cs
@@ -1,21 +1,28 @@
 ﻿using Microsoft.Bot.Builder.AI.QnA;
-using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Dialogs.Adaptive;
 using Microsoft.Bot.Builder.Dialogs.Declarative;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+[assembly: TestFramework("Microsoft.Bot.Builder.Startup", "Microsoft.Bot.Builder.Dialogs.Declarative.Tests")]
 
 namespace Microsoft.Bot.Builder
 {
-    [TestClass]
-    public class Startup
+    public class Startup : XunitTestFramework
     {
-        [AssemblyInitialize]
-        public static void Initialize(TestContext testContext)
+        public Startup(IMessageSink messageSink)
+            : base(messageSink)
         {
             ComponentRegistration.Add(new DeclarativeComponentRegistration());
             ComponentRegistration.Add(new AdaptiveComponentRegistration());
             ComponentRegistration.Add(new LanguageGenerationComponentRegistration());
             ComponentRegistration.Add(new QnAMakerComponentRegistration());
+        }
+
+        public new void Dispose()
+        {
+            base.Dispose();
         }
     }
 }


### PR DESCRIPTION
Fixes# 4095

## Description
This PR migrates all [Microsoft.Bot.Builder.Dialogs.Declarative.Tests](https://github.com/microsoft/botbuilder-dotnet/tree/main/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests) tests from **MSTest** to **xUnit**.

## Detailed Changes
- Removed MSTest packages from the .csproj.
- Replaced `[TestMethod]` with `[Fact]`.
- Changed Asserts.
- Replaced `Assert.Fail` with `thown new XunitException`.
- Removed `TestContext`.
- Replaced `ClassInitialize` method with a class' constructor to execute tests' shared code.
- Used constants instead of variables where applicable.
- Used `var` instead of the specific type.
- Removed redundant parenthesis.

Also, we did the following changes in: 
- **_JsonLoadTests_**:
    - Added the `Dispose` method to clean up after each test execution.
    - Added the test name as parameter in `BuildTestFlow` and `BuildQnAMakerTestFlow` to pass it to `InitializeAdapter` method instead of `TestContext.TestName`
- **_SchemaMergeTests_**:
   - Replaced `[DataTestMethod]` with `Theory`
- **_Startup_**:
  - Replaced `[AssemblyInitialize]` with the `AssemblyFixture` feature of Xunit. 

## Testing
The following image shows the tests passing after the changes.
![image](https://user-images.githubusercontent.com/44245136/92282274-a27f8e00-eed3-11ea-83e3-f2871ad4a595.png)
