### PR TITLE
Stop building twice in the dotnet functional test pipelines

### DIFF
--- a/build/yaml/botbuilder-dotnet-ci-facebook-test.yml
+++ b/build/yaml/botbuilder-dotnet-ci-facebook-test.yml
@@ -48,6 +48,9 @@ variables:
 #  FacebookTestBotSenderId: define this in Azure?: This var not needed in build 156862. Revisit this after the build's test is fixed & running.
 
 steps:
+- powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
+  displayName: 'Display env vars'
+
 - powershell: |
    # Set values in appsettings.json file.
    $file = "$(Build.SourcesDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot\appsettings.json";
@@ -59,15 +62,13 @@ steps:
    $content | ConvertTo-Json | Set-Content $file;
   displayName: 'Set values in appsettings.json file.'
 
-- template: ci-build-steps.yml
-
 - task: DotNetCoreCLI@2
   displayName: 'dotnet publish testbot'
   inputs:
     command: publish
     publishWebProjects: false
     projects: '$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot\Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot.csproj'
-    arguments: '--output $(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot\PublishedBot -p:TreatWarningsAsErrors=false'
+    arguments: '--configuration $(BuildConfiguration) --output $(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot\PublishedBot -p:TreatWarningsAsErrors=false'
     modifyOutputPath: false
 
 - task: AzureCLI@1
@@ -102,7 +103,7 @@ steps:
   inputs:
     command: test
     projects: '$(System.DefaultWorkingDirectory)\FunctionalTests\Microsoft.Bot.Builder.FunctionalTests\Microsoft.Bot.Builder.FunctionalTests.csproj'
-    arguments: '-v n --configuration $(BuildConfiguration) --no-build --no-restore --filter FacebookChatTest'
+    arguments: '-v n --configuration $(BuildConfiguration) --filter FacebookChatTest'
 
 - task: AzureCLI@1
   displayName: 'Delete Azure resources'

--- a/build/yaml/botbuilder-dotnet-ci-slack-test.yml
+++ b/build/yaml/botbuilder-dotnet-ci-slack-test.yml
@@ -52,7 +52,8 @@ variables:
 #  SlackTestBotSlackVerificationToken: define this in Azure
 
 steps:
-- template: ci-build-steps.yml
+- powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
+  displayName: 'Display env vars'
 
 - task: DotNetCoreCLI@2
   displayName: 'Dotnet Publish TestBot'
@@ -60,7 +61,7 @@ steps:
     command: publish
     publishWebProjects: false
     projects: '$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Slack.TestBot\Microsoft.Bot.Builder.Adapters.Slack.TestBot.csproj'
-    arguments: '--output $(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Slack.TestBot\PublishedBot -p:TreatWarningsAsErrors=false'
+    arguments: '--configuration $(BuildConfiguration) --output $(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Slack.TestBot\PublishedBot -p:TreatWarningsAsErrors=false'
     modifyOutputPath: false
 
 #- powershell: |
@@ -103,7 +104,7 @@ steps:
     command: test
     projects: |
      FunctionalTests\Microsoft.Bot.Builder.FunctionalTests\Microsoft.Bot.Builder.FunctionalTests.csproj
-    arguments: '-v n --configuration $(BuildConfiguration) --no-build --no-restore --filter SlackClientTest'
+    arguments: '-v n --configuration $(BuildConfiguration) --filter SlackClientTest'
     workingDirectory: tests
 
 - task: AzureCLI@1

--- a/build/yaml/botbuilder-dotnet-ci-twilio-test.yml
+++ b/build/yaml/botbuilder-dotnet-ci-twilio-test.yml
@@ -43,7 +43,8 @@ variables:
 #  TwilioNumber: define this in Azure
 
 steps:
-- template: ci-build-steps.yml
+- powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
+  displayName: 'Display env vars'
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet publish Twilio.TestBot'
@@ -51,7 +52,7 @@ steps:
     command: publish
     publishWebProjects: false
     projects: '$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Twilio.TestBot\Microsoft.Bot.Builder.Adapters.Twilio.TestBot.csproj'
