### PR TITLE
Migrate Microsoft.Bot.Builder.Azure.Tests project to xUnit

### DIFF
--- a/tests/Microsoft.Bot.Builder.Azure.Tests/AzureQueueTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/AzureQueueTests.cs
@@ -10,17 +10,14 @@ using Microsoft.Bot.Builder.Azure.Queues;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Tests;
 using Microsoft.Bot.Schema;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Azure.Tests
 {
-    [TestClass]
     public class AzureQueueTests : StorageBaseTests
     {
         private const string ConnectionString = @"UseDevelopmentStorage=true";
-
-        public TestContext TestContext { get; set; }
 
         // These tests require Azure Storage Emulator v5.7
         public async Task<QueueClient> ContainerInit(string name)
@@ -31,7 +28,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             return queue;
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ContinueConversationLaterTests()
         {
             if (StorageEmulatorHelper.CheckEmulator())
@@ -58,14 +55,14 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 var message = messages.Value[0];
                 var messageJson = Encoding.UTF8.GetString(Convert.FromBase64String(message.MessageText));
                 var activity = JsonConvert.DeserializeObject<Activity>(messageJson);
-                Assert.AreEqual(ActivityTypes.Event, activity.Type);
-                Assert.AreEqual("ContinueConversation", activity.Name);
-                Assert.AreEqual("foo", activity.Value);
-                Assert.IsNotNull(activity.RelatesTo);
+                Assert.Equal(ActivityTypes.Event, activity.Type);
+                Assert.Equal("ContinueConversation", activity.Name);
+                Assert.Equal("foo", activity.Value);
+                Assert.NotNull(activity.RelatesTo);
                 var cr2 = activity.GetConversationReference();
                 cr.ActivityId = null;
                 cr2.ActivityId = null;
-                Assert.AreEqual(JsonConvert.SerializeObject(cr), JsonConvert.SerializeObject(cr2));
+                Assert.Equal(JsonConvert.SerializeObject(cr), JsonConvert.SerializeObject(cr2));
             }
         }
     }

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDBKeyEscapeTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDBKeyEscapeTests.cs
@@ -2,99 +2,98 @@
 // Licensed under the MIT License.
 
 using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Azure.Tests
 {
-    [TestClass]
-    [TestCategory("Storage")]
-    [TestCategory("Storage - CosmosDB")]
+    [Trait("TestCategory", "Storage")]
+    [Trait("TestCategory", "Storage - CosmosDB")]
     public class CosmosDBKeyEscapeTests
     {
-        [TestMethod]
+        [Fact]
         public void Sanitize_Key_Should_Fail_With_Null_Key()
         {
             // Null key should throw
-            Assert.ThrowsException<ArgumentNullException>(() => CosmosDbKeyEscape.EscapeKey(null));
+            Assert.Throws<ArgumentNullException>(() => CosmosDbKeyEscape.EscapeKey(null));
 
             // Empty string should throw
-            Assert.ThrowsException<ArgumentNullException>(() => CosmosDbKeyEscape.EscapeKey(string.Empty));
+            Assert.Throws<ArgumentNullException>(() => CosmosDbKeyEscape.EscapeKey(string.Empty));
 
             // Whitespace key should throw
-            Assert.ThrowsException<ArgumentNullException>(() => CosmosDbKeyEscape.EscapeKey("     "));
+            Assert.Throws<ArgumentNullException>(() => CosmosDbKeyEscape.EscapeKey("     "));
         }
 
-        [TestMethod]
+        [Fact]
         public void Sanitize_Key_Should_Not_Change_A_Valid_Key()
         {
-            var validKey = "Abc12345";
+            const string validKey = "Abc12345";
             var sanitizedKey = CosmosDbKeyEscape.EscapeKey(validKey);
-            Assert.AreEqual(validKey, sanitizedKey);
+            Assert.Equal(validKey, sanitizedKey);
         }
 
-        [TestMethod]
+        [Fact]
         public void Long_Key_Should_Be_Truncated()
         {
             var tooLongKey = new string('a', CosmosDbKeyEscape.MaxKeyLength + 1);
 
             var sanitizedKey = CosmosDbKeyEscape.EscapeKey(tooLongKey);
-            Assert.IsTrue(sanitizedKey.Length <= CosmosDbKeyEscape.MaxKeyLength, "Key too long");
+            Assert.True(sanitizedKey.Length <= CosmosDbKeyEscape.MaxKeyLength, "Key too long");
 
             // The resulting key should be:
             var hash = tooLongKey.GetHashCode().ToString("x");
             var correctKey = sanitizedKey.Substring(0, CosmosDbKeyEscape.MaxKeyLength - hash.Length) + hash;
 
-            Assert.AreEqual(correctKey, sanitizedKey);
+            Assert.Equal(correctKey, sanitizedKey);
         }
 
-        [TestMethod]
+        [Fact]
         public void Long_Key_With_Illegal_Characters_Should_Be_Truncated()
         {
             var tooLongKeyWithIllegalCharacters = "?test?" + new string('A', 1000);
             var sanitizedKey = CosmosDbKeyEscape.EscapeKey(tooLongKeyWithIllegalCharacters);
 
             // Verify the key ws truncated
-            Assert.IsTrue(sanitizedKey.Length <= CosmosDbKeyEscape.MaxKeyLength, "Key too long");
+            Assert.True(sanitizedKey.Length <= CosmosDbKeyEscape.MaxKeyLength, "Key too long");
 
             // Make sure the escaping still happened
-            Assert.IsTrue(sanitizedKey.StartsWith("*3ftest*3f"));
+            Assert.StartsWith("*3ftest*3f", sanitizedKey);
         }
 
-        [TestMethod]
+        [Fact]
         public void Sanitize_Key_Should_Escape_Illegal_Character()
         {
             // Ascii code of "?" is "3f".
             var sanitizedKey = CosmosDbKeyEscape.EscapeKey("?test?");
-            Assert.AreEqual(sanitizedKey, "*3ftest*3f");
+            Assert.Equal("*3ftest*3f", sanitizedKey);
 
             // Ascii code of "/" is "2f".
             var sanitizedKey2 = CosmosDbKeyEscape.EscapeKey("/test/");
-            Assert.AreEqual(sanitizedKey2, "*2ftest*2f");
+            Assert.Equal("*2ftest*2f", sanitizedKey2);
 
             // Ascii code of "\" is "5c".
             var sanitizedKey3 = CosmosDbKeyEscape.EscapeKey("\\test\\");
-            Assert.AreEqual(sanitizedKey3, "*5ctest*5c");
+            Assert.Equal("*5ctest*5c", sanitizedKey3);
 
             // Ascii code of "#" is "23".
             var sanitizedKey4 = CosmosDbKeyEscape.EscapeKey("#test#");
-            Assert.AreEqual(sanitizedKey4, "*23test*23");
+            Assert.Equal("*23test*23", sanitizedKey4);
 
             // Ascii code of "*" is "2a".
             var sanitizedKey5 = CosmosDbKeyEscape.EscapeKey("*test*");
-            Assert.AreEqual(sanitizedKey5, "*2atest*2a");
+            Assert.Equal("*2atest*2a", sanitizedKey5);
 
             // Check a compound key
             var compoundSanitizedKey = CosmosDbKeyEscape.EscapeKey("?#/");
-            Assert.AreEqual(compoundSanitizedKey, "*3f*23*2f");
+            Assert.Equal("*3f*23*2f", compoundSanitizedKey);
         }
 
-        [TestMethod]
+        [Fact]
         public void Collisions_Should_Not_Happen()
         {
-            var validKey = "*2atest*2a";
-            var validKey2 = "*test*";
+            const string validKey = "*2atest*2a";
+            const string validKey2 = "*test*";
 
-            // If we failed to esacpe the "*", then validKey2 would
+            // If we failed to escape the "*", then validKey2 would
             // escape to the same value as validKey. To prevent this
             // we makes sure to escape the *.
 
@@ -102,43 +101,43 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             var escaped1 = CosmosDbKeyEscape.EscapeKey(validKey);
             var escaped2 = CosmosDbKeyEscape.EscapeKey(validKey2);
 
-            Assert.AreNotEqual(escaped1, escaped2);
+            Assert.NotEqual(escaped1, escaped2);
         }
 
-        [TestMethod]
+        [Fact]
         public void Long_Key_Should_Not_Be_Truncated_With_False_CompatibilityMode()
         {
             var tooLongKey = new string('a', CosmosDbKeyEscape.MaxKeyLength + 1);
 
             var sanitizedKey = CosmosDbKeyEscape.EscapeKey(tooLongKey, string.Empty, false);
-            Assert.AreEqual(CosmosDbKeyEscape.MaxKeyLength + 1, sanitizedKey.Length, "Key should not have been truncated");
+            Assert.Equal(CosmosDbKeyEscape.MaxKeyLength + 1, sanitizedKey.Length);
 
             // The resulting key should be identical
-            Assert.AreEqual(tooLongKey, sanitizedKey);
+            Assert.Equal(tooLongKey, sanitizedKey);
         }
 
-        [TestMethod]
+        [Fact]
         public void Long_Key_With_Illegal_Characters_Should_Not_Be_Truncated_With_False_CompatibilityMode()
         {
             var longKeyWithIllegalCharacters = "?test?" + new string('A', 1000);
             var sanitizedKey = CosmosDbKeyEscape.EscapeKey(longKeyWithIllegalCharacters, string.Empty, false);
 
             // Verify the key was NOT truncated
-            Assert.AreEqual(1010, sanitizedKey.Length, "Key should not have been truncated");
+            Assert.Equal(1010, sanitizedKey.Length);
 
             // Make sure the escaping still happened
-            Assert.IsTrue(sanitizedKey.StartsWith("*3ftest*3f"));
+            Assert.StartsWith("*3ftest*3f", sanitizedKey);
         }
 
-        [TestMethod]
+        [Fact]
         public void KeySuffix_Is_Added_To_End_of_Key()
         {
-            var suffix = "test suffix";
-            var key = "this is a test";
+            const string suffix = "test suffix";
+            const string key = "this is a test";
             var sanitizedKey = CosmosDbKeyEscape.EscapeKey(key, suffix, false);
 
             // Verify the suffix was added to the end of the key
-            Assert.AreEqual(sanitizedKey, $"{key}{suffix}", "Suffix was not added to end of key");
+            Assert.Equal(sanitizedKey, $"{key}{suffix}");
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/Microsoft.Bot.Builder.Azure.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/Microsoft.Bot.Builder.Azure.Tests.csproj
@@ -12,6 +12,11 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes# 4090

## Description
This PR migrates some of the [Microsoft.Bot.Builder.Azure.Tests](https://github.com/microsoft/botbuilder-dotnet/tree/main/tests/Microsoft.Bot.Builder.Azure.Tests) tests from **MSTest** to **xUnit**.

## Detailed Changes
- Added Xunit packages to the .csproj.
- Replaced `[TestMethod]` with `[Fact]`.
- Replaced `[TestCategory]` with `[Trait]`
- Changed Asserts.
- Removed unused `TestContext`.
- Used constants instead of variables where applicable.
- Used `var` instead of the specific type.

The rest of the files couldn't be migrated as they use MSTests' `TestContext` in `ContainerName` through several classes and there's no equivalent in Xunit for this feature.

## Testing
The following image shows the tests passing after the changes.
![image](https://user-images.githubusercontent.com/44245136/92520097-74f75500-f1f1-11ea-888a-b2f0817909f2.png)
