### PR TITLE
Migrate Microsoft.Bot.Builder.Dialogs.Adaptive.Tests to xUnit

### DIFF
--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionScopeTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionScopeTests.cs
@@ -2,67 +2,60 @@
 // Licensed under the MIT License.
 #pragma warning disable SA1118 // Parameter should not span multiple lines
 
-using System.IO;
 using System.Threading.Tasks;
-using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 {
-    [TestClass]
-    public class ActionScopeTests
+    public class ActionScopeTests : IClassFixture<ResourceExplorerFixture>
     {
-        public static ResourceExplorer ResourceExplorer { get; set; }
+        private readonly ResourceExplorerFixture _resourceExplorerFixture;
 
-        public TestContext TestContext { get; set; }
-
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext context)
+        public ActionScopeTests(ResourceExplorerFixture resourceExplorerFixture)
         {
-            ResourceExplorer = new ResourceExplorer()
-                .AddFolder(Path.Combine(TestUtils.GetProjectPath(), "Tests", nameof(ActionScopeTests)), monitorChanges: false);
+            _resourceExplorerFixture = resourceExplorerFixture.AddFolder(nameof(ActionScopeTests));
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ActionScope_Goto()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ActionScope_Goto_Parent()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ActionScope_Goto_OnIntent()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ActionScope_Goto_Nowhere()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ActionScope_Break()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ActionScope_Continue()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ActionScope_Goto_Switch()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionScopeTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionScopeTests.cs
@@ -7,13 +7,14 @@ using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 {
+    [CollectionDefinition("Dialogs.Adaptive")]
     public class ActionScopeTests : IClassFixture<ResourceExplorerFixture>
     {
         private readonly ResourceExplorerFixture _resourceExplorerFixture;
 
         public ActionScopeTests(ResourceExplorerFixture resourceExplorerFixture)
         {
-            _resourceExplorerFixture = resourceExplorerFixture.AddFolder(nameof(ActionScopeTests));
+            _resourceExplorerFixture = resourceExplorerFixture.Initialize(nameof(ActionScopeTests));
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
@@ -14,367 +14,361 @@ using Microsoft.Bot.Builder.Dialogs.Adaptive.Actions;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Bot.Schema;
-using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using RichardSzalay.MockHttp;
+using Xunit;
 using HttpMethod = System.Net.Http.HttpMethod;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 {
-    [TestClass]
-    public class ActionTests
+    public class ActionTests : IClassFixture<ResourceExplorerFixture>
     {
-        public static ResourceExplorer ResourceExplorer { get; set; }
+        private readonly ResourceExplorerFixture _resourceExplorerFixture;
 
-        public TestContext TestContext { get; set; }
-
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext context)
+        public ActionTests(ResourceExplorerFixture resourceExplorerFixture)
         {
-            ResourceExplorer = new ResourceExplorer()
-                .AddFolder(Path.Combine(TestUtils.GetProjectPath(), "Tests", nameof(ActionTests)), monitorChanges: false);
+            _resourceExplorerFixture = resourceExplorerFixture.AddFolder(nameof(ActionTests));
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_AttachmentInput()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_BeginDialog()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_BeginDialogWithActivity()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_BeginDialogWithoutActivity()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_CancelDialog()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_CancelDialog_Processed()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_CancelAllDialogs()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_CancelAllDialogs_DoubleCancel()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_ChoiceInput()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_ChoiceInput_WithLocale()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_ChoicesInMemory()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_ChoiceStringInMemory()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_ConfirmInput()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_DatetimeInput()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_DeleteActivity()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_DoActions()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_DynamicBeginDialog()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_EditActionInsertActions()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_EditActionAppendActions()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_EditActionReplaceSequence()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_EmitEvent()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_EndDialog()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_Foreach()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_Foreach_Nested()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_Foreach_Empty()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_ForeachPage()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_ForeachPage_Nested()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_ForeachPage_Empty()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_ForeachPage_Partial()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_GetActivityMembers()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_GetConversationMembers()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_IfCondition()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_NumberInput()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_NumberInputWithDefaultValue()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_NumberInputWithVAlueExpression()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_RepeatDialog()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_RepeatDialogLoop()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_ReplaceDialog()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_ReplaceDialogRecursive()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_SignOutUser()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_Switch()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_Switch_Bool()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_Switch_Default()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_Switch_Number()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_TextInput()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_TextInputWithInvalidPrompt()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_TextInputWithValueExpression()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_TraceActivity()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_UpdateActivity()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_WaitForInput()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task InputDialog_ActivityProcessed()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_SendActivity()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_SetProperty()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_SetProperties()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_DeleteProperty()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_DeleteProperties()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_HttpRequest()
         {
             var handler = new MockHttpMessageHandler();
@@ -529,7 +523,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                 }
             };
 
-            DialogManager dm = new DialogManager(rootDialog)
+            var dm = new DialogManager(rootDialog)
                 .UseResourceExplorer(new ResourceExplorer())
                 .UseLanguageGeneration();
             dm.InitialTurnState.Set<HttpClient>(handler.ToHttpClient());
@@ -549,7 +543,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                 .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Action_TelemetryTrackEvent()
         {
             var mockTelemetryClient = new Mock<IBotTelemetryClient>();
@@ -572,7 +566,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                                     new Dictionary<string, AdaptiveExpressions.Properties.
                                         StringExpression>()
                                     {
-                                        { "prop1", "value1" }, 
+                                        { "prop1", "value1" },
                                         { "prop2", "value2" }
                                     }
                             },
@@ -585,17 +579,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             var dm = new DialogManager(rootDialog)
                 .UseResourceExplorer(new ResourceExplorer())
                 .UseLanguageGeneration();
-            
+
             await new TestFlow((TestAdapter)testAdapter, dm.OnTurnAsync)
                 .SendConversationUpdate()
                 .StartTestAsync();
 
             var testEventInvocation = mockTelemetryClient.Invocations.FirstOrDefault(i => i.Arguments[0]?.ToString() == "testEvent");
 
-            Assert.IsNotNull(testEventInvocation);
-            Assert.IsTrue(((Dictionary<string, string>)testEventInvocation.Arguments[1]).Count == 2);
-            Assert.AreEqual(((Dictionary<string, string>)testEventInvocation.Arguments[1])["prop1"], "value1");
-            Assert.AreEqual(((Dictionary<string, string>)testEventInvocation.Arguments[1])["prop2"], "value2");
+            Assert.NotNull(testEventInvocation);
+            Assert.Equal(2, ((Dictionary<string, string>)testEventInvocation.Arguments[1]).Count);
+            Assert.Equal("value1", ((Dictionary<string, string>)testEventInvocation.Arguments[1])["prop1"]);
+            Assert.Equal("value2", ((Dictionary<string, string>)testEventInvocation.Arguments[1])["prop2"]);
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
@@ -23,13 +23,14 @@ using HttpMethod = System.Net.Http.HttpMethod;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 {
+    [CollectionDefinition("Dialogs.Adaptive")]
     public class ActionTests : IClassFixture<ResourceExplorerFixture>
     {
         private readonly ResourceExplorerFixture _resourceExplorerFixture;
 
         public ActionTests(ResourceExplorerFixture resourceExplorerFixture)
         {
-            _resourceExplorerFixture = resourceExplorerFixture.AddFolder(nameof(ActionTests));
+            _resourceExplorerFixture = resourceExplorerFixture.Initialize(nameof(ActionTests));
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/AdaptiveDialogTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/AdaptiveDialogTests.cs
@@ -18,13 +18,14 @@ using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 {
+    [CollectionDefinition("Dialogs.Adaptive")]
     public class AdaptiveDialogTests : IClassFixture<ResourceExplorerFixture>
     {
         private readonly ResourceExplorerFixture _resourceExplorerFixture;
 
         public AdaptiveDialogTests(ResourceExplorerFixture resourceExplorerFixture)
         {
-            _resourceExplorerFixture = resourceExplorerFixture.AddFolder(nameof(AdaptiveDialogTests));
+            _resourceExplorerFixture = resourceExplorerFixture.Initialize(nameof(AdaptiveDialogTests));
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/AdaptiveDialogTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/AdaptiveDialogTests.cs
@@ -8,252 +8,242 @@
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Threading;
-using System.IO;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Actions;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Templates;
-using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing;
-using Newtonsoft.Json.Linq;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 {
-    [TestClass]
-    public class AdaptiveDialogTests
+    public class AdaptiveDialogTests : IClassFixture<ResourceExplorerFixture>
     {
-        public static ResourceExplorer ResourceExplorer { get; set; }
+        private readonly ResourceExplorerFixture _resourceExplorerFixture;
 
-        public TestContext TestContext { get; set; }
-
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext context)
+        public AdaptiveDialogTests(ResourceExplorerFixture resourceExplorerFixture)
         {
-            ResourceExplorer = new ResourceExplorer()
-                .AddFolder(Path.Combine(TestUtils.GetProjectPath(), "Tests", nameof(AdaptiveDialogTests)), monitorChanges: false);
+            _resourceExplorerFixture = resourceExplorerFixture.AddFolder(nameof(AdaptiveDialogTests));
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_ActivityEvents()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_ActivityAndIntentEvents()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_AdaptiveCardSubmit()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_AllowInterruption()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_AllowInterruptionAlwaysWithFailedValidation()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_AllowInterruptionNever()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_AllowInterruptionNeverWithInvalidInput()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_AllowInterruptionNeverWithMaxCount()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_AllowInterruptionNeverWithUnrecognizedInput()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_BeginDialog()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_BindingCaptureValueWithinSameAdaptive()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_BindingOptionsAcrossAdaptiveDialogs()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_BindingReferValueInLaterAction()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_BindingReferValueInNestedAction()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_ConditionallyAllowInterruptions()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_DoActions()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_EditArray()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_EndTurn()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_IfProperty()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_NestedInlineSequences()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_NestedRecognizers()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_PropertySetInInterruption()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_ReplacePlan()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_ReProcessInputProperty()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_ReProcessInputPropertyValidOnlyOnce()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_StringLiteralInExpression()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_TextInput()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_TextInputDefaultValueResponse()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_TextInputNoMaxTurnCount()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_TopLevelFallback()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_TopLevelFallbackMultipleActivities()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestBindingTwoWayAcrossAdaptiveDialogs()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestForeachWithPrompt()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestBindingTwoWayAcrossAdaptiveDialogsDefaultResultProperty()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_EmitEventActivityReceived()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_NestedMemoryAccess()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
-        [Ignore]
+        [Fact(Skip = "Ignore")]
         public async Task TestForeachWithLargeItems()
         {
             var testFlow = new TestScript()
@@ -267,7 +257,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                 testFlow = testFlow.AssertReply(i.ToString());
             }
 
-            await testFlow.ExecuteAsync(ResourceExplorer);
+            await testFlow.ExecuteAsync(_resourceExplorerFixture.ResourceExplorer);
         }
 
         private class ForeachItemsDialog : ComponentDialog
@@ -306,17 +296,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void AdaptiveDialog_GetInternalVersion()
         {
             var ds = new TestAdaptiveDialog();
             var version1 = ds.GetInternalVersion_Test();
-            Assert.IsNotNull(version1);
+            Assert.NotNull(version1);
 
             var ds2 = new TestAdaptiveDialog();
-            var version2 = ds.GetInternalVersion_Test();
-            Assert.IsNotNull(version2);
-            Assert.AreEqual(version1, version2, "Same configuration should give same version");
+            var version2 = ds2.GetInternalVersion_Test();
+            Assert.NotNull(version2);
+            Assert.Equal(version1, version2);
 
             ds2 = new TestAdaptiveDialog()
             {
@@ -329,8 +319,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             };
 
             var version3 = ds2.GetInternalVersion_Test();
-            Assert.IsNotNull(version3);
-            Assert.AreNotEqual(version2, version3, "version should change if trigger added");
+            Assert.NotNull(version3);
+            Assert.NotEqual(version2, version3);
 
             ds2 = new TestAdaptiveDialog()
             {
@@ -344,8 +334,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             };
 
             var version4 = ds2.GetInternalVersion_Test();
-            Assert.IsNotNull(version4);
-            Assert.AreNotEqual(version3, version4, "version should change if condition modified");
+            Assert.NotNull(version4);
+            Assert.NotEqual(version3, version4);
 
             var ds3 = new TestAdaptiveDialog()
             {
@@ -363,14 +353,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             };
 
             var version5 = ds3.GetInternalVersion_Test();
-            Assert.IsNotNull(version5);
-            Assert.AreNotEqual(version4, version5, "version should change if action added ");
+            Assert.NotNull(version5);
+            Assert.NotEqual(version4, version5);
 
             var version6 = ds3.GetInternalVersion_Test();
-            Assert.AreEqual(version5, version6, "version should be same if no change");
+            Assert.Equal(version5, version6);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_ChangeDetect_None()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -396,7 +386,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                 .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AdaptiveDialog_ChangeDetect()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -459,7 +449,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
         {
             public string GetInternalVersion_Test()
             {
-                this.EnsureDependenciesInstalled();
+                EnsureDependenciesInstalled();
                 return GetInternalVersion();
             }
         }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/AdaptiveDialogTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/AdaptiveDialogTests.cs
@@ -303,12 +303,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             var version1 = ds.GetInternalVersion_Test();
             Assert.NotNull(version1);
 
-            var ds2 = new TestAdaptiveDialog();
-            var version2 = ds2.GetInternalVersion_Test();
+            var version2 = ds.GetInternalVersion_Test();
             Assert.NotNull(version2);
             Assert.Equal(version1, version2);
 
-            ds2 = new TestAdaptiveDialog()
+            var ds2 = new TestAdaptiveDialog()
             {
                 Triggers = new List<OnCondition>()
                 {

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ChoiceSetTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ChoiceSetTests.cs
@@ -8,9 +8,9 @@ using AdaptiveExpressions.Converters;
 using AdaptiveExpressions.Properties;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Input;
 using Microsoft.Bot.Builder.Dialogs.Choices;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 {
@@ -23,19 +23,18 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
         public ObjectExpression<ChoiceSet> Choices { get; set; }
     }
 
-    [TestClass]
     public class ChoiceSetTests
     {
-        private JsonSerializerSettings settings = new JsonSerializerSettings()
+        private readonly JsonSerializerSettings settings = new JsonSerializerSettings()
         {
-            Converters = new List<JsonConverter>() 
-            { 
+            Converters = new List<JsonConverter>()
+            {
                 new ChoiceSetConverter(),
                 new ObjectExpressionConverter<ChoiceSet>()
             }
         };
 
-        [TestMethod]
+        [Fact]
         public void TestExpressionAccess()
         {
             var state = new
@@ -50,12 +49,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 
             var ep = new ObjectExpression<ChoiceSet>("choices");
             var (result, error) = ep.TryGetValue(state);
-            Assert.AreEqual("test1", result[0].Value);
-            Assert.AreEqual("test2", result[1].Value);
-            Assert.AreEqual("test3", result[2].Value);
+            Assert.Equal("test1", result[0].Value);
+            Assert.Equal("test2", result[1].Value);
+            Assert.Equal("test3", result[2].Value);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestValueAccess()
         {
             var state = new object();
@@ -66,12 +65,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                     new Choice() { Value = "test3" }
                 });
             var (result, error) = ep.TryGetValue(state);
-            Assert.AreEqual("test1", result[0].Value);
-            Assert.AreEqual("test2", result[1].Value);
-            Assert.AreEqual("test3", result[2].Value);
+            Assert.Equal("test1", result[0].Value);
+            Assert.Equal("test2", result[1].Value);
+            Assert.Equal("test3", result[2].Value);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestJObjectAccess()
         {
             var foo = new List<Choice>()
@@ -83,23 +82,23 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 
             var ep = new ObjectExpression<ChoiceSet>(new ChoiceSet(JArray.FromObject(foo)));
             var (result, error) = ep.TryGetValue(new object());
-            Assert.AreEqual("test1", result[0].Value);
-            Assert.AreEqual("test2", result[1].Value);
-            Assert.AreEqual("test3", result[2].Value);
+            Assert.Equal("test1", result[0].Value);
+            Assert.Equal("test2", result[1].Value);
+            Assert.Equal("test3", result[2].Value);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestStringArrayAccess()
         {
             var foo = new List<string>() { "test1", "test2", "test3" };
             var ep = new ObjectExpression<ChoiceSet>(new ChoiceSet(JArray.FromObject(foo)));
             var (result, error) = ep.TryGetValue(new object());
-            Assert.AreEqual("test1", result[0].Value);
-            Assert.AreEqual("test2", result[1].Value);
-            Assert.AreEqual("test3", result[2].Value);
+            Assert.Equal("test1", result[0].Value);
+            Assert.Equal("test2", result[1].Value);
+            Assert.Equal("test3", result[2].Value);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestConverterExpressionAccess()
         {
             var state = new
@@ -119,15 +118,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             var json = JsonConvert.SerializeObject(sample, settings);
 
             var bar = JsonConvert.DeserializeObject<Bar>(json, settings);
-            Assert.AreEqual(typeof(Bar), bar.GetType());
-            Assert.AreEqual(typeof(ObjectExpression<ChoiceSet>), bar.Choices.GetType());
+            Assert.Equal(typeof(Bar), bar.GetType());
+            Assert.Equal(typeof(ObjectExpression<ChoiceSet>), bar.Choices.GetType());
             var (result, error) = bar.Choices.TryGetValue(state);
-            Assert.AreEqual("test1", result[0].Value);
-            Assert.AreEqual("test2", result[1].Value);
-            Assert.AreEqual("test3", result[2].Value);
+            Assert.Equal("test1", result[0].Value);
+            Assert.Equal("test2", result[1].Value);
+            Assert.Equal("test3", result[2].Value);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestConverterObjectAccess()
         {
             var state = new
@@ -146,15 +145,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             var json = JsonConvert.SerializeObject(sample, settings);
 
             var bar = JsonConvert.DeserializeObject<Bar>(json, settings);
-            Assert.AreEqual(typeof(Bar), bar.GetType());
-            Assert.AreEqual(typeof(ObjectExpression<ChoiceSet>), bar.Choices.GetType());
+            Assert.Equal(typeof(Bar), bar.GetType());
+            Assert.Equal(typeof(ObjectExpression<ChoiceSet>), bar.Choices.GetType());
             var (result, error) = bar.Choices.TryGetValue(state);
-            Assert.AreEqual("test1", result[0].Value);
-            Assert.AreEqual("test2", result[1].Value);
-            Assert.AreEqual("test3", result[2].Value);
+            Assert.Equal("test1", result[0].Value);
+            Assert.Equal("test2", result[1].Value);
+            Assert.Equal("test3", result[2].Value);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestConverterStringAccess()
         {
             var state = new
@@ -174,15 +173,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             var json = JsonConvert.SerializeObject(sample, settings);
 
             var bar = JsonConvert.DeserializeObject<Bar>(json, settings);
-            Assert.AreEqual(typeof(Bar), bar.GetType());
-            Assert.AreEqual(typeof(ObjectExpression<ChoiceSet>), bar.Choices.GetType());
+            Assert.Equal(typeof(Bar), bar.GetType());
+            Assert.Equal(typeof(ObjectExpression<ChoiceSet>), bar.Choices.GetType());
             var (result, error) = bar.Choices.TryGetValue(state);
-            Assert.AreEqual("test1", result[0].Value);
-            Assert.AreEqual("test2", result[1].Value);
-            Assert.AreEqual("test3", result[2].Value);
+            Assert.Equal("test1", result[0].Value);
+            Assert.Equal("test2", result[1].Value);
+            Assert.Equal("test3", result[2].Value);
         }
 
-        [TestMethod]
+        [Fact]
         public void ChoiceSet_RoundTrip()
         {
             var foo = new ChoiceSet()
@@ -193,24 +192,26 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                 };
 
             var bar = JsonConvert.DeserializeObject<ChoiceSet>(JsonConvert.SerializeObject(foo));
-            for (int i = 0; i < foo.Count; i++)
+            for (var i = 0; i < foo.Count; i++)
             {
-                Assert.AreEqual(foo[i].Value, bar[i].Value);
+                Assert.Equal(foo[i].Value, bar[i].Value);
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void ChoiceSet_StringArray()
         {
-            var values = new JArray();
-            values.Add("test1");
-            values.Add("test2");
-            values.Add("test3");
+            var values = new JArray
+            {
+                "test1",
+                "test2",
+                "test3"
+            };
 
             var result = JsonConvert.DeserializeObject<ChoiceSet>(values.ToString());
-            Assert.AreEqual("test1", result[0].Value);
-            Assert.AreEqual("test2", result[1].Value);
-            Assert.AreEqual("test3", result[2].Value);
+            Assert.Equal("test1", result[0].Value);
+            Assert.Equal("test2", result[1].Value);
+            Assert.Equal("test3", result[2].Value);
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ChoiceSetTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ChoiceSetTests.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
         public ObjectExpression<ChoiceSet> Choices { get; set; }
     }
 
+    [CollectionDefinition("Dialogs.Adaptive")]
     public class ChoiceSetTests
     {
         private readonly JsonSerializerSettings settings = new JsonSerializerSettings()

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ConditionalsTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ConditionalsTests.cs
@@ -10,13 +10,14 @@ using dbg = System.Diagnostics;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 {
+    [CollectionDefinition("Dialogs.Adaptive")]
     public class ConditionalsTests : IClassFixture<ResourceExplorerFixture>
     {
         private readonly ResourceExplorerFixture _resourceExplorerFixture;
 
         public ConditionalsTests(ResourceExplorerFixture resourceExplorerFixture)
         {
-            _resourceExplorerFixture = resourceExplorerFixture.AddFolder(nameof(ConditionalsTests));
+            _resourceExplorerFixture = resourceExplorerFixture.Initialize(nameof(ConditionalsTests));
         }
         
         [Fact]

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ConditionalsTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ConditionalsTests.cs
@@ -2,62 +2,48 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
-using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions;
-using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Bot.Schema;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 using dbg = System.Diagnostics;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 {
-    [TestClass]
-    public class ConditionalsTests
+    public class ConditionalsTests : IClassFixture<ResourceExplorerFixture>
     {
-        public static ResourceExplorer ResourceExplorer { get; set; }
+        private readonly ResourceExplorerFixture _resourceExplorerFixture;
 
-        public TestContext TestContext { get; set; }
-
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext context)
+        public ConditionalsTests(ResourceExplorerFixture resourceExplorerFixture)
         {
-            ResourceExplorer = new ResourceExplorer()
-                .AddFolder(Path.Combine(TestUtils.GetProjectPath(), "Tests", nameof(ConditionalsTests)), monitorChanges: false);
+            _resourceExplorerFixture = resourceExplorerFixture.AddFolder(nameof(ConditionalsTests));
         }
         
-        [TestMethod]
+        [Fact]
         public async Task ConditionalsTests_OnIntent()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ConditionalsTests_OnIntentWithEntities()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ConditionalsTests_OnActivityTypes()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ConditionalsTests_OnChooseIntent()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        public void AssertExpression(OnCondition condition, string expectedExpression)
-        {
-            var exp = condition.GetExpression();
-            dbg.Trace.TraceInformation(exp.ToString());
-            Assert.AreEqual(expectedExpression, exp.ToString());
-        }
-
-        [TestMethod]
+        [Fact]
         public void OnConditionWithCondition()
         {
             AssertExpression(
@@ -188,6 +174,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                     Condition = "turn.test == 1"
                 },
                 "(turn.test == 1)");
+        }
+
+        private void AssertExpression(OnCondition condition, string expectedExpression)
+        {
+            var exp = condition.GetExpression();
+            dbg.Trace.TraceInformation(exp.ToString());
+            Assert.Equal(expectedExpression, exp.ToString());
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ConfigurationFixture.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ConfigurationFixture.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
+{
+    public class ConfigurationFixture : IDisposable
+    {
+        public ConfigurationFixture()
+        {
+            Configuration = new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: false)
+                .Build();
+        }
+
+        public IConfiguration Configuration { get; private set; }
+
+        public void Dispose()
+        {
+            Configuration = null;
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ConfigurationFixture.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ConfigurationFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/CrossTrainedRecognizerSetTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/CrossTrainedRecognizerSetTests.cs
@@ -7,13 +7,14 @@ using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
 {
+    [CollectionDefinition("Dialogs.Adaptive.Recognizers")]
     public class CrossTrainedRecognizerSetTests : IClassFixture<ResourceExplorerFixture>
     {
         private readonly ResourceExplorerFixture _resourceExplorerFixture;
 
         public CrossTrainedRecognizerSetTests(ResourceExplorerFixture resourceExplorerFixture)
         {
-            _resourceExplorerFixture = resourceExplorerFixture.AddFolder(nameof(CrossTrainedRecognizerSetTests));
+            _resourceExplorerFixture = resourceExplorerFixture.Initialize(nameof(CrossTrainedRecognizerSetTests));
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/CrossTrainedRecognizerSetTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/CrossTrainedRecognizerSetTests.cs
@@ -1,62 +1,55 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Tests;
-using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
 {
-    [TestClass]
-    public class CrossTrainedRecognizerSetTests
+    public class CrossTrainedRecognizerSetTests : IClassFixture<ResourceExplorerFixture>
     {
-        public static ResourceExplorer ResourceExplorer { get; set; }
+        private readonly ResourceExplorerFixture _resourceExplorerFixture;
 
-        public TestContext TestContext { get; set; }
-
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext context)
+        public CrossTrainedRecognizerSetTests(ResourceExplorerFixture resourceExplorerFixture)
         {
-            ResourceExplorer = new ResourceExplorer()
-                .AddFolder(Path.Combine(TestUtils.GetProjectPath(), "Tests", nameof(CrossTrainedRecognizerSetTests)), monitorChanges: false);
+            _resourceExplorerFixture = resourceExplorerFixture.AddFolder(nameof(CrossTrainedRecognizerSetTests));
         }
 
-        [TestMethod]
+        [Fact]
         public async Task CrossTrainedRecognizerSetTests_DoubleDefer()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task CrossTrainedRecognizerSetTests_CircleDefer()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task CrossTrainedRecognizerSetTests_DoubleIntent()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task CrossTrainedRecognizerSetTests_NoneWithIntent()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task CrossTrainedRecognizerSetTests_AllNone()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task CrossTrainedRecognizerSetTests_Empty()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/DebugComposer.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/DebugComposer.cs
@@ -3,21 +3,17 @@
 #pragma warning disable SA1118 // Parameter should not span multiple lines
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Extensions.Configuration;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 {
-    [TestClass]
     public class DebugComposer
     {
-        public TestContext TestContext { get; set; }
-
         // This test can be used to debug a composer bot, simple point botPath => composer bot
         // and add debug.test.dialog script to that folder
         // {
@@ -26,8 +22,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
         //  "dialog": "bot.root.dialog",
         //  "script": [...] 
         // }
-        [Ignore]
-        [TestMethod]
+        [Fact(Skip = "Ignore")]
         public async Task DebugComposerBot()
         {
             // luis.settings.{environment}.{region}.json

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/DebugComposer.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/DebugComposer.cs
@@ -12,6 +12,7 @@ using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 {
+    [CollectionDefinition("Dialogs.Adaptive")]
     public class DebugComposer
     {
         // This test can be used to debug a composer bot, simple point botPath => composer bot

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/EntityRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/EntityRecognizerTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
 {
+    [CollectionDefinition("Dialogs.Adaptive.Recognizers")]
     public class EntityRecognizerTests
     {
         private static JsonSerializerSettings jsonSerializerSettings = new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, Formatting = Formatting.Indented };

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/EntityRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/EntityRecognizerTests.cs
@@ -1,15 +1,11 @@
 ﻿using System;
-using System.IO;
 using System.Linq;
 using Microsoft.Bot.Builder.Adapters;
-using Microsoft.Bot.Builder.Dialogs.Adaptive.Tests;
-using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
 {
-    [TestClass]
     public class EntityRecognizerTests
     {
         private static JsonSerializerSettings jsonSerializerSettings = new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, Formatting = Formatting.Indented };
@@ -40,201 +36,199 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
             };
         });
 
-        public TestContext TestContext { get; set; }
-
-        [TestMethod]
+        [Fact]
         public void TestAge()
         {
-            var turnContext = GetTurnContext("This is a test of one, 2, three years old");
+            var turnContext = GetTurnContext(nameof(TestAge), "This is a test of one, 2, three years old");
             var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
 
-            Assert.AreEqual(6, results.Count, "Should be 5 entities found");
-            Assert.AreEqual(1, results.Where(entity => entity.Type == "age").Count(), "Should have 1 age entity");
+            Assert.Equal(6, results.Count);
+            Assert.Single(results.Where(entity => entity.Type == "age").ToList());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestConfirmation()
         {
-            var turnContext = GetTurnContext("yes, please");
+            var turnContext = GetTurnContext(nameof(TestConfirmation), "yes, please");
             var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
 
-            Assert.AreEqual(2, results.Count, "Should be 1 entities found");
-            Assert.AreEqual(1, results.Where(entity => entity.Type == "boolean").Count(), "Should have 1 boolean results");
+            Assert.Equal(2, results.Count);
+            Assert.Single(results.Where(entity => entity.Type == "boolean").ToList());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestCurrency()
         {
-            var turnContext = GetTurnContext("I would pay four dollars for that.");
+            var turnContext = GetTurnContext(nameof(TestCurrency), "I would pay four dollars for that.");
             var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
 
-            Assert.AreEqual(3, results.Count, "Should be 2 entities found");
-            Assert.AreEqual(1, results.Where(entity => entity.Type == "currency").Count(), "Should have 1 currency result");
+            Assert.Equal(3, results.Count);
+            Assert.Single(results.Where(entity => entity.Type == "currency").ToList());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestDateTime()
         {
-            var turnContext = GetTurnContext("Next thursday at 4pm.");
+            var turnContext = GetTurnContext(nameof(TestDateTime), "Next thursday at 4pm.");
             var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
 
-            Assert.AreEqual(4, results.Count, "Should be 3 entities found");
-            Assert.AreEqual(1, results.Where(entity => entity.Type == "datetimeV2.datetime").Count(), "Should have 1 datetime result");
-            Assert.AreEqual(1, results.Where(entity => entity.Type == "ordinal.relative").Count(), "Should have 1 ordinal.relative result");
-            Assert.AreEqual(1, results.Where(entity => entity.Type == "dimension").Count(), "Should have 1 dimension result");
+            Assert.Equal(4, results.Count);
+            Assert.Single(results.Where(entity => entity.Type == "datetimeV2.datetime").ToList());
+            Assert.Single(results.Where(entity => entity.Type == "ordinal.relative").ToList());
+            Assert.Single(results.Where(entity => entity.Type == "dimension").ToList());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestDimension()
         {
-            var turnContext = GetTurnContext("I think he's 5 foot ten");
+            var turnContext = GetTurnContext(nameof(TestDimension), "I think he's 5 foot ten");
             var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
 
-            Assert.AreEqual(4, results.Count, "Should be 3 entities found");
-            Assert.AreEqual(1, results.Where(entity => entity.Type == "dimension").Count(), "Should have 1 dimension result");
+            Assert.Equal(4, results.Count);
+            Assert.Single(results.Where(entity => entity.Type == "dimension").ToList());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestEmail()
         {
-            var turnContext = GetTurnContext("my email address is foo@att.uk.co");
+            var turnContext = GetTurnContext(nameof(TestEmail), "my email address is foo@att.uk.co");
             var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
 
-            Assert.AreEqual(2, results.Count, "Should be 1 entities found");
-            Assert.AreEqual(1, results.Where(entity => entity.Type == "email").Count(), "Should have 1 email result");
+            Assert.Equal(2, results.Count);
+            Assert.Single(results.Where(entity => entity.Type == "email").ToList());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestGuid()
         {
             var guid = Guid.Empty;
-            var turnContext = GetTurnContext($"my account number is {guid}...");
+            var turnContext = GetTurnContext(nameof(TestGuid), $"my account number is {guid}...");
             var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
 
-            Assert.AreEqual(7, results.Count, "Should be 6 entities found");
-            Assert.AreEqual(1, results.Where(entity => entity.Type == "guid").Count(), "Should have 1 guid result");
+            Assert.Equal(7, results.Count);
+            Assert.Single(results.Where(entity => entity.Type == "guid").ToList());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestHashtag()
         {
-            var turnContext = GetTurnContext($"I'm so cool #cool #groovy...");
+            var turnContext = GetTurnContext(nameof(TestHashtag), $"I'm so cool #cool #groovy...");
             var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
 
-            Assert.AreEqual(3, results.Count, "Should be 2 entities found");
-            Assert.AreEqual(2, results.Where(entity => entity.Type == "hashtag").Count(), "Should have 2 hashtag result");
+            Assert.Equal(3, results.Count);
+            Assert.Equal(2, results.Where(entity => entity.Type == "hashtag").Count());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestIp()
         {
-            var turnContext = GetTurnContext($"My address is 1.2.3.4");
+            var turnContext = GetTurnContext(nameof(TestIp), $"My address is 1.2.3.4");
             var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
 
-            Assert.AreEqual(6, results.Count, "Should be 5 entities found");
-            Assert.AreEqual(1, results.Where(entity => entity.Type == "ip").Count(), "Should have 1 ip result");
+            Assert.Equal(6, results.Count);
+            Assert.Single(results.Where(entity => entity.Type == "ip").ToList());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestMention()
         {
-            var turnContext = GetTurnContext($"Tell @joesmith I'm coming...");
+            var turnContext = GetTurnContext(nameof(TestMention), $"Tell @joesmith I'm coming...");
             var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
 
-            Assert.AreEqual(2, results.Count, "Should be 1 entities found");
-            Assert.AreEqual(1, results.Where(entity => entity.Type == "mention").Count(), "Should have 1 mention result");
+            Assert.Equal(2, results.Count);
+            Assert.Single(results.Where(entity => entity.Type == "mention").ToList());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestNumber()
         {
-            var turnContext = GetTurnContext("This is a test of one, 2, three");
+            var turnContext = GetTurnContext(nameof(TestNumber), "This is a test of one, 2, three");
             var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
 
-            Assert.AreEqual(4, results.Count, "Should be 3 numbers found");
-            Assert.AreEqual(3, results.Where(entity => entity.Type == "number").Count(), "Should have 3 numbers");
+            Assert.Equal(4, results.Count);
+            Assert.Equal(3, results.Where(entity => entity.Type == "number").Count());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestNumberRange()
         {
-            var turnContext = GetTurnContext("there are 3 to 5 of them");
+            var turnContext = GetTurnContext(nameof(TestNumberRange), "there are 3 to 5 of them");
             var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
 
-            Assert.AreEqual(4, results.Count, "Should be 3 entities found");
-            Assert.AreEqual(1, results.Where(entity => entity.Type == "numberrange").Count(), "Should have 1 number range");
+            Assert.Equal(4, results.Count);
+            Assert.Single(results.Where(entity => entity.Type == "numberrange").ToList());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestOrdinal()
         {
-            var turnContext = GetTurnContext("First, second or third");
+            var turnContext = GetTurnContext(nameof(TestOrdinal), "First, second or third");
             var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
 
-            Assert.AreEqual(4, results.Count, "Should be 3 entities found");
-            Assert.AreEqual(3, results.Where(entity => entity.Type == "ordinal").Count(), "Should have 3 ordinals");
+            Assert.Equal(4, results.Count);
+            Assert.Equal(3, results.Where(entity => entity.Type == "ordinal").Count());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestPercentage()
         {
-            var turnContext = GetTurnContext("The population hit 33.3%");
+            var turnContext = GetTurnContext(nameof(TestPercentage), "The population hit 33.3%");
             var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
 
-            Assert.AreEqual(3, results.Count, "Should be 2 entities found");
-            Assert.AreEqual(1, results.Where(entity => entity.Type == "percentage").Count(), "Should have 1 percentage");
+            Assert.Equal(3, results.Count);
+            Assert.Single(results.Where(entity => entity.Type == "percentage").ToList());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestPhoneNumber()
         {
-            var turnContext = GetTurnContext("Call 425-882-8080");
+            var turnContext = GetTurnContext(nameof(TestPhoneNumber), "Call 425-882-8080");
             var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
 
-            Assert.AreEqual(5, results.Count, "Should be 4 entities found");
-            Assert.AreEqual(1, results.Where(entity => entity.Type == "phonenumber").Count(), "Should have 1 phonenumber");
+            Assert.Equal(5, results.Count);
+            Assert.Single(results.Where(entity => entity.Type == "phonenumber").ToList());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestTemperature()
         {
-            var turnContext = GetTurnContext("set the oven to 350 degrees");
+            var turnContext = GetTurnContext(nameof(TestTemperature), "set the oven to 350 degrees");
             var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
 
-            Assert.AreEqual(3, results.Count, "Should be 2 entities found");
-            Assert.AreEqual(1, results.Where(entity => entity.Type == "temperature").Count(), "Should have 1 temperature");
+            Assert.Equal(3, results.Count);
+            Assert.Single(results.Where(entity => entity.Type == "temperature").ToList());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestUrl()
         {
-            var turnContext = GetTurnContext("go to http://about.me for more info");
+            var turnContext = GetTurnContext(nameof(TestUrl), "go to http://about.me for more info");
             var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
 
-            Assert.AreEqual(2, results.Count, "Should be 1 entities found");
-            Assert.AreEqual(1, results.Where(entity => entity.Type == "url").Count(), "Should have 1 url");
+            Assert.Equal(2, results.Count);
+            Assert.Single(results.Where(entity => entity.Type == "url").ToList());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestRegEx()
         {
             // I would like {order} 
-            var turnContext = GetTurnContext("I would like a red or Blue cat");
+            var turnContext = GetTurnContext(nameof(TestRegEx), "I would like a red or Blue cat");
             var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
 
-            Assert.AreEqual(3, results.Count, "Should be 2 entities found");
-            Assert.AreEqual(2, results.Where(entity => entity.Type == "color").Count(), "Should have 2 color results");
-            Assert.AreEqual(results[1].Properties["text"], "red", "should be red");
-            Assert.AreEqual(results[2].Properties["text"], "Blue", "should be Blue");
+            Assert.Equal(3, results.Count);
+            Assert.Equal(2, results.Where(entity => entity.Type == "color").Count());
+            Assert.Equal("red", results[1].Properties["text"]);
+            Assert.Equal("Blue", results[2].Properties["text"]);
         }
 
-        private DialogContext GetTurnContext(string text, string locale = "en-us")
+        private DialogContext GetTurnContext(string testName, string text, string locale = "en-us")
         {
             return new DialogContext(
-                new DialogSet(), 
+                new DialogSet(),
                 new TurnContext(
-                    new TestAdapter(TestAdapter.CreateConversation(TestContext.TestName)), 
-                    new Schema.Activity(type: Schema.ActivityTypes.Message, text: text, locale: locale)), 
+                    new TestAdapter(TestAdapter.CreateConversation(testName)),
+                    new Schema.Activity(type: Schema.ActivityTypes.Message, text: text, locale: locale)),
                 new DialogState());
         }
     }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/FunctionsTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/FunctionsTests.cs
@@ -13,13 +13,14 @@ using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 {
+    [CollectionDefinition("Dialogs.Adaptive")]
     public class FunctionsTests : IClassFixture<ResourceExplorerFixture>
     {
         private readonly ResourceExplorerFixture _resourceExplorerFixture;
 
         public FunctionsTests(ResourceExplorerFixture resourceExplorerFixture)
         {
-            _resourceExplorerFixture = resourceExplorerFixture.AddFolder(nameof(FunctionsTests));
+            _resourceExplorerFixture = resourceExplorerFixture.Initialize(nameof(FunctionsTests));
 
             // this will test that we are registering the custom functions
             new AdaptiveComponentRegistration();

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/FunctionsTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/FunctionsTests.cs
@@ -3,41 +3,29 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Threading.Tasks;
 using AdaptiveExpressions;
 using Microsoft.Bot.Builder.Adapters;
-using Microsoft.Bot.Builder.Dialogs.Adaptive.Functions;
-using Microsoft.Bot.Builder.Dialogs.Adaptive.Tests;
-using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
-using Microsoft.Bot.Builder.Dialogs.Functions;
 using Microsoft.Bot.Builder.Dialogs.Memory;
 using Microsoft.Bot.Builder.Dialogs.Memory.Scopes;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
 using Newtonsoft.Json.Linq;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 {
-    [TestClass]
-    public class FunctionsTests
+    public class FunctionsTests : IClassFixture<ResourceExplorerFixture>
     {
-        public static ResourceExplorer ResourceExplorer { get; set; }
+        private readonly ResourceExplorerFixture _resourceExplorerFixture;
 
-        public TestContext TestContext { get; set; }
-
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext context)
+        public FunctionsTests(ResourceExplorerFixture resourceExplorerFixture)
         {
-            ResourceExplorer = new ResourceExplorer()
-                .AddFolder(Path.Combine(TestUtils.GetProjectPath(), "Tests", nameof(FunctionsTests)), monitorChanges: false);
+            _resourceExplorerFixture = resourceExplorerFixture.AddFolder(nameof(FunctionsTests));
 
             // this will test that we are registering the custom functions
-            var component = new AdaptiveComponentRegistration();
+            new AdaptiveComponentRegistration();
         }
 
-        [TestMethod]
+        [Fact]
         public void IsDialogActive_Variations()
         {
             var config = new DialogStateManagerConfiguration()
@@ -48,31 +36,31 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                 }
             };
             var dc = new DialogContext(new DialogSet(), new TurnContext(new TestAdapter(), new Schema.Activity()), new DialogState());
-            DialogStateManager dsm = new DialogStateManager(dc, config);
+            var dsm = new DialogStateManager(dc, config);
 
-            Assert.AreEqual(true, Expression.Parse("isDialogActive('a')").TryEvaluate(dsm).value);
-            Assert.AreEqual(true, Expression.Parse("isDialogActive('b','c','d')").TryEvaluate(dsm).value);
-            Assert.AreEqual(false, Expression.Parse("isDialogActive('b','c','e')").TryEvaluate(dsm).value);
-            Assert.AreEqual(false, Expression.Parse("isDialogActive('c')").TryEvaluate(dsm).value);
-            Assert.AreEqual(false, Expression.Parse("isDialogActive('f')").TryEvaluate(dsm).value);
-            Assert.AreEqual(true, Expression.Parse("isDialogActive('F')").TryEvaluate(dsm).value);
+            Assert.True((bool)Expression.Parse("isDialogActive('a')").TryEvaluate(dsm).value);
+            Assert.True((bool)Expression.Parse("isDialogActive('b','c','d')").TryEvaluate(dsm).value);
+            Assert.False((bool)Expression.Parse("isDialogActive('b','c','e')").TryEvaluate(dsm).value);
+            Assert.False((bool)Expression.Parse("isDialogActive('c')").TryEvaluate(dsm).value);
+            Assert.False((bool)Expression.Parse("isDialogActive('f')").TryEvaluate(dsm).value);
+            Assert.True((bool)Expression.Parse("isDialogActive('F')").TryEvaluate(dsm).value);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task IsDialogActive()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task HasPendingActions()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
         public class MockMemoryScope : MemoryScope
         {
-            private object memory;
+            private readonly object memory;
 
             public MockMemoryScope(string name, object memory)
                 : base(name, false)
@@ -82,7 +70,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 
             public override object GetMemory(DialogContext dc)
             {
-                return this.memory;
+                return memory;
             }
 
             public override void SetMemory(DialogContext dc, object memory)

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/GeneratorTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/GeneratorTests.cs
@@ -1,37 +1,37 @@
 ﻿// Licensed under the MIT License.
 // Copyright (c) Microsoft Corporation. All rights reserved.
 
-using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.AI.Luis;
 using Microsoft.Bot.Builder.AI.Luis.Testing;
-using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
-using Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests;
 using Microsoft.Extensions.Configuration;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 {
-    [TestClass]
-    public class GeneratorTests
+    public class GeneratorTests : IClassFixture<ResourceExplorerFixture>
     {
         private readonly string sandwichDirectory = PathUtils.NormalizePath(@"..\..\..\..\..\tests\Microsoft.Bot.Builder.Dialogs.Adaptive.Tests\Tests\GeneratorTests\sandwich\");
         private readonly string unitTestsDirectory = PathUtils.NormalizePath(@"..\..\..\..\..\tests\Microsoft.Bot.Builder.Dialogs.Adaptive.Tests\Tests\GeneratorTests\unittests\");
+        private readonly IConfiguration _configuration;
+        private readonly ResourceExplorerFixture _resourceExplorerFixture;
 
-        public TestContext TestContext { get; set; }
-
-        [TestMethod]
-        public async Task Generator_sandwich()
+        public GeneratorTests(ResourceExplorerFixture resourceExplorerFixture)
         {
-            var config = new ConfigurationBuilder()
+            _resourceExplorerFixture = resourceExplorerFixture.AddFolder(nameof(GeneratorTests));
+
+            _configuration = new ConfigurationBuilder()
                 .UseMockLuisSettings(sandwichDirectory, "TestBot")
                 .Build();
-            
-            var resourceExplorer = new ResourceExplorer()
-                .AddFolder(Path.Combine(TestUtils.GetProjectPath(), "Tests", nameof(GeneratorTests)), monitorChanges: false)
-                .RegisterType(LuisAdaptiveRecognizer.Kind, typeof(MockLuisRecognizer), new MockLuisLoader(config));
 
-            await TestUtils.RunTestScript(resourceExplorer, configuration: config);
+            _resourceExplorerFixture.ResourceExplorer
+                .RegisterType(LuisAdaptiveRecognizer.Kind, typeof(MockLuisRecognizer), new MockLuisLoader(_configuration));
+        }
+
+        [Fact]
+        public async Task Generator_sandwich()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, configuration: _configuration);
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/GeneratorTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/GeneratorTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 {
+    [CollectionDefinition("Dialogs.Adaptive")]
     public class GeneratorTests : IClassFixture<ResourceExplorerFixture>
     {
         private readonly string sandwichDirectory = PathUtils.NormalizePath(@"..\..\..\..\..\tests\Microsoft.Bot.Builder.Dialogs.Adaptive.Tests\Tests\GeneratorTests\sandwich\");
@@ -18,7 +19,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 
         public GeneratorTests(ResourceExplorerFixture resourceExplorerFixture)
         {
-            _resourceExplorerFixture = resourceExplorerFixture.AddFolder(nameof(GeneratorTests));
+            _resourceExplorerFixture = resourceExplorerFixture.Initialize(nameof(GeneratorTests));
 
             _configuration = new ConfigurationBuilder()
                 .UseMockLuisSettings(sandwichDirectory, "TestBot")

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests.csproj
@@ -14,8 +14,11 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
   </ItemGroup>
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/MiscTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/MiscTests.cs
@@ -19,13 +19,14 @@ using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 {
+    [CollectionDefinition("Dialogs.Adaptive")]
     public class MiscTests : IClassFixture<ResourceExplorerFixture>
     {
         private readonly ResourceExplorerFixture _resourceExplorerFixture;
 
         public MiscTests(ResourceExplorerFixture resourceExplorerFixture)
         {
-            _resourceExplorerFixture = resourceExplorerFixture.AddFolder(nameof(MiscTests));
+            _resourceExplorerFixture = resourceExplorerFixture.Initialize(nameof(MiscTests));
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/MiscTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/MiscTests.cs
@@ -5,10 +5,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Actions;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Generators;
@@ -16,40 +14,33 @@ using Microsoft.Bot.Builder.Dialogs.Adaptive.Input;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Templates;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing;
-using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Bot.Schema;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Newtonsoft.Json;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 {
-    [TestClass]
-    public class MiscTests
+    public class MiscTests : IClassFixture<ResourceExplorerFixture>
     {
-        public static ResourceExplorer ResourceExplorer { get; set; }
+        private readonly ResourceExplorerFixture _resourceExplorerFixture;
 
-        public TestContext TestContext { get; set; }
-
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext context)
+        public MiscTests(ResourceExplorerFixture resourceExplorerFixture)
         {
-            ResourceExplorer = new ResourceExplorer()
-                .AddFolder(Path.Combine(TestUtils.GetProjectPath(), "Tests", nameof(MiscTests)), monitorChanges: false);
+            _resourceExplorerFixture = resourceExplorerFixture.AddFolder(nameof(MiscTests));
         }
 
-        [TestMethod]
+        [Fact]
         public async Task IfCondition_EndDialog()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Rule_Reprompt()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task DialogManager_InitDialogsEnsureDependencies()
         {
             Dialog CreateDialog()
@@ -85,7 +76,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                     .AssertReply("Enter age")
                 .Send("10")
                     .AssertReply("You said 10")
-                .ExecuteAsync(ResourceExplorer);
+                .ExecuteAsync(_resourceExplorerFixture.ResourceExplorer);
 
             // create new dialog manager and new dialog each turn should be the same as when it's static
             await new TestScript()
@@ -94,13 +85,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                     .AssertReply("Enter age")
                 .Send("10")
                     .AssertReply("You said 10")
-                .ExecuteAsync(ResourceExplorer, callback: (context, ct) => new DialogManager(CreateDialog())
-                    .UseResourceExplorer(ResourceExplorer)
+                .ExecuteAsync(_resourceExplorerFixture.ResourceExplorer, callback: (context, ct) => new DialogManager(CreateDialog())
+                    .UseResourceExplorer(_resourceExplorerFixture.ResourceExplorer)
                     .UseLanguageGeneration()
                     .OnTurnAsync(context, ct));
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestMultipleEditActions()
         {
             var jokeDialog = new AdaptiveDialog("jokeDialog")
@@ -364,7 +355,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                 .Send("52")
                     .AssertReply("I have 52")
                     .AssertReply("Here is the joke you asked for..") 
-                .ExecuteAsync(ResourceExplorer);
+                .ExecuteAsync(_resourceExplorerFixture.ResourceExplorer);
         }
     }
 
@@ -372,7 +363,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
     {
         public override Task<RecognizerResult> RecognizeAsync(DialogContext dialogContext, Activity activity, CancellationToken cancellationToken = default, Dictionary<string, string> telemetryProperties = null, Dictionary<string, double> telemetryMetrics = null)
         {
-            return this.RecognizeAsync(new TurnContext(dialogContext.Context.Adapter, activity), cancellationToken);
+            return RecognizeAsync(new TurnContext(dialogContext.Context.Adapter, activity), cancellationToken);
         }
 
         public Task<RecognizerResult> RecognizeAsync(ITurnContext turnContext, CancellationToken cancellationToken)

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/MultiLanguageRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/MultiLanguageRecognizerTests.cs
@@ -1,56 +1,49 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Tests;
-using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
 {
-    [TestClass]
-    public class MultiLanguageRecognizerTests
+    public class MultiLanguageRecognizerTests : IClassFixture<ResourceExplorerFixture>
     {
-        public static ResourceExplorer ResourceExplorer { get; set; }
+        private readonly ResourceExplorerFixture _resourceExplorerFixture;
 
-        public TestContext TestContext { get; set; }
-
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext context)
+        public MultiLanguageRecognizerTests(ResourceExplorerFixture resourceExplorerFixture)
         {
-            ResourceExplorer = new ResourceExplorer()
-                .AddFolder(Path.Combine(TestUtils.GetProjectPath(), "Tests", nameof(MultiLanguageRecognizerTests)), monitorChanges: false);
+            _resourceExplorerFixture = resourceExplorerFixture.AddFolder(nameof(MultiLanguageRecognizerTests));
         }
 
-        [TestMethod]
+        [Fact]
         public async Task MultiLanguageRecognizerTest_EnUsFallback()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task MultiLanguageRecognizerTest_EnUsFallback_ActivityLocaleCasing()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task MultiLanguageRecognizerTest_EnGbFallback()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task MultiLanguageRecognizerTest_EnFallback()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task MultiLanguageRecognizerTest_DefaultFallback()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/MultiLanguageRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/MultiLanguageRecognizerTests.cs
@@ -7,13 +7,14 @@ using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
 {
+    [CollectionDefinition("Dialogs.Adaptive.Recognizers")]
     public class MultiLanguageRecognizerTests : IClassFixture<ResourceExplorerFixture>
     {
         private readonly ResourceExplorerFixture _resourceExplorerFixture;
 
         public MultiLanguageRecognizerTests(ResourceExplorerFixture resourceExplorerFixture)
         {
-            _resourceExplorerFixture = resourceExplorerFixture.AddFolder(nameof(MultiLanguageRecognizerTests));
+            _resourceExplorerFixture = resourceExplorerFixture.Initialize(nameof(MultiLanguageRecognizerTests));
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/RecognizerSetTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/RecognizerSetTests.cs
@@ -7,13 +7,14 @@ using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
 {
+    [CollectionDefinition("Dialogs.Adaptive.Recognizers")]
     public class RecognizerSetTests : IClassFixture<ResourceExplorerFixture>
     {
         private readonly ResourceExplorerFixture _resourceExplorerFixture;
 
         public RecognizerSetTests(ResourceExplorerFixture resourceExplorerFixture)
         {
-            _resourceExplorerFixture = resourceExplorerFixture.AddFolder(nameof(RecognizerSetTests));
+            _resourceExplorerFixture = resourceExplorerFixture.Initialize(nameof(RecognizerSetTests));
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/RecognizerSetTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/RecognizerSetTests.cs
@@ -1,38 +1,31 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Tests;
-using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
 {
-    [TestClass]
-    public class RecognizerSetTests
+    public class RecognizerSetTests : IClassFixture<ResourceExplorerFixture>
     {
-        public static ResourceExplorer ResourceExplorer { get; set; }
+        private readonly ResourceExplorerFixture _resourceExplorerFixture;
 
-        public TestContext TestContext { get; set; }
-
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext context)
+        public RecognizerSetTests(ResourceExplorerFixture resourceExplorerFixture)
         {
-            ResourceExplorer = new ResourceExplorer()
-                .AddFolder(Path.Combine(TestUtils.GetProjectPath(), "Tests", nameof(RecognizerSetTests)), monitorChanges: false);
+            _resourceExplorerFixture = resourceExplorerFixture.AddFolder(nameof(RecognizerSetTests));
         }
 
-        [TestMethod]
+        [Fact]
         public async Task RecognizerSetTests_Merge()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task RecognizerSetTests_None()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/RegexRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/RegexRecognizerTests.cs
@@ -2,40 +2,33 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Tests;
-using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Bot.Schema;
 using Microsoft.Recognizers.Text;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
 {
-    [TestClass]
-    public class RegexRecognizerTests
+    public class RegexRecognizerTests : IClassFixture<ResourceExplorerFixture>
     {
-        public static ResourceExplorer ResourceExplorer { get; set; }
+        private readonly ResourceExplorerFixture _resourceExplorerFixture;
 
-        public TestContext TestContext { get; set; }
-
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext context)
+        public RegexRecognizerTests(ResourceExplorerFixture resourceExplorerFixture)
         {
-            ResourceExplorer = new ResourceExplorer()
-                .AddFolder(Path.Combine(TestUtils.GetProjectPath(), "Tests", nameof(RegexRecognizerTests)), monitorChanges: false);
+            _resourceExplorerFixture = resourceExplorerFixture.AddFolder(nameof(RegexRecognizerTests));
         }
 
-        [TestMethod]
+        [Fact]
         public async Task RegexRecognizerTests_Entities()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task RegexRecognizerTests_Intents()
         {
             var recognizer = new RegexRecognizer()
@@ -85,7 +78,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
             var activity = Activity.CreateMessageActivity();
             activity.Text = "intent a1 b2";
             activity.Locale = Culture.English;
-            result = await recognizer.RecognizeAsync(dc,  (Activity)activity, CancellationToken.None);
+            result = await recognizer.RecognizeAsync(dc, (Activity)activity, CancellationToken.None);
             ValidateCodeIntent(result);
 
             activity.Text = "I would like color red and orange";
@@ -95,31 +88,31 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
 
         private static void ValidateColorIntent(RecognizerResult result)
         {
-            Assert.AreEqual(1, result.Intents.Count, "Should recognize one intent");
-            Assert.AreEqual("colorIntent", result.Intents.Select(i => i.Key).First(), "Should recognize colorIntent");
+            Assert.Single(result.Intents);
+            Assert.Equal("colorIntent", result.Intents.Select(i => i.Key).First());
 
             // entity assertions from capture group
             dynamic entities = result.Entities;
-            Assert.IsNotNull(entities.color, "should find color");
-            Assert.IsNull(entities.code, "should not find code");
-            Assert.AreEqual(2, entities.color.Count, "should find 2 colors");
-            Assert.AreEqual("red", (string)entities.color[0], "should find red");
-            Assert.AreEqual("orange", (string)entities.color[1], "should find orange");
+            Assert.NotNull(entities.color);
+            Assert.Null(entities.code);
+            Assert.Equal(2, entities.color.Count);
+            Assert.Equal("red", (string)entities.color[0]);
+            Assert.Equal("orange", (string)entities.color[1]);
         }
 
         private static void ValidateCodeIntent(RecognizerResult result)
         {
             // intent assertions
-            Assert.AreEqual(1, result.Intents.Count, "Should recognize one intent");
-            Assert.AreEqual("codeIntent", result.Intents.Select(i => i.Key).First(), "Should recognize codeIntent");
+            Assert.Single(result.Intents);
+            Assert.Equal("codeIntent", result.Intents.Select(i => i.Key).First());
 
             // entity assertions from capture group
             dynamic entities = result.Entities;
-            Assert.IsNotNull(entities.code, "should find code");
-            Assert.IsNull(entities.color, "should not find color");
-            Assert.AreEqual(2, entities.code.Count, "should find 2 codes");
-            Assert.AreEqual("a1", (string)entities.code[0], "should find a1");
-            Assert.AreEqual("b2", (string)entities.code[1], "should find b2");
+            Assert.NotNull(entities.code);
+            Assert.Null(entities.color);
+            Assert.Equal(2, entities.code.Count);
+            Assert.Equal("a1", (string)entities.code[0]);
+            Assert.Equal("b2", (string)entities.code[1]);
         }
 
         private static DialogContext CreateContext(string text)

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/RegexRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/RegexRecognizerTests.cs
@@ -13,13 +13,14 @@ using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
 {
+    [CollectionDefinition("Dialogs.Adaptive.Recognizers")]
     public class RegexRecognizerTests : IClassFixture<ResourceExplorerFixture>
     {
         private readonly ResourceExplorerFixture _resourceExplorerFixture;
 
         public RegexRecognizerTests(ResourceExplorerFixture resourceExplorerFixture)
         {
-            _resourceExplorerFixture = resourceExplorerFixture.AddFolder(nameof(RegexRecognizerTests));
+            _resourceExplorerFixture = resourceExplorerFixture.Initialize(nameof(RegexRecognizerTests));
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ResourceExplorerFixture.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ResourceExplorerFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.IO;
 using System.Linq;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ResourceExplorerFixture.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ResourceExplorerFixture.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
+
+namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
+{
+    public class ResourceExplorerFixture : IDisposable
+    {
+        private string _projectPath;
+
+        public ResourceExplorerFixture()
+        {
+            ResourceExplorer = new ResourceExplorer();
+            _projectPath = TestUtils.GetProjectPath();
+        }
+
+        public ResourceExplorer ResourceExplorer { get; private set; }
+
+        public ResourceExplorerFixture AddFolder(string resourceFolder)
+        {
+            var folderPath = Path.Combine(_projectPath, "Tests", resourceFolder);
+            
+            if (!ResourceExplorer.ResourceProviders.Any(e => e.Id == folderPath))
+            {
+                ResourceExplorer.AddFolder(folderPath, monitorChanges: false);
+            }
+
+            return this;
+        }
+
+        public void Dispose()
+        {
+            ResourceExplorer.Dispose();
+            _projectPath = null;
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ResourceExplorerFixture.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ResourceExplorerFixture.cs
@@ -3,30 +3,27 @@
 
 using System;
 using System.IO;
-using System.Linq;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 {
     public class ResourceExplorerFixture : IDisposable
     {
-        private string _projectPath;
+        private string _folderPath = string.Empty;
 
         public ResourceExplorerFixture()
         {
             ResourceExplorer = new ResourceExplorer();
-            _projectPath = TestUtils.GetProjectPath();
         }
 
         public ResourceExplorer ResourceExplorer { get; private set; }
 
-        public ResourceExplorerFixture AddFolder(string resourceFolder)
+        public ResourceExplorerFixture Initialize(string resourceFolder)
         {
-            var folderPath = Path.Combine(_projectPath, "Tests", resourceFolder);
-            
-            if (!ResourceExplorer.ResourceProviders.Any(e => e.Id == folderPath))
+            if (_folderPath.Length == 0)
             {
-                ResourceExplorer.AddFolder(folderPath, monitorChanges: false);
+                _folderPath = Path.Combine(TestUtils.GetProjectPath(), "Tests", resourceFolder);
+                ResourceExplorer = ResourceExplorer.AddFolder(_folderPath, monitorChanges: false);
             }
 
             return this;
@@ -34,8 +31,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 
         public void Dispose()
         {
+            _folderPath = string.Empty;
             ResourceExplorer.Dispose();
-            _projectPath = null;
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/SelectorTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/SelectorTests.cs
@@ -6,13 +6,14 @@ using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 {
+    [CollectionDefinition("Dialogs.Adaptive")]
     public class SelectorTests : IClassFixture<ResourceExplorerFixture>
     {
         private readonly ResourceExplorerFixture _resourceExplorerFixture;
 
         public SelectorTests(ResourceExplorerFixture resourceExplorerFixture)
         {
-            _resourceExplorerFixture = resourceExplorerFixture.AddFolder(nameof(SelectorTests));
+            _resourceExplorerFixture = resourceExplorerFixture.Initialize(nameof(SelectorTests));
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/SelectorTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/SelectorTests.cs
@@ -1,71 +1,67 @@
-﻿using System.IO;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using System.Threading.Tasks;
-using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 {
-    [TestClass]
-    public class SelectorTests
+    public class SelectorTests : IClassFixture<ResourceExplorerFixture>
     {
-        public static ResourceExplorer ResourceExplorer { get; set; }
+        private readonly ResourceExplorerFixture _resourceExplorerFixture;
 
-        public TestContext TestContext { get; set; }
-
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext context)
+        public SelectorTests(ResourceExplorerFixture resourceExplorerFixture)
         {
-            ResourceExplorer = new ResourceExplorer()
-                .AddFolder(Path.Combine(TestUtils.GetProjectPath(), "Tests", nameof(SelectorTests)), monitorChanges: false);
+            _resourceExplorerFixture = resourceExplorerFixture.AddFolder(nameof(SelectorTests));
         }
 
-        [TestMethod]
+        [Fact]
         public async Task SelectorTests_FirstSelector()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task SelectorTests_RandomSelector()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task SelectorTests_MostSpecificFirstSelector()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task SelectorTests_MostSpecificRandomSelector()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task SelectorTests_AdaptiveTrueSelector()
         {
             // only execute first selection
-            await TestUtils.RunTestScript(ResourceExplorer, resourceId: "SelectorTests_TrueSelector.test.dialog");
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, resourceId: "SelectorTests_TrueSelector.test.dialog");
         }
 
-        [TestMethod]
+        [Fact]
         public async Task SelectorTests_AdaptiveConditionalSelector()
         {
-            await TestUtils.RunTestScript(ResourceExplorer, resourceId: "SelectorTests_ConditionalSelector.test.dialog");
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, resourceId: "SelectorTests_ConditionalSelector.test.dialog");
         }
 
-        [TestMethod]
+        [Fact]
         public async Task SelectorTests_RunOnce()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task SelectorTests_Priority()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/SettingsStateTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/SettingsStateTests.cs
@@ -1,44 +1,32 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.IO;
 using System.Threading.Tasks;
-using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
-using Microsoft.Extensions.Configuration;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 {
-    [TestClass]
-    public class SettingsStateTests
+    public class SettingsStateTests : IClassFixture<ResourceExplorerFixture>, IClassFixture<ConfigurationFixture>
     {
-        public static ResourceExplorer ResourceExplorer { get; set; }
+        private readonly ResourceExplorerFixture _resourceExplorerFixture;
+        private readonly ConfigurationFixture _configurationFixture;
 
-        public static IConfiguration Configuration { get; set; }
-
-        public TestContext TestContext { get; set; }
-
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext context)
+        public SettingsStateTests(ResourceExplorerFixture resourceExplorerFixture, ConfigurationFixture configurationFixture)
         {
-            Configuration = new ConfigurationBuilder()
-                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: false)
-                .Build();
-
-            ResourceExplorer = new ResourceExplorer()
-                .AddFolder(Path.Combine(TestUtils.GetProjectPath(), "Tests", nameof(SettingsStateTests)), monitorChanges: false);
+            _resourceExplorerFixture = resourceExplorerFixture.AddFolder(nameof(SettingsStateTests));
+            _configurationFixture = configurationFixture;
         }
 
-        [TestMethod]
+        [Fact]
         public async Task SettingsStateTests_SettingsTest()
         {
-            await TestUtils.RunTestScript(ResourceExplorer, configuration: Configuration);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, configuration: _configurationFixture.Configuration);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task SettingsStateTests_TestTurnStateAcrossBoundaries()
         {
-            await TestUtils.RunTestScript(ResourceExplorer, configuration: Configuration);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, configuration: _configurationFixture.Configuration);
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/SettingsStateTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/SettingsStateTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 {
+    [CollectionDefinition("Dialogs.Adaptive")]
     public class SettingsStateTests : IClassFixture<ResourceExplorerFixture>, IClassFixture<ConfigurationFixture>
     {
         private readonly ResourceExplorerFixture _resourceExplorerFixture;
@@ -13,7 +14,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 
         public SettingsStateTests(ResourceExplorerFixture resourceExplorerFixture, ConfigurationFixture configurationFixture)
         {
-            _resourceExplorerFixture = resourceExplorerFixture.AddFolder(nameof(SettingsStateTests));
+            _resourceExplorerFixture = resourceExplorerFixture.Initialize(nameof(SettingsStateTests));
             _configurationFixture = configurationFixture;
         }
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Startup.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Startup.cs
@@ -3,32 +3,29 @@
 
 using Microsoft.Bot.Builder.AI.Luis;
 using Microsoft.Bot.Builder.AI.QnA;
-using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Dialogs.Adaptive;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing;
 using Microsoft.Bot.Builder.Dialogs.Declarative;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+[assembly: TestFramework("Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests.Startup", "Microsoft.Bot.Builder.Dialogs.Adaptive.Tests")]
 
 namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 {
-    [TestClass]
-    internal class Startup
+    public class Startup : XunitTestFramework
     {
-        public Startup()
+        public Startup(IMessageSink messageSink) 
+            : base(messageSink)
         {
             var builder = new ConfigurationBuilder()
                 .AddJsonFile("appsettings.json", optional: true, reloadOnChange: false);
 
             Configuration = builder.Build();
-        }
 
-        public IConfiguration Configuration { get; }
-
-        [AssemblyInitialize]
-        public static void Initialize(TestContext testContext)
-        {
             ComponentRegistration.Add(new DeclarativeComponentRegistration());
             ComponentRegistration.Add(new AdaptiveComponentRegistration());
             ComponentRegistration.Add(new LanguageGenerationComponentRegistration());
@@ -37,11 +34,18 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
             ComponentRegistration.Add(new QnAMakerComponentRegistration());
         }
 
+        public IConfiguration Configuration { get; }
+
         public void ConfigureServices(IServiceCollection services)
         {
             // Adding IConfiguration in sample test server.  Otherwise this appears to be 
             // registered.
-            services.AddSingleton<IConfiguration>(this.Configuration);
+            services.AddSingleton(Configuration);
+        }
+
+        public new void Dispose()
+        {
+            base.Dispose();
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/TestScriptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/TestScriptTests.cs
@@ -12,6 +12,7 @@ using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 {
+    [CollectionDefinition("Dialogs.Adaptive")]
     public class TestScriptTests : IClassFixture<ResourceExplorerFixture>
     {
         private readonly string luisMockDirectory = PathUtils.NormalizePath(@"..\..\..\..\..\tests\Microsoft.Bot.Builder.Dialogs.Adaptive.Tests\Tests\TestScriptTests\LuisMock\");
@@ -19,7 +20,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 
         public TestScriptTests(ResourceExplorerFixture resourceExplorerFixture)
         {
-            _resourceExplorerFixture = resourceExplorerFixture.AddFolder(nameof(TestScriptTests));
+            _resourceExplorerFixture = resourceExplorerFixture.Initialize(nameof(TestScriptTests));
         }
 
 #if AUTO

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/TestScriptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/TestScriptTests.cs
@@ -4,124 +4,116 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.AI.Luis;
 using Microsoft.Bot.Builder.AI.Luis.Testing;
-using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Extensions.Configuration;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 {
-    [TestClass]
-    public class TestScriptTests
+    public class TestScriptTests : IClassFixture<ResourceExplorerFixture>
     {
         private readonly string luisMockDirectory = PathUtils.NormalizePath(@"..\..\..\..\..\tests\Microsoft.Bot.Builder.Dialogs.Adaptive.Tests\Tests\TestScriptTests\LuisMock\");
+        private readonly ResourceExplorerFixture _resourceExplorerFixture;
 
-        public static ResourceExplorer ResourceExplorer { get; set; }
-
-        public TestContext TestContext { get; set; }
-
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext context)
+        public TestScriptTests(ResourceExplorerFixture resourceExplorerFixture)
         {
-            ResourceExplorer = new ResourceExplorer()
-                .AddFolder(Path.Combine(TestUtils.GetProjectPath(), "Tests", nameof(TestScriptTests)), monitorChanges: false);
+            _resourceExplorerFixture = resourceExplorerFixture.AddFolder(nameof(TestScriptTests));
         }
 
 #if AUTO
         public static IEnumerable<object[]> AssertReplyScripts => TestUtils.GetTestScripts(@"Tests\TestAssertReply");
 
-        [DataTestMethod]
-        [DynamicData(nameof(AssertReplyScripts))]
+        [Theory]
+        [MemberData(nameof(AssertReplyScripts), DisableDiscoveryEnumeration = true)]
         public async Task TestScript_AssertReply(string resourceId)
         {
-            await TestUtils.RunTestScript(resourceId);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, resourceId: resourceId);
         }
 #endif
-        [TestMethod]
+
+        [Fact]
         public async Task TestScriptTests_AssertReplyOneOf()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestScriptTests_AssertReplyOneOf_Assertions()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestScriptTests_AssertReplyOneOf_exact()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestScriptTests_AssertReplyOneOf_User()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestScriptTests_AssertReply_Assertions()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestScriptTests_AssertReply_Assertions_Failed()
         {
             try
             {
-                await TestUtils.RunTestScript(ResourceExplorer);
+                await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
             }
             catch (Exception e)
             {
-                Assert.IsTrue(e.Message.Contains("\"text\": \"hi User1\""));
+                Assert.Contains("\"text\": \"hi User1\"", e.Message);
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestScriptTests_AssertReply_Exact()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestScriptTests_AssertReply_User()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestScriptTests_HttpRequestMock()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestScriptTests_HttpRequestLuisMock()
         {
             var config = new ConfigurationBuilder()
                 .UseMockLuisSettings(luisMockDirectory, "TestBot")
                 .Build();
 
-            var resourceExplorer = new ResourceExplorer()
-                .AddFolder(Path.Combine(TestUtils.GetProjectPath(), "Tests", nameof(TestScriptTests)), monitorChanges: false)
+            var resourceExplorer = _resourceExplorerFixture.ResourceExplorer
                 .RegisterType(LuisAdaptiveRecognizer.Kind, typeof(MockLuisRecognizer), new MockLuisLoader(config));
 
             await TestUtils.RunTestScript(resourceExplorer, configuration: config);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestScriptTests_CustomEvent()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestScriptTests_PropertyMock()
         {
             var configBuilder = new ConfigurationBuilder();
@@ -131,25 +123,25 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                 new KeyValuePair<string, string>("fileoverwrite", "this is overwritten")
             });
 
-            await TestUtils.RunTestScript(ResourceExplorer, configuration: configBuilder.Build());
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, configuration: configBuilder.Build());
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestScriptTests_UserConversationUpdate()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestScriptTests_UserTokenMock()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestScriptTests_UserTyping()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/TestUtils.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/TestUtils.cs
@@ -7,11 +7,9 @@ using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Extensions.Configuration;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 {
-    [TestClass]
     public class TestUtils
     {
         public static IConfiguration DefaultConfiguration { get; set; } = new ConfigurationBuilder().AddInMemoryCollection().Build();

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ValueRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ValueRecognizerTests.cs
@@ -1,38 +1,31 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Tests;
-using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
 {
-    [TestClass]
-    public class ValueRecognizerTests
+    public class ValueRecognizerTests : IClassFixture<ResourceExplorerFixture>
     {
-        public static ResourceExplorer ResourceExplorer { get; set; }
+        private readonly ResourceExplorerFixture _resourceExplorerFixture;
 
-        public TestContext TestContext { get; set; }
-
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext context)
+        public ValueRecognizerTests(ResourceExplorerFixture resourceExplorerFixture)
         {
-            ResourceExplorer = new ResourceExplorer()
-                .AddFolder(Path.Combine(TestUtils.GetProjectPath(), "Tests", nameof(ValueRecognizerTests)), monitorChanges: false);
+            _resourceExplorerFixture = resourceExplorerFixture.AddFolder(nameof(ValueRecognizerTests));
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ValueRecognizerTests_WithIntent()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ValueRecognizerTests_WithNoIntent()
         {
-            await TestUtils.RunTestScript(ResourceExplorer);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ValueRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ValueRecognizerTests.cs
@@ -7,13 +7,14 @@ using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
 {
+    [CollectionDefinition("Dialogs.Adaptive.Recognizers")]
     public class ValueRecognizerTests : IClassFixture<ResourceExplorerFixture>
     {
         private readonly ResourceExplorerFixture _resourceExplorerFixture;
 
         public ValueRecognizerTests(ResourceExplorerFixture resourceExplorerFixture)
         {
-            _resourceExplorerFixture = resourceExplorerFixture.AddFolder(nameof(ValueRecognizerTests));
+            _resourceExplorerFixture = resourceExplorerFixture.Initialize(nameof(ValueRecognizerTests));
         }
 
         [Fact]


### PR DESCRIPTION
Fixes # 4093

## Description
This PR migrates all [Microsoft.Bot.Builder.Dialogs.Adaptive](https://github.com/microsoft/botbuilder-dotnet/tree/main/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests) tests from **MSTest** to **xUnit**.

## Specific Changes
- Replaced `MSTest` packages with `xUnit` in the `.csproj`.
- Changed `[TestClass]` to `[CollectionDefinition]`.
- Changed `[TestMethod]` to `[Fact]`.
- Changed `Assert.AreEqual` to `Assert.Equal`.
- Changed `Assert.IsNotNull` to `Assert.NotNull`.
- Changed `Assert.IsNull` to `Assert.Null`.
- Added `[assembly: TestFramework("Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests.Startup", "Microsoft.Bot.Builder.Dialogs.Adaptive.Tests")]` to the `Startup` class to replace `[AssemblyInitialize]`.
- Implemented `ResourceExplorerFixture` class to share the `ResourceExplorer` among tests.
- Implemented `ConfigurationFixture` class to share the `Configuration` among tests.
- Improved tests Assertions.

## Testing
In the following image there are the passing tests.
![image](https://user-images.githubusercontent.com/62260472/92411702-56c12480-f11f-11ea-9576-c0732658735f.png)