### PR TITLE
Add missing XML documentation to the Bot.Builder.Dialogs.Adaptive Root folder 

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/ActionChangeList.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/ActionChangeList.cs
@@ -7,17 +7,38 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive
 {
+    /// <summary>
+    /// Defines the action state change list.
+    /// </summary>
     [DebuggerDisplay("{ChangeType}:{Desire}")]
     public class ActionChangeList
     {
+        /// <summary>
+        /// Gets or sets the action change type value.
+        /// </summary>
+        /// <value>
+        /// Action change type value.
+        /// </value>
         [JsonProperty(PropertyName = "changeType")]
         public ActionChangeType ChangeType { get; set; } = ActionChangeType.InsertActions;
 
+        /// <summary>
+        /// Gets or sets the <see cref="ActionState"/> list.
+        /// </summary>
+        /// <value>
+        /// <see cref="ActionState"/> list.
+        /// </value>
         [JsonProperty(PropertyName = "actions")]
 #pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public List<ActionState> Actions { get; set; } = new List<ActionState>();
 #pragma warning restore CA2227 // Collection properties should be read only
 
+        /// <summary>
+        /// Gets or sets the tag list.
+        /// </summary>
+        /// <value>
+        /// Tag list.
+        /// </value>
         [JsonProperty(PropertyName = "tags")]
 #pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public List<string> Tags { get; set; } = new List<string>();

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/ActionState.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/ActionState.cs
@@ -6,22 +6,45 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive
 {
+    /// <summary>
+    /// Contains state information about the action.
+    /// </summary>
     [DebuggerDisplay("{DialogId}")]
     public class ActionState : DialogState
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActionState"/> class.
+        /// </summary>
         public ActionState()
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActionState"/> class.
+        /// </summary>
+        /// <param name="dialogId">Optional, dialog identifier value.</param>
+        /// <param name="options">Optional, dialog options.</param>
         public ActionState(string dialogId = null, object options = null)
         {
             DialogId = dialogId;
             Options = options;
         }
 
+        /// <summary>
+        /// Gets or sets DialogId value.
+        /// </summary>
+        /// <value>
+        /// DialogId value.
+        /// </value>
         [JsonProperty(PropertyName = "dialogId")]
         public string DialogId { get; set; }
 
+        /// <summary>
+        /// Gets or sets options value.
+        /// </summary>
+        /// <value>
+        /// Options value.
+        /// </value>
         [JsonProperty(PropertyName = "options")]
         public object Options { get; set; }
     }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveComponentRegistration.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveComponentRegistration.cs
@@ -24,8 +24,14 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive
 {
+    /// <summary>
+    /// <see cref="ComponentRegistration"/> implementation for adaptive components.
+    /// </summary>
     public class AdaptiveComponentRegistration : ComponentRegistration, IComponentDeclarativeTypes
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AdaptiveComponentRegistration"/> class.
+        /// </summary>
         public AdaptiveComponentRegistration()
         {
             // adaptive dialog functions
@@ -34,6 +40,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             Expression.Functions.Add(HasPendingActionsFunction.Name, new HasPendingActionsFunction());
         }
 
+        /// <summary>
+        /// Gets adaptive <see cref="DeclarativeType"/> resources.
+        /// </summary>
+        /// <param name="resourceExplorer"><see cref="ResourceExplorer"/> with expected path to get all schema resources.</param>
+        /// <returns>Adaptive <see cref="DeclarativeType"/> resources.</returns>
         public virtual IEnumerable<DeclarativeType> GetDeclarativeTypes(ResourceExplorer resourceExplorer)
         {
             // Conditionals
@@ -172,6 +183,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             }
         }
 
+        /// <summary>
+        /// Gets adaptive <see cref="JsonConverter"/> resources.
+        /// </summary>
+        /// <param name="resourceExplorer">ResourceExplorer to use to resolve references.</param>
+        /// <param name="sourceContext">SourceContext to build debugger source map.</param>
+        /// <returns>Adaptive <see cref="JsonConverter"/> resources.</returns>
         public virtual IEnumerable<JsonConverter> GetConverters(ResourceExplorer resourceExplorer, SourceContext sourceContext)
         {
             yield return new InterfaceConverter<OnCondition>(resourceExplorer, sourceContext);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         /// <summary>
         /// Initializes a new instance of the <see cref="AdaptiveDialog"/> class.
         /// </summary>
-        /// <param name="dialogId">Optioonal, dialog identifier.</param>
+        /// <param name="dialogId">Optional, dialog identifier.</param>
         /// <param name="callerPath">Optional, source file full path.</param>
         /// <param name="callerLine">Optional, line number in source file.</param>
         public AdaptiveDialog(string dialogId = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
@@ -242,7 +242,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         }
 
         /// <summary>
-        /// Called when a child dialog completed this turn, returning control to this dialog.
+        /// Called when a child dialog completed its turn, returning control to this dialog.
         /// </summary>
         /// <param name="dc">The dialog context for the current turn of the conversation.</param>
         /// <param name="reason">Reason why the dialog resumed.</param>
@@ -744,7 +744,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         }
 
         /// <summary>
-        /// Called when the dialog's action ends, finishes turn.
+        /// Awaits for completed actions to finish processing entity assignments and finishes turn.
         /// </summary>
         /// <param name="actionContext">The <see cref="ActionContext"/> for the current turn of conversation.</param>
         /// <param name="cancellationToken">Optional, a <see cref="CancellationToken"/> that can be used by other objects.</param>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
@@ -389,7 +389,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         /// </summary>
         /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
         /// <param name="dialogEvent">The <see cref="DialogEvent"/> being raised.</param>
-        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> for the task.</param>
+        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns> Whether the event is handled by the current dialog and further processing should stop.</returns>
         protected override async Task<bool> OnPreBubbleEventAsync(DialogContext dc, DialogEvent dialogEvent, CancellationToken cancellationToken = default)
         {
@@ -404,7 +404,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         /// </summary>
         /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
         /// <param name="dialogEvent">The <see cref="DialogEvent"/> being raised.</param>
-        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> for the task.</param>
+        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns> Whether the event is handled by the current dialog and further processing should stop.</returns>
         protected override async Task<bool> OnPostBubbleEventAsync(DialogContext dc, DialogEvent dialogEvent, CancellationToken cancellationToken = default)
         {
@@ -628,7 +628,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         /// </summary>
         /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
         /// <param name="options">Options used in evaluation. </param>
-        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> for the task.</param>
+        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>A <see cref="Task"/> representation of <see cref="DialogTurnResult"/>.</returns>
         protected async Task<DialogTurnResult> ContinueActionsAsync(DialogContext dc, object options, CancellationToken cancellationToken)
         {
@@ -779,7 +779,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         /// </summary>
         /// <param name="actionContext">The <see cref="ActionContext"/> for the current turn of conversation.</param>
         /// <param name="activity"><see cref="Activity"/> to recognize.</param>
-        /// <param name="cancellationToken">Optional, a <see cref="CancellationToken"/> for the task.</param>
+        /// <param name="cancellationToken">Optional, a <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>A <see cref="Task"/> representing a <see cref="RecognizerResult"/>.</returns>
         protected async Task<RecognizerResult> OnRecognizeAsync(ActionContext actionContext, Activity activity, CancellationToken cancellationToken = default)
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialogState.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialogState.cs
@@ -6,12 +6,24 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive
 {
+    /// <summary>
+    /// Defines adaptive dialog <see cref="ActionState"/> list.
+    /// </summary>
     public class AdaptiveDialogState
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AdaptiveDialogState"/> class.
+        /// </summary>
         public AdaptiveDialogState()
         {
         }
 
+        /// <summary>
+        /// Gets or sets <see cref="ActionState"/> list.
+        /// </summary>
+        /// <value>
+        /// <see cref="ActionState"/> list.
+        /// </value>
         [JsonProperty(PropertyName = "actions")]
 #pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public List<ActionState> Actions { get; set; } = new List<ActionState>();

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveEvents.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveEvents.cs
@@ -3,6 +3,9 @@
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive
 {
+    /// <summary>
+    /// Adaptive event identifier definition list.
+    /// </summary>
     public class AdaptiveEvents : DialogEvents
     {
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/EntityAssignment.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/EntityAssignment.cs
@@ -91,6 +91,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             }
         }
 
+        /// <summary>
+        /// Returns a string that represents the current object.
+        /// </summary>
+        /// <returns>A string that represents the current object.</returns>
         public override string ToString()
             => (IsExpected ? "+" : string.Empty) + $"{Event}: {Property} = {Operation}({Entity})";
     }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/EntityAssignmentComparer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/EntityAssignmentComparer.cs
@@ -31,6 +31,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             operationPreference = operations;
         }
 
+        /// <summary>
+        /// Compares <see cref="EntityAssignment"/> x against y to determine its relative priority.
+        /// </summary>
+        /// <param name="x">Reference Entity.</param>
+        /// <param name="y">Comparisson Entity.</param>
+        /// <returns>Numerical value representing x's relative priority.</returns>
         public override int Compare(EntityAssignment x, EntityAssignment y)
         {
             // Order by event

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/EntityInfo.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/EntityInfo.cs
@@ -126,6 +126,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         public bool Covers(EntityInfo entity)
             => (entity == this || entity.RootEntity != RootEntity) && Start <= entity.Start && End >= entity.End && End - Start > entity.End - entity.Start;
 
+        /// <summary>
+        /// Returns a string that represents the current object.
+        /// </summary>
+        /// <returns>A string that represents the current object.</returns>
         public override string ToString()
             => $"{Operation}({Name}:{Value}) P{Priority} {Score} {Coverage}";
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/JsonExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/JsonExtensions.cs
@@ -9,8 +9,17 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive
 {
+    /// <summary>
+    /// Implements JSON extensions.
+    /// </summary>
     public static class JsonExtensions
     {
+        /// <summary>
+        /// Removes first element of a queue.
+        /// </summary>
+        /// <typeparam name="T">Element type.</typeparam>
+        /// <param name="queue">List from where to remove first element.</param>
+        /// <returns>Element removed.</returns>
         public static T Dequeue<T>(this List<T> queue)
         {
             var result = default(T);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/LGResourceLoader.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/LGResourceLoader.cs
@@ -15,6 +15,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
     public class LGResourceLoader
 #pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
     {
+        /// <summary>
+        /// Groups locales from a given resource path.
+        /// </summary>
+        /// <param name="resourceExplorer"><see cref="ResourceExplorer"/> for the path to group.</param>
+        /// <returns>Dictionary of grouped locale.</returns>
         public static Dictionary<string, IList<Resource>> GroupByLocale(ResourceExplorer resourceExplorer)
         {
             var resourceMapping = new Dictionary<string, IList<Resource>>();

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/LanguageGenerator.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/LanguageGenerator.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         /// <param name="dialogContext">dialogContext.</param>
         /// <param name="template">template or [templateId].</param>
         /// <param name="data">data to bind to.</param>
-        /// <param name="cancellationToken">the <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <param name="cancellationToken">the <see cref="CancellationToken"/> for the task.</param>
         /// <returns>object or text.</returns>
 #pragma warning disable CA1716 // Identifiers should not match keywords (we can't change the template parameter name without breaking binary compat).
         public abstract Task<object> GenerateAsync(DialogContext dialogContext, string template, object data, CancellationToken cancellationToken = default);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/LanguageGenerator.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/LanguageGenerator.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         /// <param name="dialogContext">dialogContext.</param>
         /// <param name="template">template or [templateId].</param>
         /// <param name="data">data to bind to.</param>
-        /// <param name="cancellationToken">the <see cref="CancellationToken"/> for the task.</param>
+        /// <param name="cancellationToken">the <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>object or text.</returns>
 #pragma warning disable CA1716 // Identifiers should not match keywords (we can't change the template parameter name without breaking binary compat).
         public abstract Task<object> GenerateAsync(DialogContext dialogContext, string template, object data, CancellationToken cancellationToken = default);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/LanguageGeneratorExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/LanguageGeneratorExtensions.cs
@@ -9,6 +9,9 @@ using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive
 {
+    /// <summary>
+    /// Implements language generator extensions.
+    /// </summary>
     public static class LanguageGeneratorExtensions
     {
         private static Dictionary<ResourceExplorer, LanguageGeneratorManager> languageGeneratorManagers = new Dictionary<ResourceExplorer, LanguageGeneratorManager>();

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/LanguageGeneratorExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/LanguageGeneratorExtensions.cs
@@ -10,7 +10,7 @@ using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive
 {
     /// <summary>
-    /// Implements language generator extensions.
+    /// Implements extension methods for language generator.
     /// </summary>
     public static class LanguageGeneratorExtensions
     {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/LanguagePolicy.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/LanguagePolicy.cs
@@ -12,13 +12,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
     /// Language policy with fallback for each language as most specific to default en-us -> en -> default.
     /// </summary>
     public class LanguagePolicy : Dictionary<string, string[]>
-    {
-        // Keep this method for JSON deserialization 
+    { 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LanguagePolicy"/> class.
+        /// </summary>
+        // Keep this method for JSON deserialization
         public LanguagePolicy()
             : base(DefaultPolicy(), StringComparer.OrdinalIgnoreCase) 
         { 
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LanguagePolicy"/> class.
+        /// </summary>
+        /// <param name="defaultLanguage">Default language to use.</param>
         public LanguagePolicy(params string[] defaultLanguage)
             : base(DefaultPolicy(defaultLanguage), StringComparer.OrdinalIgnoreCase)
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Microsoft.Bot.Builder.Dialogs.Adaptive.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Microsoft.Bot.Builder.Dialogs.Adaptive.csproj
@@ -24,7 +24,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
     <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
     <!-- CA2225: Operator overloads have named alternates, excluding for now, we should address this if we want to support other platforms than C#
     see https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2225?view=vs-2019 .-->

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Microsoft.Bot.Builder.Dialogs.Adaptive.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Microsoft.Bot.Builder.Dialogs.Adaptive.csproj
@@ -28,7 +28,7 @@
     <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
     <!-- CA2225: Operator overloads have named alternates, excluding for now, we should address this if we want to support other platforms than C#
     see https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2225?view=vs-2019 .-->
-    <NoWarn>$(NoWarn);CS1591;SX1309;CA2225</NoWarn>
+    <NoWarn>$(NoWarn);SX1309;CA2225</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/PropertySchema.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/PropertySchema.cs
@@ -127,6 +127,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         /// </value>
         public IReadOnlyList<PropertySchema> Children { get; }
 
+        /// <summary>
+        /// Returns a string that represents the current object.
+        /// </summary>
+        /// <returns>A string that represents the current object.</returns>
         public override string ToString() => $"PropertySchema({Path})";
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/ResourceExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/ResourceExtensions.cs
@@ -9,6 +9,9 @@ using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive
 {
+    /// <summary>
+    /// Implements resource extensions.
+    /// </summary>
     public static class ResourceExtensions
     {
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/ResourceExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/ResourceExtensions.cs
@@ -10,7 +10,7 @@ using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive
 {
     /// <summary>
-    /// Implements resource extensions.
+    /// Implements extension methods for resource explorer.
     /// </summary>
     public static class ResourceExtensions
     {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TelemetryExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TelemetryExtensions.cs
@@ -3,6 +3,9 @@
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive
 {
+    /// <summary>
+    /// Implements telemetry extensions.
+    /// </summary>
     public static class TelemetryExtensions
     {
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TelemetryExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TelemetryExtensions.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive
 {
     /// <summary>
-    /// Implements telemetry extensions.
+    /// Implements extension methods for telemetry.
     /// </summary>
     public static class TelemetryExtensions
     {


### PR DESCRIPTION
Address # 4321

## Description
This PR adds the missing XML documentation to all visible classes, methods, properties, and parameters in the [Bot.Builder.Dialogs.Adaptive root folder](https://github.com/microsoft/botbuilder-dotnet/tree/main/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive), removing 46 errors.

Also, the NoWarn-CS1591 property is removed from the .csproj file, note that this change **will make the build throw errors** if the previous PRs with adding the library's documentation has not been merged.

The following PRs should be merged before this one:
- Add missing XML documentation to Bot.Builder.Dialogs.Adaptive Functions, Generators, Input, Memory, Selectors and Templates folders.
- Add missing XML documentation to Bot.Builder.Dialogs.Adaptive/Recognizers.
- Add missing XML documentation to Bot.Builder.Dialogs.Adaptive/TriggerConditions.
- Add missing XML documentation to Bot.Builder.Dialogs.Adaptive/Actions.


## Specific Changes
- Adds all missing documentation instances to all *.cs* files found within [*Microsoft.Bot.Builder.Dialogs.Adaptive* Root directory](https://github.com/microsoft/botbuilder-dotnet/tree/main/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive).
- Removed the NoWarn-CS1591 and its comment about removing it from the .csproj file.

## Testing
Below you can see the number of errors shown before and after the changes when de NoWarn-CS1591 property is removed.
![image](https://user-images.githubusercontent.com/38112957/92283639-b082de00-eed6-11ea-8257-f84a8f8803e2.png)
