### PR TITLE
Migrate Microsoft.Bot.Builder.Dialogs.Tests to xUnit

### DIFF
--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ActivityPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ActivityPromptTests.cs
@@ -6,40 +6,31 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Schema;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Tests
 {
-    [TestClass]
     public class ActivityPromptTests
     {
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public void ActivityPromptWithEmptyIdShouldFail()
         {
-            var emptyId = string.Empty;
-            var textPrompt = new EventActivityPrompt(emptyId, Validator);
+            Assert.Throws<ArgumentNullException>(() => new EventActivityPrompt(string.Empty, Validator));
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public void ActivityPromptWithNullIdShouldFail()
         {
-            var nullId = string.Empty;
-            nullId = null;
-            var textPrompt = new EventActivityPrompt(nullId, Validator);
+            Assert.Throws<ArgumentNullException>(() => new EventActivityPrompt(null, Validator));
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public void ActivityPromptWithNullValidatorShouldFail()
         {
-            var validator = (PromptValidator<Activity>)Validator;
-            validator = null;
-            var textPrompt = new EventActivityPrompt("EventActivityPrompt", validator);
+            Assert.Throws<ArgumentNullException>(() => new EventActivityPrompt("EventActivityPrompt", null));
         }
 
-        [TestMethod]
+        [Fact]
         public async Task BasicActivityPrompt()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -81,7 +72,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ActivityPromptShouldSendRetryPromptIfValidationFailed()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -141,7 +132,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ActivityPromptResumeDialogShouldPromptNotRetry()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -205,7 +196,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task OnPromptOverloadWithoutIsRetryParamReturnsBasicActivityPrompt()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -247,47 +238,51 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public async Task OnPromptErrorsWithNullContext()
         {
-            var eventPrompt = new EventActivityPrompt("EventActivityPrompt", Validator);
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                var eventPrompt = new EventActivityPrompt("EventActivityPrompt", Validator);
 
-            var options = new PromptOptions { Prompt = new Activity { Type = ActivityTypes.Message, Text = "please send an event." } };
+                var options = new PromptOptions { Prompt = new Activity { Type = ActivityTypes.Message, Text = "please send an event." } };
 
-            await eventPrompt.OnPromptNullContext(options);
+                await eventPrompt.OnPromptNullContext(options);
+            });
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public async Task OnPromptErrorsWithNullOptions()
         {
-            var convoState = new ConversationState(new MemoryStorage());
-            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
-
-            var adapter = new TestAdapter()
-                .Use(new AutoSaveStateMiddleware(convoState));
-
-            // Create new DialogSet.
-            var dialogs = new DialogSet(dialogState);
-
-            // Create and add custom activity prompt to DialogSet.
-            var eventPrompt = new EventActivityPrompt("EventActivityPrompt", Validator);
-            dialogs.Add(eventPrompt);
-
-            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
             {
-                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+                var convoState = new ConversationState(new MemoryStorage());
+                var dialogState = convoState.CreateProperty<DialogState>("dialogState");
 
-                await eventPrompt.OnPromptNullOptions(dc);
-            })
-            .Send("hello")
-            .StartTestAsync();
+                var adapter = new TestAdapter()
+                    .Use(new AutoSaveStateMiddleware(convoState));
+
+                // Create new DialogSet.
+                var dialogs = new DialogSet(dialogState);
+
+                // Create and add custom activity prompt to DialogSet.
+                var eventPrompt = new EventActivityPrompt("EventActivityPrompt", Validator);
+                dialogs.Add(eventPrompt);
+
+                await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+                {
+                    var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                    await eventPrompt.OnPromptNullOptions(dc);
+                })
+                .Send("hello")
+                .StartTestAsync();
+            });
         }
 
         private async Task<bool> Validator(PromptValidatorContext<Activity> promptContext, CancellationToken cancellationToken)
         {
-            Assert.IsTrue(promptContext.AttemptCount > 0);
+            Assert.True(promptContext.AttemptCount > 0);
 
             var activity = promptContext.Recognized.Value;
             if (activity.Type == ActivityTypes.Event)

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/AttachmentPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/AttachmentPromptTests.cs
@@ -6,39 +6,31 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Schema;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Tests
 {
-    [TestClass]
     public class AttachmentPromptTests
     {
-        public TestContext TestContext { get; set; }
-
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public void AttachmentPromptWithEmptyIdShouldFail()
         {
-            var emptyId = string.Empty;
-            var attachmentPrompt = new AttachmentPrompt(emptyId);
+            Assert.Throws<ArgumentNullException>(() => new AttachmentPrompt(string.Empty));
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public void AttachmentPromptWithNullIdShouldFail()
         {
-            var nullId = string.Empty;
-            nullId = null;
-            var attachmentPrompt = new AttachmentPrompt(nullId);
+            Assert.Throws<ArgumentNullException>(() => new AttachmentPrompt(null));
         }
 
-        [TestMethod]
+        [Fact]
         public async Task BasicAttachmentPrompt()
         {
             var convoState = new ConversationState(new MemoryStorage());
             var dialogState = convoState.CreateProperty<DialogState>("dialogState");
 
-            var adapter = new TestAdapter(TestAdapter.CreateConversation(TestContext.TestName))
+            var adapter = new TestAdapter(TestAdapter.CreateConversation(nameof(BasicAttachmentPrompt)))
                 .Use(new AutoSaveStateMiddleware(convoState))
                 .Use(new TranscriptLoggerMiddleware(new TraceTranscriptLogger(traceActivity: false)));
 
@@ -79,13 +71,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task RetryAttachmentPrompt()
         {
             var convoState = new ConversationState(new MemoryStorage());
             var dialogState = convoState.CreateProperty<DialogState>("dialogState");
 
-            var adapter = new TestAdapter(TestAdapter.CreateConversation(TestContext.TestName))
+            var adapter = new TestAdapter(TestAdapter.CreateConversation(nameof(RetryAttachmentPrompt)))
                 .Use(new AutoSaveStateMiddleware(convoState))
                 .Use(new TranscriptLoggerMiddleware(new TraceTranscriptLogger(traceActivity: false)));
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoiceFactoryTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoiceFactoryTests.cs
@@ -6,13 +6,12 @@ using System.Linq;
 using Microsoft.Bot.Builder.Dialogs.Choices;
 using Microsoft.Bot.Connector;
 using Microsoft.Bot.Schema;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Tests
 {
-    [TestClass]
-    [TestCategory("Prompts")]
-    [TestCategory("Choice Tests")]
+    [Trait("TestCategory", "Prompts")]
+    [Trait("TestCategory", "Choice Tests")]
     public class ChoiceFactoryTests
     {
         private static List<Choice> colorChoices = new List<Choice> { new Choice("red"), new Choice("green"), new Choice("blue") };
@@ -24,163 +23,163 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             new Choice("PostBack") { Action = new CardAction(ActionTypes.PostBack, "PostBack Action", value: "PostBack Value") },
         };
 
-        [TestMethod]
+        [Fact]
         public void ShouldRenderChoicesInline()
         {
             var activity = ChoiceFactory.Inline(colorChoices, "select from:");
-            Assert.AreEqual("select from: (1) red, (2) green, or (3) blue", activity.Text);
+            Assert.Equal("select from: (1) red, (2) green, or (3) blue", activity.Text);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldRenderChoicesAsAList()
         {
             var activity = ChoiceFactory.List(colorChoices, "select from:");
-            Assert.AreEqual("select from:\n\n   1. red\n   2. green\n   3. blue", activity.Text);
+            Assert.Equal("select from:\n\n   1. red\n   2. green\n   3. blue", activity.Text);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldRenderUnincludedNumbersChoicesAsAList()
         {
             var activity = ChoiceFactory.List(colorChoices, "select from:", options: new ChoiceFactoryOptions { IncludeNumbers = false });
-            Assert.AreEqual("select from:\n\n   - red\n   - green\n   - blue", activity.Text);
+            Assert.Equal("select from:\n\n   - red\n   - green\n   - blue", activity.Text);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldRenderChoicesAsSuggestedActions()
         {
             var activity = ChoiceFactory.SuggestedAction(colorChoices, "select from:");
-            Assert.AreEqual("select from:", activity.Text);
-            Assert.IsNotNull(activity.SuggestedActions);
-            Assert.AreEqual(3, activity.SuggestedActions.Actions.Count);
-            Assert.AreEqual(ActionTypes.ImBack, activity.SuggestedActions.Actions[0].Type);
-            Assert.AreEqual("red", activity.SuggestedActions.Actions[0].Value);
-            Assert.AreEqual("red", activity.SuggestedActions.Actions[0].Title);
-            Assert.AreEqual(ActionTypes.ImBack, activity.SuggestedActions.Actions[1].Type);
-            Assert.AreEqual("green", activity.SuggestedActions.Actions[1].Value);
-            Assert.AreEqual("green", activity.SuggestedActions.Actions[1].Title);
-            Assert.AreEqual(ActionTypes.ImBack, activity.SuggestedActions.Actions[2].Type);
-            Assert.AreEqual("blue", activity.SuggestedActions.Actions[2].Value);
-            Assert.AreEqual("blue", activity.SuggestedActions.Actions[2].Title);
+            Assert.Equal("select from:", activity.Text);
+            Assert.NotNull(activity.SuggestedActions);
+            Assert.Equal(3, activity.SuggestedActions.Actions.Count);
+            Assert.Equal(ActionTypes.ImBack, activity.SuggestedActions.Actions[0].Type);
+            Assert.Equal("red", activity.SuggestedActions.Actions[0].Value);
+            Assert.Equal("red", activity.SuggestedActions.Actions[0].Title);
+            Assert.Equal(ActionTypes.ImBack, activity.SuggestedActions.Actions[1].Type);
+            Assert.Equal("green", activity.SuggestedActions.Actions[1].Value);
+            Assert.Equal("green", activity.SuggestedActions.Actions[1].Title);
+            Assert.Equal(ActionTypes.ImBack, activity.SuggestedActions.Actions[2].Type);
+            Assert.Equal("blue", activity.SuggestedActions.Actions[2].Value);
+            Assert.Equal("blue", activity.SuggestedActions.Actions[2].Title);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldRenderChoicesAsHeroCard()
         {
             var activity = ChoiceFactory.HeroCard(colorChoices, "select from:");
 
-            Assert.IsNotNull(activity.Attachments);
+            Assert.NotNull(activity.Attachments);
 
             var heroCard = (HeroCard)activity.Attachments.First().Content;
 
-            Assert.AreEqual(3, heroCard.Buttons.Count);
-            Assert.AreEqual(ActionTypes.ImBack, heroCard.Buttons[0].Type);
-            Assert.AreEqual("red", heroCard.Buttons[0].Value);
-            Assert.AreEqual("red", heroCard.Buttons[0].Title);
-            Assert.AreEqual(ActionTypes.ImBack, heroCard.Buttons[1].Type);
-            Assert.AreEqual("green", heroCard.Buttons[1].Value);
-            Assert.AreEqual("green", heroCard.Buttons[1].Title);
-            Assert.AreEqual(ActionTypes.ImBack, heroCard.Buttons[2].Type);
-            Assert.AreEqual("blue", heroCard.Buttons[2].Value);
-            Assert.AreEqual("blue", heroCard.Buttons[2].Title);
+            Assert.Equal(3, heroCard.Buttons.Count);
+            Assert.Equal(ActionTypes.ImBack, heroCard.Buttons[0].Type);
+            Assert.Equal("red", heroCard.Buttons[0].Value);
+            Assert.Equal("red", heroCard.Buttons[0].Title);
+            Assert.Equal(ActionTypes.ImBack, heroCard.Buttons[1].Type);
+            Assert.Equal("green", heroCard.Buttons[1].Value);
+            Assert.Equal("green", heroCard.Buttons[1].Title);
+            Assert.Equal(ActionTypes.ImBack, heroCard.Buttons[2].Type);
+            Assert.Equal("blue", heroCard.Buttons[2].Value);
+            Assert.Equal("blue", heroCard.Buttons[2].Title);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldAutomaticallyChooseRenderStyleBasedOnChannelType()
         {
             var activity = ChoiceFactory.ForChannel(Channels.Emulator, colorChoices, "select from:");
-            Assert.AreEqual("select from:", activity.Text);
-            Assert.IsNotNull(activity.SuggestedActions);
-            Assert.AreEqual(3, activity.SuggestedActions.Actions.Count);
-            Assert.AreEqual(ActionTypes.ImBack, activity.SuggestedActions.Actions[0].Type);
-            Assert.AreEqual("red", activity.SuggestedActions.Actions[0].Value);
-            Assert.AreEqual("red", activity.SuggestedActions.Actions[0].Title);
-            Assert.AreEqual(ActionTypes.ImBack, activity.SuggestedActions.Actions[1].Type);
-            Assert.AreEqual("green", activity.SuggestedActions.Actions[1].Value);
-            Assert.AreEqual("green", activity.SuggestedActions.Actions[1].Title);
-            Assert.AreEqual(ActionTypes.ImBack, activity.SuggestedActions.Actions[2].Type);
-            Assert.AreEqual("blue", activity.SuggestedActions.Actions[2].Value);
-            Assert.AreEqual("blue", activity.SuggestedActions.Actions[2].Title);
+            Assert.Equal("select from:", activity.Text);
+            Assert.NotNull(activity.SuggestedActions);
+            Assert.Equal(3, activity.SuggestedActions.Actions.Count);
+            Assert.Equal(ActionTypes.ImBack, activity.SuggestedActions.Actions[0].Type);
+            Assert.Equal("red", activity.SuggestedActions.Actions[0].Value);
+            Assert.Equal("red", activity.SuggestedActions.Actions[0].Title);
+            Assert.Equal(ActionTypes.ImBack, activity.SuggestedActions.Actions[1].Type);
+            Assert.Equal("green", activity.SuggestedActions.Actions[1].Value);
+            Assert.Equal("green", activity.SuggestedActions.Actions[1].Title);
+            Assert.Equal(ActionTypes.ImBack, activity.SuggestedActions.Actions[2].Type);
+            Assert.Equal("blue", activity.SuggestedActions.Actions[2].Value);
+            Assert.Equal("blue", activity.SuggestedActions.Actions[2].Title);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldChooseCorrectStylesForCortana()
         {
             var activity = ChoiceFactory.ForChannel(Channels.Cortana, colorChoices, "select from:");
 
-            Assert.IsNotNull(activity.Attachments);
+            Assert.NotNull(activity.Attachments);
 
             var heroCard = (HeroCard)activity.Attachments.First().Content;
 
-            Assert.AreEqual(3, heroCard.Buttons.Count);
-            Assert.AreEqual(ActionTypes.ImBack, heroCard.Buttons[0].Type);
-            Assert.AreEqual("red", heroCard.Buttons[0].Value);
-            Assert.AreEqual("red", heroCard.Buttons[0].Title);
-            Assert.AreEqual(ActionTypes.ImBack, heroCard.Buttons[1].Type);
-            Assert.AreEqual("green", heroCard.Buttons[1].Value);
-            Assert.AreEqual("green", heroCard.Buttons[1].Title);
-            Assert.AreEqual(ActionTypes.ImBack, heroCard.Buttons[2].Type);
-            Assert.AreEqual("blue", heroCard.Buttons[2].Value);
-            Assert.AreEqual("blue", heroCard.Buttons[2].Title);
+            Assert.Equal(3, heroCard.Buttons.Count);
+            Assert.Equal(ActionTypes.ImBack, heroCard.Buttons[0].Type);
+            Assert.Equal("red", heroCard.Buttons[0].Value);
+            Assert.Equal("red", heroCard.Buttons[0].Title);
+            Assert.Equal(ActionTypes.ImBack, heroCard.Buttons[1].Type);
+            Assert.Equal("green", heroCard.Buttons[1].Value);
+            Assert.Equal("green", heroCard.Buttons[1].Title);
+            Assert.Equal(ActionTypes.ImBack, heroCard.Buttons[2].Type);
+            Assert.Equal("blue", heroCard.Buttons[2].Value);
+            Assert.Equal("blue", heroCard.Buttons[2].Title);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldChooseCorrectStylesForTeams()
         {
             var activity = ChoiceFactory.ForChannel(Channels.Msteams, colorChoices, "select from:");
 
-            Assert.IsNotNull(activity.Attachments);
+            Assert.NotNull(activity.Attachments);
 
             var heroCard = (HeroCard)activity.Attachments.First().Content;
 
-            Assert.AreEqual(3, heroCard.Buttons.Count);
-            Assert.AreEqual(ActionTypes.ImBack, heroCard.Buttons[0].Type);
-            Assert.AreEqual("red", heroCard.Buttons[0].Value);
-            Assert.AreEqual("red", heroCard.Buttons[0].Title);
-            Assert.AreEqual(ActionTypes.ImBack, heroCard.Buttons[1].Type);
-            Assert.AreEqual("green", heroCard.Buttons[1].Value);
-            Assert.AreEqual("green", heroCard.Buttons[1].Title);
-            Assert.AreEqual(ActionTypes.ImBack, heroCard.Buttons[2].Type);
-            Assert.AreEqual("blue", heroCard.Buttons[2].Value);
-            Assert.AreEqual("blue", heroCard.Buttons[2].Title);
+            Assert.Equal(3, heroCard.Buttons.Count);
+            Assert.Equal(ActionTypes.ImBack, heroCard.Buttons[0].Type);
+            Assert.Equal("red", heroCard.Buttons[0].Value);
+            Assert.Equal("red", heroCard.Buttons[0].Title);
+            Assert.Equal(ActionTypes.ImBack, heroCard.Buttons[1].Type);
+            Assert.Equal("green", heroCard.Buttons[1].Value);
+            Assert.Equal("green", heroCard.Buttons[1].Title);
+            Assert.Equal(ActionTypes.ImBack, heroCard.Buttons[2].Type);
+            Assert.Equal("blue", heroCard.Buttons[2].Value);
+            Assert.Equal("blue", heroCard.Buttons[2].Title);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldIncludeChoiceActionsInSuggestedActions()
         {
             var activity = ChoiceFactory.SuggestedAction(choicesWithActions, "select from:");
-            Assert.AreEqual("select from:", activity.Text);
-            Assert.IsNotNull(activity.SuggestedActions);
-            Assert.AreEqual(3, activity.SuggestedActions.Actions.Count);
-            Assert.AreEqual(ActionTypes.ImBack, activity.SuggestedActions.Actions[0].Type);
-            Assert.AreEqual("ImBack Value", activity.SuggestedActions.Actions[0].Value);
-            Assert.AreEqual("ImBack Action", activity.SuggestedActions.Actions[0].Title);
-            Assert.AreEqual(ActionTypes.MessageBack, activity.SuggestedActions.Actions[1].Type);
-            Assert.AreEqual("MessageBack Value", activity.SuggestedActions.Actions[1].Value);
-            Assert.AreEqual("MessageBack Action", activity.SuggestedActions.Actions[1].Title);
-            Assert.AreEqual(ActionTypes.PostBack, activity.SuggestedActions.Actions[2].Type);
-            Assert.AreEqual("PostBack Value", activity.SuggestedActions.Actions[2].Value);
-            Assert.AreEqual("PostBack Action", activity.SuggestedActions.Actions[2].Title);
+            Assert.Equal("select from:", activity.Text);
+            Assert.NotNull(activity.SuggestedActions);
+            Assert.Equal(3, activity.SuggestedActions.Actions.Count);
+            Assert.Equal(ActionTypes.ImBack, activity.SuggestedActions.Actions[0].Type);
+            Assert.Equal("ImBack Value", activity.SuggestedActions.Actions[0].Value);
+            Assert.Equal("ImBack Action", activity.SuggestedActions.Actions[0].Title);
+            Assert.Equal(ActionTypes.MessageBack, activity.SuggestedActions.Actions[1].Type);
+            Assert.Equal("MessageBack Value", activity.SuggestedActions.Actions[1].Value);
+            Assert.Equal("MessageBack Action", activity.SuggestedActions.Actions[1].Title);
+            Assert.Equal(ActionTypes.PostBack, activity.SuggestedActions.Actions[2].Type);
+            Assert.Equal("PostBack Value", activity.SuggestedActions.Actions[2].Value);
+            Assert.Equal("PostBack Action", activity.SuggestedActions.Actions[2].Title);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldIncludeChoiceActionsInHeroCards()
         {
             var activity = ChoiceFactory.HeroCard(choicesWithActions, "select from:");
 
-            Assert.IsNotNull(activity.Attachments);
+            Assert.NotNull(activity.Attachments);
 
             var heroCard = (HeroCard)activity.Attachments.First().Content;
 
-            Assert.AreEqual(3, heroCard.Buttons.Count);
-            Assert.AreEqual(ActionTypes.ImBack, heroCard.Buttons[0].Type);
-            Assert.AreEqual("ImBack Value", heroCard.Buttons[0].Value);
-            Assert.AreEqual("ImBack Action", heroCard.Buttons[0].Title);
-            Assert.AreEqual(ActionTypes.MessageBack, heroCard.Buttons[1].Type);
-            Assert.AreEqual("MessageBack Value", heroCard.Buttons[1].Value);
-            Assert.AreEqual("MessageBack Action", heroCard.Buttons[1].Title);
-            Assert.AreEqual(ActionTypes.PostBack, heroCard.Buttons[2].Type);
-            Assert.AreEqual("PostBack Value", heroCard.Buttons[2].Value);
-            Assert.AreEqual("PostBack Action", heroCard.Buttons[2].Title);
+            Assert.Equal(3, heroCard.Buttons.Count);
+            Assert.Equal(ActionTypes.ImBack, heroCard.Buttons[0].Type);
+            Assert.Equal("ImBack Value", heroCard.Buttons[0].Value);
+            Assert.Equal("ImBack Action", heroCard.Buttons[0].Title);
+            Assert.Equal(ActionTypes.MessageBack, heroCard.Buttons[1].Type);
+            Assert.Equal("MessageBack Value", heroCard.Buttons[1].Value);
+            Assert.Equal("MessageBack Action", heroCard.Buttons[1].Title);
+            Assert.Equal(ActionTypes.PostBack, heroCard.Buttons[2].Type);
+            Assert.Equal("PostBack Value", heroCard.Buttons[2].Value);
+            Assert.Equal("PostBack Action", heroCard.Buttons[2].Title);
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicePromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicePromptTests.cs
@@ -3,21 +3,19 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Builder.Dialogs.Choices;
 using Microsoft.Bot.Builder.Dialogs.Prompts;
 using Microsoft.Bot.Schema;
 using Microsoft.Recognizers.Text;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 using static Microsoft.Bot.Builder.Dialogs.Prompts.PromptCultureModels;
 
 namespace Microsoft.Bot.Builder.Dialogs.Tests
 {
-    [TestClass]
-    [TestCategory("Prompts")]
-    [TestCategory("Choice Prompts")]
+    [Trait("TestCategory", "Prompts")]
+    [Trait("TestCategory", "Choice Tests")]
     public class ChoicePromptTests
     {
         private readonly List<Choice> _colorChoices = new List<Choice>
@@ -27,21 +25,53 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             new Choice { Value = "blue" },
         };
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        /// <summary>
+        /// Generates an Enumerable of variations on all supported locales.
+        /// </summary>
+        /// <returns>An iterable collection of objects.</returns>
+        public static IEnumerable<object[]> GetLocaleVariationTest()
+        {
+            var testLocales = new TestLocale[]
+            {
+                new TestLocale(Bulgarian),
+                new TestLocale(Chinese),
+                new TestLocale(Dutch),
+                new TestLocale(English),
+                new TestLocale(French),
+                new TestLocale(German),
+                new TestLocale(Hindi),
+                new TestLocale(Italian),
+                new TestLocale(Japanese),
+                new TestLocale(Korean),
+                new TestLocale(Portuguese),
+                new TestLocale(Spanish),
+                new TestLocale(Swedish),
+                new TestLocale(Turkish),
+            };
+
+            foreach (var locale in testLocales)
+            {
+                yield return new object[] { locale.ValidLocale, locale.InlineOr, locale.InlineOrMore, locale.Separator };
+                yield return new object[] { locale.CapEnding, locale.InlineOr, locale.InlineOrMore, locale.Separator };
+                yield return new object[] { locale.TitleEnding, locale.InlineOr, locale.InlineOrMore, locale.Separator };
+                yield return new object[] { locale.CapTwoLetter, locale.InlineOr, locale.InlineOrMore, locale.Separator };
+                yield return new object[] { locale.LowerTwoLetter, locale.InlineOr, locale.InlineOrMore, locale.Separator };
+            }
+        }
+
+        [Fact]
         public void ChoicePromptWithEmptyIdShouldFail()
         {
-            var choicePrompt = new ChoicePrompt(string.Empty);
+            Assert.Throws<ArgumentNullException>(() => new ChoicePrompt(string.Empty));
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public void ChoicePromptWithNullIdShouldFail()
         {
-            var choicePrompt = new ChoicePrompt(null);
+            Assert.Throws<ArgumentNullException>(() => new ChoicePrompt(null));
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ChoicePromptWithCardActionAndNoValueShouldNotFail()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -86,7 +116,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ShouldSendPrompt()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -121,7 +151,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ShouldSendPromptAsAnInlineList()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -155,7 +185,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ShouldSendPromptAsANumberedList()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -195,7 +225,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ShouldSendPromptUsingSuggestedActions()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -243,7 +273,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ShouldSendPromptUsingHeroCard()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -292,7 +322,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ShouldSendPromptUsingAppendedHeroCard()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -344,7 +374,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ShouldSendPromptWithoutAddingAList()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -383,7 +413,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ShouldSendPromptWithoutAddingAListButAddingSsml()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -427,7 +457,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ShouldRecognizeAChoice()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -473,7 +503,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ShouldNotRecognizeOtherText()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -514,7 +544,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ShouldCallCustomValidator()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -560,7 +590,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ShouldUseChoiceStyleIfPresent()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -605,8 +635,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 .StartTestAsync();
         }
 
-        [DataTestMethod]
-        [DynamicData(nameof(GetLocaleVariationTest), DynamicDataSourceType.Method)]
+        [Theory]
+        [MemberData(nameof(GetLocaleVariationTest), DisableDiscoveryEnumeration = true)]
         public async Task ShouldRecognizeLocaleVariationsOfCorrectLocales(string testCulture, string inlineOr, string inlineOrMore, string separator)
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -649,15 +679,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                         InlineOrMore = inlineOrMore,
                         InlineSeparator = separator,
                     }).Text;
-                    Assert.AreEqual($"favorite color?{expectedChoices}", activity.AsMessageActivity().Text);
+                    Assert.Equal($"favorite color?{expectedChoices}", activity.AsMessageActivity().Text);
                 })
                 .StartTestAsync();
         }
 
-        [TestMethod]
-        [DataRow(null)]
-        [DataRow("")]
-        [DataRow("not-supported")]
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("not-supported")]
         public async Task ShouldDefaultToEnglishLocale(string activityLocale)
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -700,12 +730,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                         InlineOrMore = English.InlineOrMore,
                         InlineSeparator = English.Separator,
                     }).Text;
-                    Assert.AreEqual($"favorite color?{expectedChoices}", activity.AsMessageActivity().Text);
+                    Assert.Equal($"favorite color?{expectedChoices}", activity.AsMessageActivity().Text);
                 })
                 .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ShouldAcceptAndRecognizeCustomLocaleDict()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -764,13 +794,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                         InlineOrMore = culture.InlineOrMore,
                         InlineSeparator = culture.Separator,
                     }).Text;
-                    Assert.AreEqual($"favorite color?{expectedChoices}", activity.AsMessageActivity().Text);
+                    Assert.Equal($"favorite color?{expectedChoices}", activity.AsMessageActivity().Text);
                 })
                 .StartTestAsync();
         }
 
         /*
-        [TestMethod]
+        [Fact]
         public async Task ShouldHandleAnUndefinedRequest()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -820,9 +850,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         {
             return activity =>
             {
-                Assert.IsInstanceOfType(activity, typeof(IMessageActivity));
+                Assert.IsAssignableFrom<IMessageActivity>(activity);
                 var msg = (IMessageActivity)activity;
-                Assert.IsTrue(msg.Text.StartsWith(expected));
+                Assert.StartsWith(expected, msg.Text);
             };
         }
 
@@ -830,15 +860,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         {
             return activity =>
             {
-                Assert.IsInstanceOfType(activity, typeof(IMessageActivity));
+                Assert.IsAssignableFrom<IMessageActivity>(activity);
                 var msg = (IMessageActivity)activity;
-                Assert.AreEqual(expectedText, msg.Text);
-                Assert.AreEqual(expectedSuggestedActions.Actions.Count, msg.SuggestedActions.Actions.Count);
+                Assert.Equal(expectedText, msg.Text);
+                Assert.Equal(expectedSuggestedActions.Actions.Count, msg.SuggestedActions.Actions.Count);
                 for (var i = 0; i < expectedSuggestedActions.Actions.Count; i++)
                 {
-                    Assert.AreEqual(expectedSuggestedActions.Actions[i].Type, msg.SuggestedActions.Actions[i].Type);
-                    Assert.AreEqual(expectedSuggestedActions.Actions[i].Value, msg.SuggestedActions.Actions[i].Value);
-                    Assert.AreEqual(expectedSuggestedActions.Actions[i].Title, msg.SuggestedActions.Actions[i].Title);
+                    Assert.Equal(expectedSuggestedActions.Actions[i].Type, msg.SuggestedActions.Actions[i].Type);
+                    Assert.Equal(expectedSuggestedActions.Actions[i].Value, msg.SuggestedActions.Actions[i].Value);
+                    Assert.Equal(expectedSuggestedActions.Actions[i].Title, msg.SuggestedActions.Actions[i].Title);
                 }
             };
         }
@@ -847,18 +877,18 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         {
             return activity =>
             {
-                Assert.IsInstanceOfType(activity, typeof(IMessageActivity));
+                Assert.IsAssignableFrom<IMessageActivity>(activity);
                 var msg = (IMessageActivity)activity;
 
                 var attachedHeroCard = (HeroCard)msg.Attachments[index].Content;
 
-                Assert.AreEqual(expectedHeroCard.Title, attachedHeroCard.Title);
-                Assert.AreEqual(expectedHeroCard.Buttons.Count, attachedHeroCard.Buttons.Count);
+                Assert.Equal(expectedHeroCard.Title, attachedHeroCard.Title);
+                Assert.Equal(expectedHeroCard.Buttons.Count, attachedHeroCard.Buttons.Count);
                 for (var i = 0; i < expectedHeroCard.Buttons.Count; i++)
                 {
-                    Assert.AreEqual(expectedHeroCard.Buttons[i].Type, attachedHeroCard.Buttons[i].Type);
-                    Assert.AreEqual(expectedHeroCard.Buttons[i].Value, attachedHeroCard.Buttons[i].Value);
-                    Assert.AreEqual(expectedHeroCard.Buttons[i].Title, attachedHeroCard.Buttons[i].Title);
+                    Assert.Equal(expectedHeroCard.Buttons[i].Type, attachedHeroCard.Buttons[i].Type);
+                    Assert.Equal(expectedHeroCard.Buttons[i].Value, attachedHeroCard.Buttons[i].Value);
+                    Assert.Equal(expectedHeroCard.Buttons[i].Title, attachedHeroCard.Buttons[i].Title);
                 }
             };
         }
@@ -867,45 +897,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         {
             return activity =>
             {
-                Assert.IsInstanceOfType(activity, typeof(IMessageActivity));
+                Assert.IsAssignableFrom<IMessageActivity>(activity);
                 var msg = (IMessageActivity)activity;
-                Assert.AreEqual(expectedText, msg.Text);
-                Assert.AreEqual(expectedSpeak, msg.Speak);
+                Assert.Equal(expectedText, msg.Text);
+                Assert.Equal(expectedSpeak, msg.Speak);
             };
-        }
-
-        /// <summary>
-        /// Generates an Enumerable of variations on all supported locales.
-        /// </summary>
-        #pragma warning disable SA1204 // Static elements should appear before instance elements
-        private static IEnumerable<object[]> GetLocaleVariationTest()
-        {
-            var testLocales = new TestLocale[]
-            {
-                new TestLocale(Bulgarian),
-                new TestLocale(Chinese),
-                new TestLocale(Dutch),
-                new TestLocale(English),
-                new TestLocale(French),
-                new TestLocale(German),
-                new TestLocale(Hindi),
-                new TestLocale(Italian),
-                new TestLocale(Japanese),
-                new TestLocale(Korean),
-                new TestLocale(Portuguese),
-                new TestLocale(Spanish),
-                new TestLocale(Swedish),
-                new TestLocale(Turkish),
-            };
-
-            foreach (var locale in testLocales)
-            {
-                yield return new object[] { locale.ValidLocale, locale.InlineOr, locale.InlineOrMore, locale.Separator };
-                yield return new object[] { locale.CapEnding, locale.InlineOr, locale.InlineOrMore, locale.Separator };
-                yield return new object[] { locale.TitleEnding, locale.InlineOr, locale.InlineOrMore, locale.Separator };
-                yield return new object[] { locale.CapTwoLetter, locale.InlineOr, locale.InlineOrMore, locale.Separator };
-                yield return new object[] { locale.LowerTwoLetter, locale.InlineOr, locale.InlineOrMore, locale.Separator };
-            }
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicesChannelTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicesChannelTests.cs
@@ -4,150 +4,149 @@
 using Microsoft.Bot.Builder.Dialogs.Choices;
 using Microsoft.Bot.Connector;
 using Microsoft.Bot.Connector.Authentication;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Tests
 {
-    [TestClass]
-    [TestCategory("Prompts")]
-    [TestCategory("Choice Tests")]
+    [Trait("TestCategory", "Prompts")]
+    [Trait("TestCategory", "Choice Tests")]
     public class ChoicesChannelTests
     {
-        [TestMethod]
+        [Fact]
         public void ShouldReturnTrueForSupportsSuggestedActionsWithLineAnd13()
         {
             var supports = Channel.SupportsSuggestedActions(Channels.Line, 13);
-            Assert.IsTrue(supports);
+            Assert.True(supports);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldReturnFalseForSupportsSuggestedActionsWithLineAnd14()
         {
             var supports = Channel.SupportsSuggestedActions(Channels.Line, 14);
-            Assert.IsFalse(supports);
+            Assert.False(supports);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldReturnTrueForSupportsSuggestedActionsWithSkypeAnd10()
         {
             var supports = Channel.SupportsSuggestedActions(Channels.Skype, 10);
-            Assert.IsTrue(supports);
+            Assert.True(supports);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldReturnFalseForSupportsSuggestedActionsWithSkypeAnd11()
         {
             var supports = Channel.SupportsSuggestedActions(Channels.Skype, 11);
-            Assert.IsFalse(supports);
+            Assert.False(supports);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldReturnTrueForSupportsSuggestedActionsWithKikAnd20()
         {
             var supports = Channel.SupportsSuggestedActions(Channels.Kik, 20);
-            Assert.IsTrue(supports);
+            Assert.True(supports);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldReturnFalseForSupportsSuggestedActionsWithKikAnd21()
         {
             var supports = Channel.SupportsSuggestedActions(Channels.Skype, 21);
-            Assert.IsFalse(supports);
+            Assert.False(supports);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldReturnTrueForSupportsSuggestedActionsWithEmulatorAnd100()
         {
             var supports = Channel.SupportsSuggestedActions(Channels.Emulator, 100);
-            Assert.IsTrue(supports);
+            Assert.True(supports);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldReturnFalseForSupportsSuggestedActionsWithEmulatorAnd101()
         {
             var supports = Channel.SupportsSuggestedActions(Channels.Emulator, 101);
-            Assert.IsFalse(supports);
+            Assert.False(supports);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldReturnTrueForSupportsSuggestedActionsWithDirectLineSpeechAnd100()
         {
             var supports = Channel.SupportsSuggestedActions(Channels.DirectlineSpeech, 100);
-            Assert.IsTrue(supports);
+            Assert.True(supports);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldReturnTrueForSupportsCardActionsWithDirectLineSpeechAnd99()
         {
             var supports = Channel.SupportsCardActions(Channels.DirectlineSpeech, 99);
-            Assert.IsTrue(supports);
+            Assert.True(supports);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldReturnTrueForSupportsCardActionsWithLineAnd99()
         {
             var supports = Channel.SupportsCardActions(Channels.Line, 99);
-            Assert.IsTrue(supports);
+            Assert.True(supports);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldReturnFalseForSupportsCardActionsWithLineAnd100()
         {
             var supports = Channel.SupportsCardActions(Channels.Line, 100);
-            Assert.IsFalse(supports);
+            Assert.False(supports);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldReturnTrueForSupportsCardActionsWithCortanaAnd100()
         {
             var supports = Channel.SupportsCardActions(Channels.Cortana, 100);
-            Assert.IsTrue(supports);
+            Assert.True(supports);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldReturnTrueForSupportsCardActionsWithSlackAnd100()
         {
             var supports = Channel.SupportsCardActions(Channels.Slack, 100);
-            Assert.IsTrue(supports);
+            Assert.True(supports);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldReturnTrueForSupportsCardActionsWithSkypeAnd100()
         {
             var supports = Channel.SupportsCardActions(Channels.Skype, 3);
-            Assert.IsTrue(supports);
+            Assert.True(supports);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldReturnFalseForSupportsCardActionsWithSkypeAnd5()
         {
             var supports = Channel.SupportsCardActions(Channels.Skype, 5);
-            Assert.IsFalse(supports);
+            Assert.False(supports);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldReturnFalseForHasMessageFeedWithCortana()
         {
             var supports = Channel.HasMessageFeed(Channels.Cortana);
-            Assert.IsFalse(supports);
+            Assert.False(supports);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldReturnChannelIdFromContextActivity()
         {
             var testActivity = new Schema.Activity() { ChannelId = Channels.Facebook };
             var testContext = new TurnContext(new BotFrameworkAdapter(new SimpleCredentialProvider()), testActivity);
             var channelId = Channel.GetChannelId(testContext);
-            Assert.AreEqual(Channels.Facebook, channelId);
+            Assert.Equal(Channels.Facebook, channelId);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldReturnEmptyFromContextActivityMissingChannel()
         {
             var testActivity = new Schema.Activity() { ChannelId = null };
             var testContext = new TurnContext(new BotFrameworkAdapter(new SimpleCredentialProvider()), testActivity);
             var channelId = Channel.GetChannelId(testContext);
-            Assert.AreEqual(channelId, string.Empty);
+            Assert.Equal(channelId, string.Empty);
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicesRecognizersTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicesRecognizersTests.cs
@@ -3,13 +3,12 @@
 
 using System.Collections.Generic;
 using Microsoft.Bot.Builder.Dialogs.Choices;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Tests
 {
-    [TestClass]
-    [TestCategory("Prompts")]
-    [TestCategory("Choice Tests")]
+    [Trait("TestCategory", "Prompts")]
+    [Trait("TestCategory", "Choice Tests")]
     public class ChoicesRecognizersTests
     {
         // FindChoices
@@ -38,193 +37,193 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         };
 
         // FindValues
-        [TestMethod]
+        [Fact]
         public void ShouldFindASimpleValueInAnSingleWordUtterance()
         {
             var found = Find.FindValues("red", colorValues);
-            Assert.AreEqual(1, found.Count);
+            Assert.Single(found);
             AssertResult(found[0], 0, 2, "red");
             AssertValue(found[0], "red", 0, 1.0f);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldFindASimpleValueInAnUtterance()
         {
             var found = Find.FindValues("the red one please.", colorValues);
-            Assert.AreEqual(1, found.Count);
+            Assert.Single(found);
             AssertResult(found[0], 4, 6, "red");
             AssertValue(found[0], "red", 0, 1.0f);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldFindMultipleValuesWithinAnUtterance()
         {
             var found = Find.FindValues("the red and blue ones please.", colorValues);
-            Assert.AreEqual(2, found.Count);
+            Assert.Equal(2, found.Count);
             AssertResult(found[0], 4, 6, "red");
             AssertValue(found[0], "red", 0, 1.0f);
             AssertValue(found[1], "blue", 2, 1.0f);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldFindMultipleValuesThatOverlap()
         {
             var found = Find.FindValues("the bread pudding and bread please.", overlappingValues);
-            Assert.AreEqual(2, found.Count);
+            Assert.Equal(2, found.Count);
             AssertResult(found[0], 4, 16, "bread pudding");
             AssertValue(found[0], "bread pudding", 1, 1.0f);
             AssertValue(found[1], "bread", 0, 1.0f);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldCorrectlyDisambiguateBetweenVerySimilarValues()
         {
             var found = Find.FindValues("option B", similarValues, new FindValuesOptions { AllowPartialMatches = true });
-            Assert.AreEqual(1, found.Count);
+            Assert.Single(found);
             AssertValue(found[0], "option B", 1, 1.0f);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldFindASingleChoiceInAnUtterance()
         {
             var found = Find.FindChoices("the red one please.", colorChoices);
-            Assert.AreEqual(1, found.Count);
+            Assert.Single(found);
             AssertResult(found[0], 4, 6, "red");
             AssertChoice(found[0], "red", 0, 1.0f, "red");
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldFindMultipleChoicesWithinAnUtterance()
         {
             var found = Find.FindChoices("the red and blue ones please.", colorChoices);
-            Assert.AreEqual(2, found.Count);
+            Assert.Equal(2, found.Count);
             AssertResult(found[0], 4, 6, "red");
             AssertChoice(found[0], "red", 0, 1.0f);
             AssertChoice(found[1], "blue", 2, 1.0f);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldFindMultipleChoicesThatOverlap()
         {
             var found = Find.FindChoices("the bread pudding and bread please.", overlappingChoices);
-            Assert.AreEqual(2, found.Count);
+            Assert.Equal(2, found.Count);
             AssertResult(found[0], 4, 16, "bread pudding");
             AssertChoice(found[0], "bread pudding", 1, 1.0f);
             AssertChoice(found[1], "bread", 0, 1.0f);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldAcceptNullUtteranceInFindChoices()
         {
             var found = Find.FindChoices(null, colorChoices);
-            Assert.AreEqual(0, found.Count);
+            Assert.Empty(found);
         }
 
         // RecognizeChoices
-        [TestMethod]
+        [Fact]
         public void ShouldFindAChoiceInAnUtteranceByName()
         {
             var found = ChoiceRecognizers.RecognizeChoices("the red one please.", colorChoices);
-            Assert.AreEqual(1, found.Count);
+            Assert.Single(found);
             AssertResult(found[0], 4, 6, "red");
             AssertChoice(found[0], "red", 0, 1.0f, "red");
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldFindAChoiceInAnUtteranceByOrdinalPosition()
         {
             var found = ChoiceRecognizers.RecognizeChoices("the first one please.", colorChoices);
-            Assert.AreEqual(1, found.Count);
+            Assert.Single(found);
             AssertResult(found[0], 4, 8, "first");
             AssertChoice(found[0], "red", 0, 1.0f);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldFindMultipleChoicesInAnUtteranceByOrdinalPosition()
         {
             var found = ChoiceRecognizers.RecognizeChoices("the first and third one please.", colorChoices);
-            Assert.AreEqual(2, found.Count);
+            Assert.Equal(2, found.Count);
             AssertChoice(found[0], "red", 0, 1.0f);
             AssertChoice(found[1], "blue", 2, 1.0f);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldFindAChoiceInAnUtteranceByNumericalIndex_digit()
         {
             var found = ChoiceRecognizers.RecognizeChoices("1", colorChoices);
-            Assert.AreEqual(1, found.Count);
+            Assert.Single(found);
             AssertResult(found[0], 0, 0, "1");
             AssertChoice(found[0], "red", 0, 1.0f);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldFindAChoiceInAnUtteranceByNumericalIndex_Text()
         {
             var found = ChoiceRecognizers.RecognizeChoices("one", colorChoices);
-            Assert.AreEqual(1, found.Count);
+            Assert.Single(found);
             AssertResult(found[0], 0, 2, "one");
             AssertChoice(found[0], "red", 0, 1.0f);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldFindMultipleChoicesInAnUtteranceByNumerical_index()
         {
             var found = ChoiceRecognizers.RecognizeChoices("option one and 3.", colorChoices);
-            Assert.AreEqual(2, found.Count);
+            Assert.Equal(2, found.Count);
             AssertChoice(found[0], "red", 0, 1.0f);
             AssertChoice(found[1], "blue", 2, 1.0f);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldAcceptNullUtteranceInRecognizeChoices()
         {
             var found = ChoiceRecognizers.RecognizeChoices(null, colorChoices);
-            Assert.AreEqual(0, found.Count);
+            Assert.Empty(found);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldNOTFindAChoiceInAnUtteranceByOrdinalPosition_RecognizeOrdinalsFalseAndRecognizeNumbersFalse()
         {
             var found = ChoiceRecognizers.RecognizeChoices("the first one please.", colorChoices, new FindChoicesOptions() { RecognizeOrdinals = false, RecognizeNumbers = false });
-            Assert.AreEqual(0, found.Count);
+            Assert.Empty(found);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldNOTFindAChoiceInAnUtteranceByNumericalIndex_Text_RecognizeNumbersFalse()
         {
             var found = ChoiceRecognizers.RecognizeChoices("one", colorChoices, new FindChoicesOptions() { RecognizeNumbers = false });
-            Assert.AreEqual(0, found.Count);
+            Assert.Empty(found);
         }
 
         // Helper functions
         private static void AssertResult<T>(ModelResult<T> result, int start, int end, string text)
         {
-            Assert.AreEqual(start, result.Start);
-            Assert.AreEqual(end, result.End);
-            Assert.AreEqual(text, result.Text);
+            Assert.Equal(start, result.Start);
+            Assert.Equal(end, result.End);
+            Assert.Equal(text, result.Text);
         }
 
         private static void AssertValue(ModelResult<FoundValue> result, string value, int index, float score)
         {
-            Assert.AreEqual("value", result.TypeName);
-            Assert.IsNotNull(result.Resolution);
+            Assert.Equal("value", result.TypeName);
+            Assert.NotNull(result.Resolution);
             var resolution = result.Resolution;
-            Assert.AreEqual(value, resolution.Value);
-            Assert.AreEqual(index, resolution.Index);
-            Assert.AreEqual(score, resolution.Score);
+            Assert.Equal(value, resolution.Value);
+            Assert.Equal(index, resolution.Index);
+            Assert.Equal(score, resolution.Score);
         }
 
         private static void AssertChoice(ModelResult<FoundChoice> result, string value, int index, float score, string synonym = null)
         {
-            Assert.AreEqual("choice", result.TypeName);
-            Assert.IsNotNull(result.Resolution);
+            Assert.Equal("choice", result.TypeName);
+            Assert.NotNull(result.Resolution);
             var resolution = result.Resolution;
-            Assert.AreEqual(value, resolution.Value);
-            Assert.AreEqual(index, resolution.Index);
-            Assert.AreEqual(score, resolution.Score);
+            Assert.Equal(value, resolution.Value);
+            Assert.Equal(index, resolution.Index);
+            Assert.Equal(score, resolution.Score);
             if (synonym != null)
             {
-                Assert.AreEqual(synonym, resolution.Synonym);
+                Assert.Equal(synonym, resolution.Synonym);
             }
         }
     }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicesTokenizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicesTokenizerTests.cs
@@ -2,76 +2,75 @@
 // Licensed under the MIT License.
 
 using Microsoft.Bot.Builder.Dialogs.Choices;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Tests
 {
-    [TestClass]
-    [TestCategory("Prompts")]
-    [TestCategory("Choice Tests")]
+    [Trait("TestCategory", "Prompts")]
+    [Trait("TestCategory", "Choice Tests")]
     public class ChoicesTokenizerTests
     {
-        [TestMethod]
+        [Fact]
         public void ShouldBreakOnSpaces()
         {
             var tokens = Tokenizer.DefaultTokenizer("how now brown cow");
-            Assert.AreEqual(4, tokens.Count);
+            Assert.Equal(4, tokens.Count);
             AssertToken(tokens[0], 0, 2, "how");
             AssertToken(tokens[1], 4, 6, "now");
             AssertToken(tokens[2], 8, 12, "brown");
             AssertToken(tokens[3], 14, 16, "cow");
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldBreakOnPunctuation()
         {
             var tokens = Tokenizer.DefaultTokenizer("how-now.brown:cow ?");
-            Assert.AreEqual(4, tokens.Count);
+            Assert.Equal(4, tokens.Count);
             AssertToken(tokens[0], 0, 2, "how");
             AssertToken(tokens[1], 4, 6, "now");
             AssertToken(tokens[2], 8, 12, "brown");
             AssertToken(tokens[3], 14, 16, "cow");
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldTokenizeSingleCharacterTokens()
         {
             var tokens = Tokenizer.DefaultTokenizer("a b c d");
-            Assert.AreEqual(4, tokens.Count);
+            Assert.Equal(4, tokens.Count);
             AssertToken(tokens[0], 0, 0, "a");
             AssertToken(tokens[1], 2, 2, "b");
             AssertToken(tokens[2], 4, 4, "c");
             AssertToken(tokens[3], 6, 6, "d");
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldReturnASingleToken()
         {
             var tokens = Tokenizer.DefaultTokenizer("food");
-            Assert.AreEqual(1, tokens.Count);
+            Assert.Single(tokens);
             AssertToken(tokens[0], 0, 3, "food");
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldReturnNoTokens()
         {
             var tokens = Tokenizer.DefaultTokenizer(".?; -()");
-            Assert.AreEqual(0, tokens.Count);
+            Assert.Empty(tokens);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldReturnTheNormalizedAndOriginalTextForAToken()
         {
             var tokens = Tokenizer.DefaultTokenizer("fOoD");
-            Assert.AreEqual(1, tokens.Count);
+            Assert.Single(tokens);
             AssertToken(tokens[0], 0, 3, "fOoD", "food");
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldBreakOnEmojis()
         {
             var tokens = Tokenizer.DefaultTokenizer("food 💥👍😀");
-            Assert.AreEqual(4, tokens.Count);
+            Assert.Equal(4, tokens.Count);
             AssertToken(tokens[0], 0, 3, "food");
             AssertToken(tokens[1], 5, 6, "💥");
             AssertToken(tokens[2], 7, 8, "👍");
@@ -80,10 +79,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
         private static void AssertToken(Token token, int start, int end, string text, string normalized = null)
         {
-            Assert.AreEqual(start, token.Start);
-            Assert.AreEqual(end, token.End);
-            Assert.AreEqual(text, token.Text);
-            Assert.AreEqual(normalized ?? text, token.Normalized);
+            Assert.Equal(start, token.Start);
+            Assert.Equal(end, token.End);
+            Assert.Equal(text, token.Text);
+            Assert.Equal(normalized ?? text, token.Normalized);
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/Microsoft.Bot.Builder.Dialogs.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/Microsoft.Bot.Builder.Dialogs.Tests.csproj
@@ -22,6 +22,11 @@
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes # 4096

## Description
This PR migrates **the following test files** inside the [Microsoft.Bot.Builder.Dialogs.Tests](https://github.com/microsoft/botbuilder-dotnet/tree/main/tests/Microsoft.Bot.Builder.Dialogs.Tests) folder from **MSTest** to **xUnit**.
- ActivityPromptTests.cs
- AttachmentPromptTests.cs
- ChoiceFactoryTests.cs
- ChoicePromptTests.cs
- ChoicesChannelTests.cs
- ChoicesRecognizersTests.cs
- ChoicesTokenizerTests.cs

## Specific Changes
- Added `xUnit` packages to `.csproj`.
- Changed `[TestMethod]` to `[Fact]`.
- Changed `[TestCategory]` to `[Trait]`.
- Changed `[ExpectedException]` to `Assert.Throws`.
- Changed `Assert.AreEqual` to `Assert.Equal`.
- Changed `Assert.IsNotNull` to `Assert.NotNull`.
- Changed `Assert.IsNull` to `Assert.Null`.
- Changed `Assert.IsTrue` to `Assert.True`.
- Changed ` Assert.IsInstanceOfType` to `Assert.IsAssignableFrom`.
- Improved tests Assertions.

## Testing
In the following image there are the passing tests.
![image](https://user-images.githubusercontent.com/62260472/92512500-3e1b4200-f1e5-11ea-9c63-01072f692f3f.png)