### PR TITLE
Add missing XML documentation to Bot.Builder.Dialogs.Adaptive Functions, Generators, Input, Memory, Selectors and Templates folders

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Functions/HasPendingActionsFunction.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Functions/HasPendingActionsFunction.cs
@@ -17,8 +17,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Functions
     /// </remarks>
     public class HasPendingActionsFunction : ExpressionEvaluator
     {
+        /// <summary>
+        /// Function identifier name.
+        /// </summary>
         public const string Name = "hasPendingActions";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HasPendingActionsFunction"/> class.
+        /// </summary>
         public HasPendingActionsFunction()
             : base(Name, Function, ReturnType.Boolean)
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Functions/IsDialogActiveFunction.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Functions/IsDialogActiveFunction.cs
@@ -22,9 +22,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Functions
     /// </example>
     public class IsDialogActiveFunction : ExpressionEvaluator
     {
+        /// <summary>
+        /// Function identifier name.
+        /// </summary>
         public const string Name = "isDialogActive";
+
+        /// <summary>
+        /// Function identifier alias.
+        /// </summary>
         public const string Alias = "isActionActive";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IsDialogActiveFunction"/> class.
+        /// </summary>
         public IsDialogActiveFunction()
             : base(Name, Function, ReturnType.Boolean)
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/LanguageGeneratorManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/LanguageGeneratorManager.cs
@@ -53,6 +53,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
         public ConcurrentDictionary<string, LanguageGenerator> LanguageGenerators { get; set; } = new ConcurrentDictionary<string, LanguageGenerator>(StringComparer.OrdinalIgnoreCase);
 #pragma warning restore CA2227 // Collection properties should be read only
 
+        /// <summary>
+        /// Returns the resolver to resolve LG import id to template text based on language and a template resource loader delegate.
+        /// </summary>
+        /// <param name="locale">Locale to identify language.</param>
+        /// <param name="resourceMapping">Template resource loader delegate.</param>
+        /// <returns>resolver.</returns>
         public static ImportResolverDelegate ResourceExplorerResolver(string locale, Dictionary<string, IList<Resource>> resourceMapping)
         {
             return (LGResource lgResource, string id) =>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/LanguageGeneratorManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/LanguageGeneratorManager.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
         /// </summary>
         /// <param name="locale">Locale to identify language.</param>
         /// <param name="resourceMapping">Template resource loader delegate.</param>
-        /// <returns>resolver.</returns>
+        /// <returns>The delegate to resolve the resource.</returns>
         public static ImportResolverDelegate ResourceExplorerResolver(string locale, Dictionary<string, IList<Resource>> resourceMapping)
         {
             return (LGResource lgResource, string id) =>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/MultiLanguageGenerator.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/MultiLanguageGenerator.cs
@@ -12,6 +12,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
     /// </summary>
     public class MultiLanguageGenerator : MultiLanguageGeneratorBase
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.MultiLanguageGenerator";
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/MultiLanguageGeneratorBase.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/MultiLanguageGeneratorBase.cs
@@ -22,6 +22,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
         {
         }
 
+        /// <summary>
+        /// Gets or sets the language policy.
+        /// </summary>
+        /// <value>
+        /// Language policy.
+        /// </value>
         [JsonProperty("languagePolicy")]
 #pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public LanguagePolicy LanguagePolicy { get; set; }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/ResourceMultiLanguageGenerator.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/ResourceMultiLanguageGenerator.cs
@@ -14,6 +14,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
     /// </remarks>
     public class ResourceMultiLanguageGenerator : MultiLanguageGeneratorBase
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.ResourceMultiLanguageGenerator";
 
@@ -26,6 +29,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
             this.ResourceId = resourceId;
         }
 
+        /// <summary>
+        /// Gets or sets the resource id.
+        /// </summary>
+        /// <value>
+        /// resource id.
+        /// </value>
         [JsonProperty("resourceId")]
         public string ResourceId { get; set; }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/ResourceMultiLanguageGenerator.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/ResourceMultiLanguageGenerator.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
         /// Gets or sets the resource id.
         /// </summary>
         /// <value>
-        /// resource id.
+        /// Resource id.
         /// </value>
         [JsonProperty("resourceId")]
         public string ResourceId { get; set; }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/TemplateEngineLanguageGenerator.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/TemplateEngineLanguageGenerator.cs
@@ -17,6 +17,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
     /// </summary>
     public class TemplateEngineLanguageGenerator : LanguageGenerator
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.TemplateEngineLanguageGenerator";
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/Ask.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/Ask.cs
@@ -25,9 +25,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </remarks>
     public class Ask : SendActivity
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public new const string Kind = "Microsoft.Ask";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Ask"/> class.
+        /// </summary>
+        /// <param name="text">Optional, text value.</param>
+        /// <param name="expectedProperties">Optional, expected properties values.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public Ask(
             string text = null,
@@ -60,6 +70,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         [JsonProperty("defaultOperation")]
         public StringExpression DefaultOperation { get; set; }
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">Optional, a <see cref="CancellationToken"/> that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default)
         {
             //get number of retries from memory

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/AttachmentInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/AttachmentInput.cs
@@ -34,9 +34,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
     /// </summary>
     public class AttachmentInput : InputDialog
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.AttachmentInput";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AttachmentInput"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         public AttachmentInput([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
         {
             this.RegisterSourceLocation(callerPath, callerLine);
@@ -51,6 +59,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         [JsonProperty("outputFormat")]
         public EnumExpression<AttachmentOutputFormat> OutputFormat { get; set; } = AttachmentOutputFormat.First;
 
+        /// <summary>
+        /// Called when input has been received, override this method to cutomize recognition of the input.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> for the task.</param>
+        /// <returns>InputState which reflects whether input was recognized as valid or not.</returns>
         protected override Task<InputState> OnRecognizeInputAsync(DialogContext dc, CancellationToken cancellationToken = default)
         {
             var input = dc.State.GetValue<List<Attachment>>(VALUE_PROPERTY);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/AttachmentInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/AttachmentInput.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         public EnumExpression<AttachmentOutputFormat> OutputFormat { get; set; } = AttachmentOutputFormat.First;
 
         /// <summary>
-        /// Called when input has been received, override this method to customize recognition of the input.
+        /// Called when input has been received.
         /// </summary>
         /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
         /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/AttachmentInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/AttachmentInput.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         public EnumExpression<AttachmentOutputFormat> OutputFormat { get; set; } = AttachmentOutputFormat.First;
 
         /// <summary>
-        /// Called when input has been received, override this method to cutomize recognition of the input.
+        /// Called when input has been received, override this method to customize recognition of the input.
         /// </summary>
         /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
         /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> for the task.</param>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/AttachmentInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/AttachmentInput.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         /// Called when input has been received, override this method to customize recognition of the input.
         /// </summary>
         /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
-        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> for the task.</param>
+        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>InputState which reflects whether input was recognized as valid or not.</returns>
         protected override Task<InputState> OnRecognizeInputAsync(DialogContext dc, CancellationToken cancellationToken = default)
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInput.cs
@@ -14,6 +14,9 @@ using static Microsoft.Recognizers.Text.Culture;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
 {
+    /// <summary>
+    /// Response format definition.
+    /// </summary>
     public enum ChoiceOutputFormat
     {
         /// <summary>
@@ -32,6 +35,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
     /// </summary>
     public class ChoiceInput : InputDialog
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.ChoiceInput";
 
@@ -47,6 +53,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             { Chinese, new ChoiceFactoryOptions { InlineSeparator = "， ", InlineOr = " 要么 ", InlineOrMore = "， 要么 ", IncludeNumbers = true } },
         };
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChoiceInput"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         public ChoiceInput([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
         {
             this.RegisterSourceLocation(callerPath, callerLine);
@@ -106,6 +117,16 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         [JsonProperty("recognizerOptions")]
         public ObjectExpression<FindChoicesOptions> RecognizerOptions { get; set; } = null;
 
+        /// <summary>
+        /// Replaces the result with the FoundChoice value if possible, then proceedes to <see cref="Dialog.ResumeDialogAsync(DialogContext, DialogReason, object, CancellationToken)"/>.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="reason">Reason why the dialog resumed.</param>
+        /// <param name="result">Optional, value returned from the dialog that was called. The type
+        /// of the value returned is dependent on the child dialog.</param>
+        /// <param name="cancellationToken">Optional, a <see cref="CancellationToken"/> that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override Task<DialogTurnResult> ResumeDialogAsync(DialogContext dc, DialogReason reason, object result = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             FoundChoice foundChoice = result as FoundChoice;
@@ -118,6 +139,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             return base.ResumeDialogAsync(dc, reason, result, cancellationToken);
         }
 
+        /// <summary>
+        /// Method which processes options.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <returns>modified options.</returns>
         protected override object OnInitializeOptions(DialogContext dc, object options)
         {
             var op = options as ChoiceInputOptions;
@@ -140,6 +167,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             return base.OnInitializeOptions(dc, op);
         }
 
+        /// <summary>
+        /// Called when input has been received, recognices choice.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> for the task.</param>
+        /// <returns>InputState which reflects whether input was recognized as valid or not.</returns>
         protected override Task<InputState> OnRecognizeInputAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
         {
             var input = dc.State.GetValue<object>(VALUE_PROPERTY);
@@ -174,6 +207,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             return Task.FromResult(InputState.Valid);
         }
 
+        /// <summary>
+        /// Method which renders the prompt to the user given the current input state.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="state">Dialog <see cref="InputState"/>.</param>
+        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> for the task.</param>
+        /// <returns>Activity to send to the user.</returns>
         protected override async Task<IActivity> OnRenderPromptAsync(DialogContext dc, InputState state, CancellationToken cancellationToken = default(CancellationToken))
         {
             var locale = GetCulture(dc);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInput.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         /// Called when input has been received, recognices choice.
         /// </summary>
         /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
-        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> for the task.</param>
+        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>InputState which reflects whether input was recognized as valid or not.</returns>
         protected override Task<InputState> OnRecognizeInputAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -212,7 +212,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         /// </summary>
         /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
         /// <param name="state">Dialog <see cref="InputState"/>.</param>
-        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> for the task.</param>
+        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>Activity to send to the user.</returns>
         protected override async Task<IActivity> OnRenderPromptAsync(DialogContext dc, InputState state, CancellationToken cancellationToken = default(CancellationToken))
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInputOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInputOptions.cs
@@ -7,8 +7,17 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
 {
+    /// <summary>
+    /// Holds choice input option list.
+    /// </summary>
     public class ChoiceInputOptions : InputDialogOptions
     {
+        /// <summary>
+        /// Gets or sets input option list.
+        /// </summary>
+        /// <value>
+        /// Input option list.
+        /// </value>
         [JsonProperty("choices")]
 #pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public List<Choice> Choices { get; set; }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceSet.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceSet.cs
@@ -11,15 +11,26 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
     [JsonConverter(typeof(ChoiceSetConverter))]
     public class ChoiceSet : List<Choice>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChoiceSet"/> class.
+        /// </summary>
         public ChoiceSet()
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChoiceSet"/> class.
+        /// </summary>
+        /// <param name="choices">Choice values.</param>
         public ChoiceSet(IEnumerable<Choice> choices)
             : base(choices)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChoiceSet"/> class.
+        /// </summary>
+        /// <param name="obj">Choice values.</param>
         public ChoiceSet(object obj)
         {
             // support string[] => choice[]
@@ -51,10 +62,22 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             }
         }
 
+        /// <summary>
+        /// Converts a bool into a <see cref="ChoiceSet"/>.
+        /// </summary>
+        /// <param name="value">Bool expression.</param>
         public static implicit operator ChoiceSet(bool value) => new ChoiceSet(value);
 
+        /// <summary>
+        /// Converts a string into a <see cref="ChoiceSet"/>.
+        /// </summary>
+        /// <param name="value">String expression.</param>
         public static implicit operator ChoiceSet(string value) => new ChoiceSet(value);
 
+        /// <summary>
+        /// Converts a <see cref="JToken"/> into a <see cref="ChoiceSet"/>.
+        /// </summary>
+        /// <param name="value"><see cref="JToken"/> expression.</param>
         public static implicit operator ChoiceSet(JToken value) => new ChoiceSet(value);
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ConfirmInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ConfirmInput.cs
@@ -20,6 +20,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
     /// </summary>
     public class ConfirmInput : InputDialog
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.ConfirmInput";
 
@@ -35,6 +38,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             { Chinese, (new Choice("是的"), new Choice("不"), new ChoiceFactoryOptions("， ", " 要么 ",  "， 要么 ", true)) },
         };
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConfirmInput"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         public ConfirmInput([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
         {
             this.RegisterSourceLocation(callerPath, callerLine);
@@ -78,6 +86,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         [JsonProperty("outputFormat")]
         public ValueExpression OutputFormat { get; set; }
 
+        /// <summary>
+        /// Called when input has been received.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> for the task.</param>
+        /// <returns>InputState which reflects whether input was recognized as valid or not.</returns>
         protected override Task<InputState> OnRecognizeInputAsync(DialogContext dc, CancellationToken cancellationToken = default)
         {
             var input = dc.State.GetValue<object>(VALUE_PROPERTY);
@@ -140,6 +154,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             return Task.FromResult(InputState.Valid);
         }
 
+        /// <summary>
+        /// Method which renders the prompt to the user given the current input state.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="state">Dialog <see cref="InputState"/>.</param>
+        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> for the task.</param>
+        /// <returns>Activity to send to the user.</returns>
         protected override async Task<IActivity> OnRenderPromptAsync(DialogContext dc, InputState state, CancellationToken cancellationToken = default)
         {
             // Format prompt to send

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ConfirmInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ConfirmInput.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         /// Called when input has been received.
         /// </summary>
         /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
-        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> for the task.</param>
+        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>InputState which reflects whether input was recognized as valid or not.</returns>
         protected override Task<InputState> OnRecognizeInputAsync(DialogContext dc, CancellationToken cancellationToken = default)
         {
@@ -159,7 +159,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         /// </summary>
         /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
         /// <param name="state">Dialog <see cref="InputState"/>.</param>
-        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> for the task.</param>
+        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>Activity to send to the user.</returns>
         protected override async Task<IActivity> OnRenderPromptAsync(DialogContext dc, InputState state, CancellationToken cancellationToken = default)
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/DateTimeInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/DateTimeInput.cs
@@ -21,9 +21,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
     /// The value that is output from a DateTimeInput is an array of DateTimeResolutions, or the output of OutputFormat.</remarks>
     public class DateTimeInput : InputDialog
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.DateTimeInput";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DateTimeInput"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         public DateTimeInput([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
         {
             this.RegisterSourceLocation(callerPath, callerLine);
@@ -46,6 +54,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         [JsonProperty("outputFormat")]
         public Expression OutputFormat { get; set; }
 
+        /// <summary>
+        /// Called when input has been received.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> for the task.</param>
+        /// <returns>InputState which reflects whether input was recognized as valid or not.</returns>
         protected override Task<InputState> OnRecognizeInputAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
         {
             var input = dc.State.GetValue<object>(VALUE_PROPERTY);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/DateTimeInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/DateTimeInput.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         /// Called when input has been received.
         /// </summary>
         /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
-        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> for the task.</param>
+        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>InputState which reflects whether input was recognized as valid or not.</returns>
         protected override Task<InputState> OnRecognizeInputAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
@@ -14,11 +14,21 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
 {
+    /// <summary>
+    /// Defines input dialogs.
+    /// </summary>
     public abstract class InputDialog : Dialog
     {
 #pragma warning disable SA1310 // Field should not contain underscore.
 #pragma warning disable CA1707 // Identifiers should not contain underscores (we shouldn't use screaming caps, but we can't change this without breaking binary compat)
+        /// <summary>
+        /// Defines dialog context turn count property value.
+        /// </summary>
         protected const string TURN_COUNT_PROPERTY = "this.turnCount";
+
+        /// <summary>
+        /// Defines dialog context state property value.
+        /// </summary>
         protected const string VALUE_PROPERTY = "this.value";
 #pragma warning restore CA1707 // Identifiers should not contain underscores
 #pragma warning restore SA1310 // Field should not contain underscore.
@@ -150,6 +160,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         [JsonProperty("defaultValue")]
         public ValueExpression DefaultValue { get; set; }
 
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">Optional, a <see cref="CancellationToken"/> that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (dc == null)
@@ -201,6 +219,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             }
         }
 
+        /// <summary>
+        /// Called when the dialog is _continued_, where it is the active dialog and the
+        /// user replies with a new activity.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="cancellationToken">Optional, a <see cref="CancellationToken"/> that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> ContinueDialogAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
         {
             var activity = dc.Context.Activity;
@@ -262,6 +288,16 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             return await dc.EndDialogAsync().ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Called when a child dialog completed this turn, returning control to this dialog.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="reason">Reason why the dialog resumed.</param>
+        /// <param name="result">Optional, value returned from the dialog that was called. The type
+        /// of the value returned is dependent on the child dialog.</param>
+        /// <param name="cancellationToken">Optional, a <see cref="CancellationToken"/> that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> ResumeDialogAsync(DialogContext dc, DialogReason reason, object result = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await this.PromptUserAsync(dc, InputState.Missing, cancellationToken).ConfigureAwait(false);
@@ -275,6 +311,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         /// <returns>InputState which reflects whether input was recognized as valid or not.</returns>
         protected abstract Task<InputState> OnRecognizeInputAsync(DialogContext dc, CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Called before an event is bubbled to its parent.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="e">The event being raised.</param>
+        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> for the task.</param>
+        /// <returns>Whether the event is handled by the current dialog and further processing should stop.</returns>
         protected override async Task<bool> OnPreBubbleEventAsync(DialogContext dc, DialogEvent e, CancellationToken cancellationToken)
         {
             if (e.Name == DialogEvents.ActivityReceived && dc.Context.Activity.Type == ActivityTypes.Message)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
@@ -289,7 +289,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         }
 
         /// <summary>
-        /// Called when a child dialog completed this turn, returning control to this dialog.
+        /// Called when a child dialog completes its turn, returning control to this dialog.
         /// </summary>
         /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
         /// <param name="reason">Reason why the dialog resumed.</param>
@@ -304,7 +304,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         }
 
         /// <summary>
-        /// Called when input has been received, override this method to cutomize recognition of the input.
+        /// Called when input has been received, override this method to customize recognition of the input.
         /// </summary>
         /// <param name="dc">dialogContext.</param>
         /// <param name="cancellationToken">the <see cref="CancellationToken"/> for the task.</param>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
@@ -316,7 +316,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         /// </summary>
         /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
         /// <param name="e">The event being raised.</param>
-        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> for the task.</param>
+        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>Whether the event is handled by the current dialog and further processing should stop.</returns>
         protected override async Task<bool> OnPreBubbleEventAsync(DialogContext dc, DialogEvent e, CancellationToken cancellationToken)
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialogOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialogOptions.cs
@@ -3,6 +3,9 @@
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
 {
+    /// <summary>
+    /// Defines input option list.
+    /// </summary>
     public class InputDialogOptions
     {
     }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/NumberInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/NumberInput.cs
@@ -17,9 +17,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
     /// </summary>
     public class NumberInput : InputDialog
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.NumberInput";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NumberInput"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         public NumberInput([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
         {
             this.RegisterSourceLocation(callerPath, callerLine);
@@ -43,6 +51,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         [JsonProperty("outputFormat")]
         public NumberExpression OutputFormat { get; set; }
 
+        /// <summary>
+        /// Called when input has been received.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> for the task.</param>
+        /// <returns>InputState which reflects whether input was recognized as valid or not.</returns>
         protected override Task<InputState> OnRecognizeInputAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
         {
             var input = dc.State.GetValue<object>(VALUE_PROPERTY);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/NumberInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/NumberInput.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         /// Called when input has been received.
         /// </summary>
         /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
-        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> for the task.</param>
+        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>InputState which reflects whether input was recognized as valid or not.</returns>
         protected override Task<InputState> OnRecognizeInputAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/OAuthInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/OAuthInput.cs
@@ -308,7 +308,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         /// Called when input has been received.
         /// </summary>
         /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
-        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> for the task.</param>
+        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>InputState which reflects whether input was recognized as valid or not.</returns>
         /// <remark>Method not implemented.</remark>
         protected override Task<InputState> OnRecognizeInputAsync(DialogContext dc, CancellationToken cancellationToken = default)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/OAuthInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/OAuthInput.cs
@@ -25,6 +25,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
     /// </summary>
     public class OAuthInput : InputDialog
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.OAuthInput";
 
@@ -301,6 +304,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             await adapter.SignOutUserAsync(dc.Context, ConnectionName.GetValue(dc.State), dc.Context.Activity?.From?.Id, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Called when input has been received.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> for the task.</param>
+        /// <returns>InputState which reflects whether input was recognized as valid or not.</returns>
+        /// <remark>Method not implemented.</remark>
         protected override Task<InputState> OnRecognizeInputAsync(DialogContext dc, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/TextInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/TextInput.cs
@@ -15,9 +15,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
     /// </summary>
     public class TextInput : InputDialog
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.TextInput";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TextInput"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         public TextInput([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
         {
             this.RegisterSourceLocation(callerPath, callerLine);
@@ -29,8 +37,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         /// <remarks>The default output is a string, if this property is set then the output of the expression is the string returned by the dialog.</remarks>
         /// <value>an expression which resolves to a string.</value>
         [JsonProperty("outputFormat")]
-        public StringExpression OutputFormat { get; set; } 
+        public StringExpression OutputFormat { get; set; }
 
+        /// <summary>
+        /// Called when input has been received.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> for the task.</param>
+        /// <returns>InputState which reflects whether input was recognized as valid or not.</returns>
         protected override Task<InputState> OnRecognizeInputAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
         {
             var input = dc.State.GetValue<string>(VALUE_PROPERTY);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/TextInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/TextInput.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         /// Called when input has been received.
         /// </summary>
         /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
-        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> for the task.</param>
+        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>InputState which reflects whether input was recognized as valid or not.</returns>
         protected override Task<InputState> OnRecognizeInputAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/Expressions/Converters/ChoiceSetConverter.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/Expressions/Converters/ChoiceSetConverter.cs
@@ -12,6 +12,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
     /// </summary>
     public class ChoiceSetConverter : JsonConverter<ChoiceSet>
     {
+        /// <summary>
+        /// Reads the JSON representation of a <see cref="ChoiceSet"/> object.
+        /// </summary>
+        /// <param name="reader">The <see cref="Newtonsoft.Json.JsonReader"/> to read from.</param>
+        /// <param name="objectType">Type of the object.</param>
+        /// <param name="existingValue">The existing value of <see cref="ChoiceSet"/> being read. If there is no existing value then null will be used.</param>
+        /// <param name="hasExistingValue">The existing value has a value.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <returns>The interpreted <see cref="ChoiceSet"/> object.</returns>
         public override ChoiceSet ReadJson(JsonReader reader, Type objectType, ChoiceSet existingValue, bool hasExistingValue, JsonSerializer serializer)
         {
             if (reader.ValueType == typeof(string))
@@ -24,6 +33,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             }
         }
 
+        /// <summary>
+        /// Writes the JSON representation of a <see cref="ChoiceSet"/> object.
+        /// </summary>
+        /// <param name="writer">The <see cref="Newtonsoft.Json.JsonWriter"/> to write to.</param>
+        /// <param name="choiceSet">The <see cref="ChoiceSet"/>.</param>
+        /// <param name="serializer">The calling serializer.</param>
         public override void WriteJson(JsonWriter writer, ChoiceSet choiceSet, JsonSerializer serializer)
         {
             writer.WriteStartArray();

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/Expressions/Converters/ChoiceSetConverter.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/Expressions/Converters/ChoiceSetConverter.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         /// <param name="reader">The <see cref="Newtonsoft.Json.JsonReader"/> to read from.</param>
         /// <param name="objectType">Type of the object.</param>
         /// <param name="existingValue">The existing value of <see cref="ChoiceSet"/> being read. If there is no existing value then null will be used.</param>
-        /// <param name="hasExistingValue">The existing value has a value.</param>
+        /// <param name="hasExistingValue">Indicates if existingValue has a value.</param>
         /// <param name="serializer">The calling serializer.</param>
         /// <returns>The interpreted <see cref="ChoiceSet"/> object.</returns>
         public override ChoiceSet ReadJson(JsonReader reader, Type objectType, ChoiceSet existingValue, bool hasExistingValue, JsonSerializer serializer)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/Expressions/Converters/DialogExpressionConverter.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/Expressions/Converters/DialogExpressionConverter.cs
@@ -32,8 +32,23 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Converters
             this.resourceExplorer = resourceExplorer;
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this <see cref="Newtonsoft.Json.JsonConverter"/> can read JSON.
+        /// </summary>
+        /// <value>
+        /// true.
+        /// </value>
         public override bool CanRead => true;
 
+        /// <summary>
+        /// Reads the JSON representation of a <see cref="DialogExpression"/> object.
+        /// </summary>
+        /// <param name="reader">The <see cref="Newtonsoft.Json.JsonReader"/> to read from.</param>
+        /// <param name="objectType">Type of the object.</param>
+        /// <param name="existingValue">The existing value of <see cref="DialogExpression"/> being read. If there is no existing value then null will be used.</param>
+        /// <param name="hasExistingValue">The existing value has a value.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <returns>The interpreted <see cref="DialogExpression"/> object.</returns>
         public override DialogExpression ReadJson(JsonReader reader, Type objectType, DialogExpression existingValue, bool hasExistingValue, JsonSerializer serializer)
         {
             var jToken = JToken.Load(reader);
@@ -75,6 +90,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Converters
             return result;
         }
 
+        /// <summary>
+        /// Writes the JSON representation of a <see cref="DialogExpression"/> object.
+        /// </summary>
+        /// <param name="writer">The <see cref="Newtonsoft.Json.JsonWriter"/> to write to.</param>
+        /// <param name="value">The value <see cref="DialogExpression"/>.</param>
+        /// <param name="serializer">The calling serializer.</param>
         public override void WriteJson(JsonWriter writer, DialogExpression value, JsonSerializer serializer)
         {
             if (value.ExpressionText != null)
@@ -101,6 +122,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Converters
             RegisterObserver(new JsonLoadObserverWrapper(observer));
         }
 
+        /// <summary>
+        /// Registers an observer to receive notifications on converter events.
+        /// </summary>
+        /// <param name="observer">The <see cref="IJsonLoadObserver"/> to be registered.</param>
         public void RegisterObserver(IJsonLoadObserver observer)
         {
             if (observer == null)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/Expressions/Converters/DialogExpressionConverter.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/Expressions/Converters/DialogExpressionConverter.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Converters
         /// <param name="reader">The <see cref="Newtonsoft.Json.JsonReader"/> to read from.</param>
         /// <param name="objectType">Type of the object.</param>
         /// <param name="existingValue">The existing value of <see cref="DialogExpression"/> being read. If there is no existing value then null will be used.</param>
-        /// <param name="hasExistingValue">The existing value has a value.</param>
+        /// <param name="hasExistingValue">Indicates if existingValue has a value.</param>
         /// <param name="serializer">The calling serializer.</param>
         /// <returns>The interpreted <see cref="DialogExpression"/> object.</returns>
         public override DialogExpression ReadJson(JsonReader reader, Type objectType, DialogExpression existingValue, bool hasExistingValue, JsonSerializer serializer)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/Expressions/Converters/DialogExpressionConverter.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/Expressions/Converters/DialogExpressionConverter.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Converters
         /// Gets a value indicating whether this <see cref="Newtonsoft.Json.JsonConverter"/> can read JSON.
         /// </summary>
         /// <value>
-        /// true.
+        /// <c>true</c>.
         /// </value>
         public override bool CanRead => true;
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/Expressions/DialogExpression.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/Expressions/DialogExpression.cs
@@ -47,12 +47,28 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         {
         }
 
+        /// <summary>
+        /// Converts a <see cref="Dialog"/> into a <see cref="DialogExpression"/>.
+        /// </summary>
+        /// <param name="value"><see cref="Dialog"/> expression.</param>
         public static implicit operator DialogExpression(Dialog value) => new DialogExpression(value);
 
+        /// <summary>
+        /// Converts a bool into a <see cref="DialogExpression"/>.
+        /// </summary>
+        /// <param name="dialogIdOrExpression">string expression.</param>
         public static implicit operator DialogExpression(string dialogIdOrExpression) => new DialogExpression(dialogIdOrExpression);
 
+        /// <summary>
+        /// Converts a <see cref="JToken"/> into a <see cref="DialogExpression"/>.
+        /// </summary>
+        /// <param name="value"><see cref="JToken"/> expression.</param>
         public static implicit operator DialogExpression(JToken value) => new DialogExpression(value);
 
+        /// <summary>
+        /// Sets the value.
+        /// </summary>
+        /// <param name="value">Value to set.</param>
         public override void SetValue(object value)
         {
             if (value is string str)
@@ -69,6 +85,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             base.SetValue(value);
         }
 
+        /// <summary>
+        /// Returns a string that represents the current object.
+        /// </summary>
+        /// <returns>A string value.</returns>
         public override string ToString()
         {
             if (this.Value != null)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/Expressions/DialogExpression.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/Expressions/DialogExpression.cs
@@ -50,23 +50,23 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         /// <summary>
         /// Converts a <see cref="Dialog"/> into a <see cref="DialogExpression"/>.
         /// </summary>
-        /// <param name="value"><see cref="Dialog"/> expression.</param>
+        /// <param name="value"><see cref="Dialog"/> to convert to a <see cref="DialogExpression"/>.</param>
         public static implicit operator DialogExpression(Dialog value) => new DialogExpression(value);
 
         /// <summary>
-        /// Converts a bool into a <see cref="DialogExpression"/>.
+        /// Converts a string into a <see cref="DialogExpression"/>.
         /// </summary>
-        /// <param name="dialogIdOrExpression">string expression.</param>
+        /// <param name="dialogIdOrExpression">string to convert to a <see cref="DialogExpression"/></param>
         public static implicit operator DialogExpression(string dialogIdOrExpression) => new DialogExpression(dialogIdOrExpression);
 
         /// <summary>
         /// Converts a <see cref="JToken"/> into a <see cref="DialogExpression"/>.
         /// </summary>
-        /// <param name="value"><see cref="JToken"/> expression.</param>
+        /// <param name="value"><see cref="JToken"/> to convert to a <see cref="DialogExpression"/></param>
         public static implicit operator DialogExpression(JToken value) => new DialogExpression(value);
 
         /// <summary>
-        /// Sets the value.
+        /// Sets the raw value of the expression property.
         /// </summary>
         /// <param name="value">Value to set.</param>
         public override void SetValue(object value)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/Expressions/DialogExpression.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/Expressions/DialogExpression.cs
@@ -56,13 +56,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         /// <summary>
         /// Converts a string into a <see cref="DialogExpression"/>.
         /// </summary>
-        /// <param name="dialogIdOrExpression">String to convert to a <see cref="DialogExpression"/></param>
+        /// <param name="dialogIdOrExpression">String to convert to a <see cref="DialogExpression"/>.</param>
         public static implicit operator DialogExpression(string dialogIdOrExpression) => new DialogExpression(dialogIdOrExpression);
 
         /// <summary>
         /// Converts a <see cref="JToken"/> into a <see cref="DialogExpression"/>.
         /// </summary>
-        /// <param name="value"><see cref="JToken"/> to convert to a <see cref="DialogExpression"/></param>
+        /// <param name="value"><see cref="JToken"/> to convert to a <see cref="DialogExpression"/>.</param>
         public static implicit operator DialogExpression(JToken value) => new DialogExpression(value);
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/Expressions/DialogExpression.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/Expressions/DialogExpression.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         /// <summary>
         /// Converts a string into a <see cref="DialogExpression"/>.
         /// </summary>
-        /// <param name="dialogIdOrExpression">string to convert to a <see cref="DialogExpression"/></param>
+        /// <param name="dialogIdOrExpression">String to convert to a <see cref="DialogExpression"/></param>
         public static implicit operator DialogExpression(string dialogIdOrExpression) => new DialogExpression(dialogIdOrExpression);
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors/ConditionalSelector.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors/ConditionalSelector.cs
@@ -16,6 +16,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Selectors
     /// </summary>
     public class ConditionalSelector : TriggerSelector
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.ConditionalSelector";
 
@@ -49,12 +52,23 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Selectors
         [JsonProperty("ifFalse")]
         public TriggerSelector IfFalse { get; set; }
 
+        /// <summary>
+        /// Initialize the selector with the set of rules.
+        /// </summary>
+        /// <param name="conditionals">Possible rules to match.</param>
+        /// <param name="evaluate">Optional, true by default if rules should be evaluated on select.</param>
         public override void Initialize(IEnumerable<OnCondition> conditionals, bool evaluate = true)
         {
             _conditionals = conditionals.ToList();
             _evaluate = evaluate;
         }
 
+        /// <summary>
+        /// Select the best rule to execute.
+        /// </summary>
+        /// <param name="actionContext">Dialog context for evaluation.</param>
+        /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/> of the task.</param>
+        /// <returns>Best rule in original list to execute or -1 if none.</returns>
         public override async Task<IReadOnlyList<OnCondition>> SelectAsync(ActionContext actionContext, CancellationToken cancellationToken = default)
         {
             var (eval, _) = Condition.TryGetValue(actionContext.State);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors/ConditionalSelector.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors/ConditionalSelector.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Selectors
         public TriggerSelector IfFalse { get; set; }
 
         /// <summary>
-        /// Initialize the selector with the set of rules.
+        /// Initializes the selector with the set of rules.
         /// </summary>
         /// <param name="conditionals">Possible rules to match.</param>
         /// <param name="evaluate">Optional, true by default if rules should be evaluated on select.</param>
@@ -64,7 +64,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Selectors
         }
 
         /// <summary>
-        /// Select the best rule to execute.
+        /// Selects the best rule to execute.
         /// </summary>
         /// <param name="actionContext">Dialog context for evaluation.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/> of the task.</param>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors/FirstSelector.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors/FirstSelector.cs
@@ -15,18 +15,32 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Selectors
     /// </summary>
     public class FirstSelector : TriggerSelector
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.FirstSelector";
 
         private List<OnCondition> _conditionals;
         private bool _evaluate;
 
+        /// <summary>
+        /// Initialize the selector with the set of rules.
+        /// </summary>
+        /// <param name="conditionals">Possible rules to match.</param>
+        /// <param name="evaluate">Optional, true by default if rules should be evaluated on select.</param>
         public override void Initialize(IEnumerable<OnCondition> conditionals, bool evaluate)
         {
             _conditionals = conditionals.ToList();
             _evaluate = evaluate;
         }
 
+        /// <summary>
+        /// Select the best rule to execute.
+        /// </summary>
+        /// <param name="context">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/> of the task.</param>
+        /// <returns>Best rule in original list to execute or -1 if none.</returns>
         public override Task<IReadOnlyList<OnCondition>> SelectAsync(ActionContext context, CancellationToken cancellationToken)
         {
             OnCondition selection = null;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors/FirstSelector.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors/FirstSelector.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Selectors
         private bool _evaluate;
 
         /// <summary>
-        /// Initialize the selector with the set of rules.
+        /// Initializes the selector with the set of rules.
         /// </summary>
         /// <param name="conditionals">Possible rules to match.</param>
         /// <param name="evaluate">Optional, true by default if rules should be evaluated on select.</param>
@@ -36,7 +36,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Selectors
         }
 
         /// <summary>
-        /// Select the best rule to execute.
+        /// Selects the best rule to execute.
         /// </summary>
         /// <param name="context">The <see cref="DialogContext"/> for the current turn of conversation.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/> of the task.</param>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors/MostSpecificSelector.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors/MostSpecificSelector.cs
@@ -15,6 +15,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Selectors
     /// </summary>
     public class MostSpecificSelector : TriggerSelector
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.MostSpecificSelector";
 
@@ -29,6 +32,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Selectors
         [JsonProperty("selector")]
         public TriggerSelector Selector { get; set; }
 
+        /// <summary>
+        /// Initialize the selector with the set of rules.
+        /// </summary>
+        /// <param name="conditionals">Possible rules to match.</param>
+        /// <param name="evaluate">Optional, true by default if rules should be evaluated on select.</param>
         public override void Initialize(IEnumerable<OnCondition> conditionals, bool evaluate)
         {
             foreach (var conditional in conditionals)
@@ -37,6 +45,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Selectors
             }
         }
 
+        /// <summary>
+        /// Select the best rule to execute.
+        /// </summary>
+        /// <param name="context">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/> of the task.</param>
+        /// <returns>Best rule in original list to execute or -1 if none.</returns>
         public override async Task<IReadOnlyList<OnCondition>> SelectAsync(ActionContext context, CancellationToken cancellationToken)
         {
             var triggers = _tree.Matches(context.State);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors/MostSpecificSelector.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors/MostSpecificSelector.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Selectors
         public TriggerSelector Selector { get; set; }
 
         /// <summary>
-        /// Initialize the selector with the set of rules.
+        /// Initializes the selector with the set of rules.
         /// </summary>
         /// <param name="conditionals">Possible rules to match.</param>
         /// <param name="evaluate">Optional, true by default if rules should be evaluated on select.</param>
@@ -46,7 +46,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Selectors
         }
 
         /// <summary>
-        /// Select the best rule to execute.
+        /// Selects the best rule to execute.
         /// </summary>
         /// <param name="context">The <see cref="DialogContext"/> for the current turn of conversation.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/> of the task.</param>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors/RandomSelector.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors/RandomSelector.cs
@@ -18,6 +18,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Selectors
     /// </summary>
     public class RandomSelector : TriggerSelector
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.RandomSelector";
 
@@ -34,12 +37,23 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Selectors
         [JsonProperty("seed")]
         public int Seed { get; set; } = -1;
 
+        /// <summary>
+        /// Initialize the selector with the set of rules.
+        /// </summary>
+        /// <param name="conditionals">Possible rules to match.</param>
+        /// <param name="evaluate">Optional, true by default if rules should be evaluated on select.</param>
         public override void Initialize(IEnumerable<OnCondition> conditionals, bool evaluate)
         {
             _conditionals = conditionals.ToList();
             _evaluate = evaluate;
         }
 
+        /// <summary>
+        /// Select the best rule to execute.
+        /// </summary>
+        /// <param name="context">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> of the task.</param>
+        /// <returns>Best rule in original list to execute or -1 if none.</returns>
         public override Task<IReadOnlyList<OnCondition>> SelectAsync(ActionContext context, CancellationToken cancellationToken = default)
         {
             var candidates = _conditionals;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors/RandomSelector.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors/RandomSelector.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Selectors
         public int Seed { get; set; } = -1;
 
         /// <summary>
-        /// Initialize the selector with the set of rules.
+        /// Initializes the selector with the set of rules.
         /// </summary>
         /// <param name="conditionals">Possible rules to match.</param>
         /// <param name="evaluate">Optional, true by default if rules should be evaluated on select.</param>
@@ -49,7 +49,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Selectors
         }
 
         /// <summary>
-        /// Select the best rule to execute.
+        /// Selects the best rule to execute.
         /// </summary>
         /// <param name="context">The <see cref="DialogContext"/> for the current turn of conversation.</param>
         /// <param name="cancellationToken"><see cref="CancellationToken"/> of the task.</param>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors/TrueSelector.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors/TrueSelector.cs
@@ -15,18 +15,32 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Selectors
     /// </summary>
     public class TrueSelector : TriggerSelector
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.TrueSelector";
 
         private List<OnCondition> _conditionals;
         private bool _evaluate;
 
+        /// <summary>
+        /// Initialize the selector with the set of rules.
+        /// </summary>
+        /// <param name="conditionals">Possible rules to match.</param>
+        /// <param name="evaluate">Optional, true by default if rules should be evaluated on select.</param>
         public override void Initialize(IEnumerable<OnCondition> conditionals, bool evaluate = true)
         {
             _conditionals = conditionals.ToList();
             _evaluate = evaluate;
         }
 
+        /// <summary>
+        /// Select the best rule to execute.
+        /// </summary>
+        /// <param name="context">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/> of the task.</param>
+        /// <returns>Best rule in original list to execute or -1 if none.</returns>
         public override Task<IReadOnlyList<OnCondition>> SelectAsync(ActionContext context, CancellationToken cancellationToken = default)
         {
             var candidates = _conditionals;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors/TrueSelector.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors/TrueSelector.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Selectors
         private bool _evaluate;
 
         /// <summary>
-        /// Initialize the selector with the set of rules.
+        /// Initializes the selector with the set of rules.
         /// </summary>
         /// <param name="conditionals">Possible rules to match.</param>
         /// <param name="evaluate">Optional, true by default if rules should be evaluated on select.</param>
@@ -36,7 +36,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Selectors
         }
 
         /// <summary>
-        /// Select the best rule to execute.
+        /// Selects the best rule to execute.
         /// </summary>
         /// <param name="context">The <see cref="DialogContext"/> for the current turn of conversation.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/> of the task.</param>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Templates/ActivityTemplate.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Templates/ActivityTemplate.cs
@@ -19,14 +19,23 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Templates
     [JsonConverter(typeof(ActivityTemplateConverter))]
     public class ActivityTemplate : ITemplate<Activity>
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.ActivityTemplate";
 
-        // Fixed text constructor for inline template
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActivityTemplate"/> class.
+        /// </summary>
         public ActivityTemplate()
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActivityTemplate"/> class.
+        /// </summary>
+        /// <param name="template">The template to evaluate to create the activity.</param>
         public ActivityTemplate(string template)
         {
             this.Template = template;
@@ -41,6 +50,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Templates
         [JsonProperty("template")]
         public string Template { get; set; }
 
+        /// <summary>
+        /// Given the turn context bind to the data to create the object of type <see cref="Activity"/>.
+        /// </summary>
+        /// <param name="dialogContext">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="data">Optional, data to bind to. If Null, then dc.State will be used.</param>
+        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> for this task.</param>
+        /// <returns>Instance of <see cref="Activity"/>.</returns>
         public virtual async Task<Activity> BindAsync(DialogContext dialogContext, object data = null, CancellationToken cancellationToken = default)
         {
             if (!string.IsNullOrEmpty(this.Template))
@@ -64,6 +80,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Templates
             return null;
         }
 
+        /// <summary>
+        /// Returns a string that represents <see cref="ActivityTemplate"/>.
+        /// </summary>
+        /// <returns>A string that represents <see cref="ActivityTemplate"/>.</returns>
         public override string ToString()
         {
             return $"{nameof(ActivityTemplate)}({this.Template})";

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Templates/StaticActivityTemplate.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Templates/StaticActivityTemplate.cs
@@ -14,26 +14,53 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Templates
     [JsonConverter(typeof(StaticActivityTemplateConverter))]
     public class StaticActivityTemplate : ITemplate<Activity>
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.StaticActivityTemplate";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StaticActivityTemplate"/> class.
+        /// </summary>
         public StaticActivityTemplate()
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StaticActivityTemplate"/> class.
+        /// </summary>
+        /// <param name="activity"><see cref="Activity"/>.</param>
         public StaticActivityTemplate(Activity activity)
         {
             this.Activity = activity;
         }
-        
+
+        /// <summary>
+        /// Gets or sets activity.
+        /// </summary>
+        /// <value>
+        /// <see cref="Activity"/>.
+        /// </value>
         [JsonProperty("activity")]
         public Activity Activity { get; set; }
 
+        /// <summary>
+        /// Gets the activity.
+        /// </summary>
+        /// <param name="context">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="data">Optional, data to bind to. If Null, then dc.State will be used.</param>
+        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> for this task.</param>
+        /// <returns>Task representing an activity.</returns>
         public Task<Activity> BindAsync(DialogContext context, object data = null, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(Activity);
         }
 
+        /// <summary>
+        /// Returns a string that represents <see cref="StaticActivityTemplate"/>.
+        /// </summary>
+        /// <returns>A string that represents <see cref="StaticActivityTemplate"/>.</returns>
         public override string ToString()
         {
             return $"{this.Activity.Text}";

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Templates/TextTemplate.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Templates/TextTemplate.cs
@@ -16,10 +16,16 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Templates
     [DebuggerDisplay("{Template}")]
     public class TextTemplate : ITemplate<string>
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.TextTemplate";
 
-        // Fixed text constructor for inline template
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TextTemplate"/> class.
+        /// </summary>
+        /// <param name="template">The template to evaluate to create the string.</param>
         public TextTemplate(string template)
         {
             this.Template = template ?? throw new ArgumentNullException(nameof(template));
@@ -34,6 +40,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Templates
         [JsonProperty("template")]
         public string Template { get; set; }
 
+        /// <summary>
+        /// Given the turn context bind to the data to create the object of type string.
+        /// </summary>
+        /// <param name="dialogContext">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="data">Optional, data to bind to. If Null, then dc.State will be used.</param>
+        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> for this task.</param>
+        /// <returns>Instance of string.</returns>
         public virtual async Task<string> BindAsync(DialogContext dialogContext, object data = null, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(this.Template))
@@ -55,6 +68,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Templates
             return null;
         }
 
+        /// <summary>
+        /// Returns a string that represents <see cref="TextTemplate"/>.
+        /// </summary>
+        /// <returns>A string that represents <see cref="TextTemplate"/>.</returns>
         public override string ToString()
         {
             return $"{nameof(TextTemplate)}({this.Template})";


### PR DESCRIPTION
Address # 4321

## Description
This PR adds the missing XML documentation to all visible classes, methods, properties, and parameters in the *Bot.Builder.Dialogs.Adaptive* [Functions](https://github.com/microsoft/botbuilder-dotnet/tree/main/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Functions), [Generators](https://github.com/microsoft/botbuilder-dotnet/tree/main/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators), [Input](https://github.com/microsoft/botbuilder-dotnet/tree/main/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input), [Memory](https://github.com/microsoft/botbuilder-dotnet/tree/main/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory), [Selectors](https://github.com/microsoft/botbuilder-dotnet/tree/main/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors), and [Templates](https://github.com/microsoft/botbuilder-dotnet/tree/main/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Templates) folders, removing 96 errors.

Note: the NoWarn-CS1591 property is removed in the last PR of the series adding the documentation to avoid build failures.

## Specific Changes
- Adds all missing documentation instances to all *.cs* files found within: 
  - [*Microsoft.Bot.Builder.Dialogs.Adaptive* Functions directory](https://github.com/microsoft/botbuilder-dotnet/tree/main/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Functions).
  - [*Microsoft.Bot.Builder.Dialogs.Adaptive* Generators directory](https://github.com/microsoft/botbuilder-dotnet/tree/main/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators).
  - [*Microsoft.Bot.Builder.Dialogs.Adaptive* Input directory](https://github.com/microsoft/botbuilder-dotnet/tree/main/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input).
  - [*Microsoft.Bot.Builder.Dialogs.Adaptive* Memory directory](https://github.com/microsoft/botbuilder-dotnet/tree/main/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory).
  - [*Microsoft.Bot.Builder.Dialogs.Adaptive* Selectors directory](https://github.com/microsoft/botbuilder-dotnet/tree/main/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors).
  - [*Microsoft.Bot.Builder.Dialogs.Adaptive* Templates directory](https://github.com/microsoft/botbuilder-dotnet/tree/main/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Templates).

## Testing
Below you can see the number of errors shown before and after the changes when de NoWarn-CS1591 property is removed.
![image](https://user-images.githubusercontent.com/38112957/92282698-8b8d6b80-eed4-11ea-993e-c1094035ce73.png)