-    arguments: '--output $(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Twilio.TestBot\PublishedBot'
+    arguments: '--configuration $(BuildConfiguration) --output $(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Twilio.TestBot\PublishedBot'
     modifyOutputPath: false
 
 - task: AzureCLI@1
@@ -76,7 +77,7 @@ steps:
   inputs:
     command: test
     projects: '$(System.DefaultWorkingDirectory)\FunctionalTests\Microsoft.Bot.Builder.FunctionalTests\Microsoft.Bot.Builder.FunctionalTests.csproj'
-    arguments: '-v n --configuration $(BuildConfiguration) --no-build --no-restore --filter TwilioNumberTests'
+    arguments: '-v n --configuration $(BuildConfiguration) --filter TwilioNumberTests'
 
 - task: AzureCLI@1
   displayName: 'Delete resources'

--- a/build/yaml/botbuilder-dotnet-ci-webex-test.yml
+++ b/build/yaml/botbuilder-dotnet-ci-webex-test.yml
@@ -53,7 +53,8 @@ variables:
 #  WebexTestBotWebexWebhookSecret: define this in Azure
 
 steps:
-- template: ci-build-steps.yml
+- powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
+  displayName: 'Display env vars'
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet publish'
@@ -61,7 +62,7 @@ steps:
     command: publish
     publishWebProjects: false
     projects: '$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Webex.TestBot\Microsoft.Bot.Builder.Adapters.Webex.TestBot.csproj'
-    arguments: '--output $(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Webex.TestBot\PublishedBot -p:TreatWarningsAsErrors=false'
+    arguments: '--configuration $(BuildConfiguration) --output $(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Webex.TestBot\PublishedBot -p:TreatWarningsAsErrors=false'
     modifyOutputPath: false
 
 - task: AzureCLI@1
@@ -99,7 +100,7 @@ steps:
   inputs:
     command: test
     projects: 'FunctionalTests\Microsoft.Bot.Builder.FunctionalTests\Microsoft.Bot.Builder.FunctionalTests.csproj'
-    arguments: '-v n --configuration $(BuildConfiguration) --no-build --no-restore --filter WebexClientTest'
+    arguments: '-v n --configuration $(BuildConfiguration) --filter WebexClientTest'
   env:
     XXXWebexTestBotWebexRoomId: $(WebexTestBotWebexRoomId)
     WebexTestBotRefreshToken: $(WebexTestBotRefreshToken)

--- a/build/yaml/botbuilder-dotnet-functional-test-linux.yml
+++ b/build/yaml/botbuilder-dotnet-functional-test-linux.yml
@@ -42,7 +42,8 @@ variables:
 #  LinuxTestBotBotName: define this in Azure
 
 steps:
-- template: ci-build-steps.yml
+- powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
+  displayName: 'Display env vars'
 
 - task: DotNetCoreCLI@2
   displayName: 'Dotnet publish test bot'
@@ -96,7 +97,7 @@ steps:
   inputs:
     command: test
     projects: '$(System.DefaultWorkingDirectory)\FunctionalTests\**\*FunctionalTests.csproj'
-    arguments: '-v n  --configuration $(BuildConfiguration) --no-build --no-restore --filter "TestCategory=FunctionalTests&TestCategory!=Adapters" --collect:"Code Coverage" --settings $(System.DefaultWorkingDirectory)\CodeCoverage.runsettings '
+    arguments: '-v n --configuration $(BuildConfiguration) --filter "TestCategory=FunctionalTests&TestCategory!=Adapters" --collect:"Code Coverage" --settings $(System.DefaultWorkingDirectory)\CodeCoverage.runsettings '
     workingDirectory: '$(System.DefaultWorkingDirectory)\'
 
 - task: AzureCLI@1

--- a/build/yaml/botbuilder-dotnet-functional-test-windows.yml
+++ b/build/yaml/botbuilder-dotnet-functional-test-windows.yml
@@ -44,7 +44,8 @@ variables:
 #  WinTestBotBotName: define this in Azure
 
 steps:
-- template: ci-build-steps.yml
+- powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
+  displayName: 'Display env vars'
 
 - task: DotNetCoreCLI@2
   displayName: 'Dotnet Publish TestBot'
@@ -52,7 +53,7 @@ steps:
     command: publish
     publishWebProjects: false
     projects: '$(System.DefaultWorkingDirectory)\tests\Microsoft.Bot.Builder.TestBot\Microsoft.Bot.Builder.TestBot.csproj'
-    arguments: '--output $(System.DefaultWorkingDirectory)\tests\Microsoft.Bot.Builder.TestBot\publishedbot -p:TreatWarningsAsErrors=false'
+    arguments: '--configuration $(BuildConfiguration) --output $(System.DefaultWorkingDirectory)\tests\Microsoft.Bot.Builder.TestBot\publishedbot -p:TreatWarningsAsErrors=false'
     modifyOutputPath: false
 
 - task: AzureCLI@1
@@ -92,12 +93,8 @@ steps:
   displayName: 'dotnet test'
   inputs:
     command: test
-    projects: |
-     **/**Tests.csproj
-     !**/Microsoft.Bot.Builder.Classic.Tests.csproj
-     !**/Microsoft.Bot.ApplicationInsights.WebApi.Tests.csproj
-     !**/Microsoft.Bot.Builder.Integration.AspNet.WebApi.Tests.csproj
-    arguments: '-v n --configuration $(BuildConfiguration) --no-build --no-restore --filter "TestCategory=FunctionalTests&TestCategory!=Adapters"'
+    projects: '$(System.DefaultWorkingDirectory)\FunctionalTests\**\*FunctionalTests.csproj'
+    arguments: '-v n --configuration $(BuildConfiguration) --filter "TestCategory=FunctionalTests&TestCategory!=Adapters"'
     workingDirectory: tests
 
 - task: AzureCLI@1


### PR DESCRIPTION
Fixes # 4081

## Description

To execute their respective tests, all functional test pipelines test projects must be built and a bot needs to be published as a target. To do so, the pipelines follow a restore, build, publish, and test pattern. 

The **bot to be deployed project is being built twice**, since the *build* step builds the whole solution, including both the bot to be deployed and the tests projects, and the *publish* step builds the bot to be deployed as well.

The changes introduced in this branch remove the build steps (including _NuGet_ steps) from all functional test pipelines and reassign building to the publish and test steps for their specific projects, saving approximately **3 minutes** on each pipeline execution.

This implementation works best for tests involving a relatively small percentage of projects from a given solution, otherwise, building the whole solution is better since the _test_ task builds all projects found within the specified paths individually.

## Specific Changes

  - To all functional test and adapter test pipelines:
      - Removes the [ci-build-steps.yml](https://github.com/microsoft/botbuilder-dotnet/blob/main/build/yaml/ci-build-steps.yml) template usage. This includes the removal of the _Tag build with package version_ task as the variables involved are not present within these pipelines. We kept the _Display env vars_ for developing/debugging purposes.
      - Adds build configuration parameters to the publish task.
      - Removes parameters `--no-build` and `--no-restore` from test task.
      - Adds missing EOL.
  - To [botbuilder-dotnet-ci-functional-test-windows.yml](https://github.com/microsoft/botbuilder-dotnet/blob/main/build/yaml/botbuilder-dotnet-functional-test-windows.yml)
      - Updated project path to search exclusively from within the functional tests directory. 

## Testing

We tested the new implementation for all functional test and adapter tests (besides Twilio) pipelines.
The following images show execution comparisons between the current and the new implementations for one adapter test and a one functional test respectively:

- Slack adapter:
![image](https://user-images.githubusercontent.com/64803884/92510603-8127e600-f1e2-11ea-8b43-06a837930df5.png)

- Windows functional test:
![image](https://user-images.githubusercontent.com/64803884/92510613-84bb6d00-f1e2-11ea-8d74-046e850c395f.png)
