### PR TITLE
Migrate Microsoft.Bot.Builder.Azure.Tests project to xUnit

### DIFF
--- a/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobTranscriptStoreTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobTranscriptStoreTests.cs
@@ -2,47 +2,48 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Reflection;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
 
 // These tests require Azure Storage Emulator v5.7
 // The emulator must be installed at this path C:\Program Files (x86)\Microsoft SDKs\Azure\Storage Emulator\AzureStorageEmulator.exe
 // More info: https://docs.microsoft.com/azure/storage/common/storage-use-emulator
 namespace Microsoft.Bot.Builder.Azure.Tests
 {
-    [TestClass]
-    [TestCategory("Storage")]
-    [TestCategory("Storage - BlobTranscripts")]
-    public class AzureBlobTranscriptStoreTests : TranscriptStoreBaseTests
+    [Trait("TestCategory", "Storage")]
+    [Trait("TestCategory", "Storage - BlobTranscripts")]
+    public class AzureBlobTranscriptStoreTests : TranscriptStoreBaseTests, IDisposable
     {
-        public TestContext TestContext { get; set; }
+        private readonly string _testName;
 
-        protected override string ContainerName
+        public AzureBlobTranscriptStoreTests(ITestOutputHelper testOutputHelper)
         {
-            get { return $"blobtranscript{TestContext.TestName.ToLower()}"; }
-        }
+            var helper = (TestOutputHelper)testOutputHelper;
 
-        protected override ITranscriptStore TranscriptStore
-        {
-            get { return new AzureBlobTranscriptStore(BlobStorageEmulatorConnectionString, ContainerName); }
-        }
+            var test = (ITest)helper.GetType().GetField("test", BindingFlags.NonPublic | BindingFlags.Instance)
+                .GetValue(helper);
 
-        [TestInitialize]
-        public async Task Init()
-        {
+            _testName = test.TestCase.TestMethod.Method.Name;
+
             if (StorageEmulatorHelper.CheckEmulator())
             {
-                await CloudStorageAccount.Parse(BlobStorageEmulatorConnectionString)
+                CloudStorageAccount.Parse(BlobStorageEmulatorConnectionString)
                     .CreateCloudBlobClient()
                     .GetContainerReference(ContainerName)
                     .DeleteIfExistsAsync().ConfigureAwait(false);
             }
         }
 
-        [TestCleanup]
-        public async Task Cleanup()
+        protected override string ContainerName => $"blobtranscript{_testName.ToLower()}";
+
+        protected override ITranscriptStore TranscriptStore => new AzureBlobTranscriptStore(BlobStorageEmulatorConnectionString, ContainerName);
+
+        public async void Dispose()
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {
@@ -54,7 +55,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         // These tests require Azure Storage Emulator v5.7
-        [TestMethod]
+        [Fact]
         public async Task LongIdAddTest()
         {
             if (StorageEmulatorHelper.CheckEmulator())
@@ -64,35 +65,34 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                     var a = CreateActivity(0, 0, LongId);
 
                     await TranscriptStore.LogActivityAsync(a);
-                    Assert.Fail("Should have thrown ");
+                    
+                    throw new XunitException("Should have thrown ");
                 }
                 catch (StorageException)
                 {
                     return;
                 }
-
-                Assert.Fail("Should have thrown ");
             }
         }
 
         // These tests require Azure Storage Emulator v5.7
-        [TestMethod]
+        [Fact]
         public void BlobTranscriptParamTest()
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {
-                Assert.ThrowsException<FormatException>(() => new AzureBlobTranscriptStore("123", ContainerName));
+                Assert.Throws<FormatException>(() => new AzureBlobTranscriptStore("123", ContainerName));
 
-                Assert.ThrowsException<ArgumentNullException>(() =>
+                Assert.Throws<ArgumentNullException>(() =>
                     new AzureBlobTranscriptStore((CloudStorageAccount)null, ContainerName));
 
-                Assert.ThrowsException<ArgumentNullException>(() =>
+                Assert.Throws<ArgumentNullException>(() =>
                     new AzureBlobTranscriptStore((string)null, ContainerName));
 
-                Assert.ThrowsException<ArgumentNullException>(() =>
+                Assert.Throws<ArgumentNullException>(() =>
                     new AzureBlobTranscriptStore((CloudStorageAccount)null, null));
 
-                Assert.ThrowsException<ArgumentNullException>(() => new AzureBlobTranscriptStore((string)null, null));
+                Assert.Throws<ArgumentNullException>(() => new AzureBlobTranscriptStore((string)null, null));
             }
         }
     }

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobTranscriptStoreTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobTranscriptStoreTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 
                     await TranscriptStore.LogActivityAsync(a);
                     
-                    throw new XunitException("Should have thrown ");
+                    throw new XunitException("Should have thrown an error");
                 }
                 catch (StorageException)
                 {

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/AzureQueueTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/AzureQueueTests.cs
@@ -10,17 +10,14 @@ using Microsoft.Bot.Builder.Azure.Queues;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Tests;
 using Microsoft.Bot.Schema;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Azure.Tests
 {
-    [TestClass]
     public class AzureQueueTests : StorageBaseTests
     {
         private const string ConnectionString = @"UseDevelopmentStorage=true";
-
-        public TestContext TestContext { get; set; }
 
         // These tests require Azure Storage Emulator v5.7
         public async Task<QueueClient> ContainerInit(string name)
@@ -31,7 +28,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             return queue;
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ContinueConversationLaterTests()
         {
             if (StorageEmulatorHelper.CheckEmulator())
@@ -58,14 +55,14 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 var message = messages.Value[0];
                 var messageJson = Encoding.UTF8.GetString(Convert.FromBase64String(message.MessageText));
                 var activity = JsonConvert.DeserializeObject<Activity>(messageJson);
-                Assert.AreEqual(ActivityTypes.Event, activity.Type);
-                Assert.AreEqual("ContinueConversation", activity.Name);
-                Assert.AreEqual("foo", activity.Value);
-                Assert.IsNotNull(activity.RelatesTo);
+                Assert.Equal(ActivityTypes.Event, activity.Type);
+                Assert.Equal("ContinueConversation", activity.Name);
+                Assert.Equal("foo", activity.Value);
+                Assert.NotNull(activity.RelatesTo);
                 var cr2 = activity.GetConversationReference();
                 cr.ActivityId = null;
                 cr2.ActivityId = null;
-                Assert.AreEqual(JsonConvert.SerializeObject(cr), JsonConvert.SerializeObject(cr2));
+                Assert.Equal(JsonConvert.SerializeObject(cr), JsonConvert.SerializeObject(cr2));
             }
         }
     }

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/BlobStorageBaseTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/BlobStorageBaseTests.cs
@@ -7,7 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Tests;
 using Microsoft.Bot.Schema;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 // These tests require Azure Storage Emulator v5.7
 // The emulator must be installed at this path C:\Program Files (x86)\Microsoft SDKs\Azure\Storage Emulator\AzureStorageEmulator.exe
@@ -23,7 +23,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 
         protected abstract string ContainerName { get; }
 
-        [TestMethod]
+        [Fact]
         public async Task TestBlobStorageWriteRead()
         {
             if (StorageEmulatorHelper.CheckEmulator())
@@ -42,13 +42,13 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 var result = await storage.ReadAsync(new[] { "x", "y" });
 
                 // Assert
-                Assert.AreEqual(2, result.Count);
-                Assert.AreEqual("hello", result["x"]);
-                Assert.AreEqual("world", result["y"]);
+                Assert.Equal(2, result.Count);
+                Assert.Equal("hello", result["x"]);
+                Assert.Equal("world", result["y"]);
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestBlobStorageWriteDeleteRead()
         {
             if (StorageEmulatorHelper.CheckEmulator())
@@ -68,12 +68,12 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 var result = await storage.ReadAsync(new[] { "x", "y" });
 
                 // Assert
-                Assert.AreEqual(1, result.Count);
-                Assert.AreEqual("world", result["y"]);
+                Assert.Equal(1, result.Count);
+                Assert.Equal("world", result["y"]);
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestBlobStorageChanges()
         {
             if (StorageEmulatorHelper.CheckEmulator())
@@ -89,13 +89,13 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 var result = await storage.ReadAsync(new[] { "a", "b", "c", "d", "e" });
 
                 // Assert
-                Assert.AreEqual(2, result.Count);
-                Assert.AreEqual("1.1", result["a"]);
-                Assert.AreEqual("3.0", result["c"]);
+                Assert.Equal(2, result.Count);
+                Assert.Equal("1.1", result["a"]);
+                Assert.Equal("3.0", result["c"]);
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestConversationStateBlobStorage()
         {
             if (StorageEmulatorHelper.CheckEmulator())
@@ -123,15 +123,15 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 var propValue2 = await propAccessor.GetAsync(turnContext2);
 
                 // Assert
-                Assert.AreEqual("hello", propValue2.X);
-                Assert.AreEqual("world", propValue2.Y);
+                Assert.Equal("hello", propValue2.X);
+                Assert.Equal("world", propValue2.Y);
 
                 await propAccessor.DeleteAsync(turnContext1);
                 await conversationState.SaveChangesAsync(turnContext1);
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestConversationStateBlobStorage_TypeNameHandlingDefault()
         {
             if (StorageEmulatorHelper.CheckEmulator())
@@ -140,7 +140,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestConversationStateBlobStorage_TypeNameHandlingNone()
         {
             if (StorageEmulatorHelper.CheckEmulator())
@@ -149,7 +149,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task StatePersistsThroughMultiTurn_TypeNameHandlingNone()
         {
             if (StorageEmulatorHelper.CheckEmulator())
@@ -185,8 +185,8 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 var propValue2 = await propAccessor.GetAsync(turnContext2);
 
                 // Assert
-                Assert.AreEqual("hello", propValue2.X);
-                Assert.AreEqual("world", propValue2.Y);
+                Assert.Equal("hello", propValue2.X);
+                Assert.Equal("world", propValue2.Y);
             }
         }
 

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/BlobsTranscriptStoreTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/BlobsTranscriptStoreTests.cs
@@ -2,45 +2,46 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Reflection;
 using System.Threading.Tasks;
 using Azure.Storage.Blobs;
 using Microsoft.Bot.Builder.Azure.Blobs;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
 
 // These tests require Azure Storage Emulator v5.7
 // The emulator must be installed at this path C:\Program Files (x86)\Microsoft SDKs\Azure\Storage Emulator\AzureStorageEmulator.exe
 // More info: https://docs.microsoft.com/azure/storage/common/storage-use-emulator
 namespace Microsoft.Bot.Builder.Azure.Tests
 {
-    [TestClass]
-    [TestCategory("Storage")]
-    [TestCategory("Storage - BlobsTranscriptStore")]
-    public class BlobsTranscriptStoreTests : TranscriptStoreBaseTests
+    [Trait("TestCategory", "Storage")]
+    [Trait("TestCategory", "Storage - BlobsTranscriptStore")]
+    public class BlobsTranscriptStoreTests : TranscriptStoreBaseTests, IDisposable
     {
-        public TestContext TestContext { get; set; }
+        private readonly string _testName;
 
-        protected override string ContainerName
+        public BlobsTranscriptStoreTests(ITestOutputHelper testOutputHelper)
         {
-            get { return $"blobstranscript{TestContext.TestName.ToLower()}"; }
-        }
+            var helper = (TestOutputHelper)testOutputHelper;
 
-        protected override ITranscriptStore TranscriptStore
-        {
-            get { return new BlobsTranscriptStore(BlobStorageEmulatorConnectionString, ContainerName); }
-        }
+            var test = (ITest)helper.GetType().GetField("test", BindingFlags.NonPublic | BindingFlags.Instance)
+                .GetValue(helper);
 
-        [TestInitialize]
-        public async Task Init()
-        {
+            _testName = test.TestCase.TestMethod.Method.Name;
+
             if (StorageEmulatorHelper.CheckEmulator())
             {
-                await new BlobContainerClient(BlobStorageEmulatorConnectionString, ContainerName)
+                new BlobContainerClient(BlobStorageEmulatorConnectionString, ContainerName)
                     .DeleteIfExistsAsync().ConfigureAwait(false);
             }
         }
 
-        [TestCleanup]
-        public async Task Cleanup()
+        protected override string ContainerName => $"blobstranscript{_testName.ToLower()}";
+
+        protected override ITranscriptStore TranscriptStore => new BlobsTranscriptStore(BlobStorageEmulatorConnectionString, ContainerName);
+
+        public async void Dispose()
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {
@@ -50,7 +51,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         // These tests require Azure Storage Emulator v5.7
-        [TestMethod]
+        [Fact]
         public async Task LongIdAddTest()
         {
             if (StorageEmulatorHelper.CheckEmulator())
@@ -60,7 +61,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                     var a = CreateActivity(0, 0, LongId);
 
                     await TranscriptStore.LogActivityAsync(a);
-                    Assert.Fail("Should have thrown ");
+                    throw new XunitException("Should have thrown ");
                 }
                 catch (System.Xml.XmlException xmlEx)
                 {
@@ -71,26 +72,26 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                     }
                 }
 
-                Assert.Fail("Should have thrown ");
+                throw new XunitException("Should have thrown ");
             }
         }
 
         // These tests require Azure Storage Emulator v5.7
-        [TestMethod]
+        [Fact]
         public void BlobTranscriptParamTest()
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {
-                Assert.ThrowsException<ArgumentNullException>(() =>
+                Assert.Throws<ArgumentNullException>(() =>
                     new BlobsTranscriptStore(null, ContainerName));
 
-                Assert.ThrowsException<ArgumentNullException>(() =>
+                Assert.Throws<ArgumentNullException>(() =>
                     new BlobsTranscriptStore(BlobStorageEmulatorConnectionString, null));
 
-                Assert.ThrowsException<ArgumentNullException>(() =>
+                Assert.Throws<ArgumentNullException>(() =>
                     new BlobsTranscriptStore(string.Empty, ContainerName));
 
-                Assert.ThrowsException<ArgumentNullException>(() =>
+                Assert.Throws<ArgumentNullException>(() =>
                     new BlobsTranscriptStore(BlobStorageEmulatorConnectionString, string.Empty));
             }
         }

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/BlobsTranscriptStoreTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/BlobsTranscriptStoreTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                     var a = CreateActivity(0, 0, LongId);
 
                     await TranscriptStore.LogActivityAsync(a);
-                    throw new XunitException("Should have thrown ");
+                    throw new XunitException("Should have thrown an error");
                 }
                 catch (System.Xml.XmlException xmlEx)
                 {
@@ -72,7 +72,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                     }
                 }
 
-                throw new XunitException("Should have thrown ");
+                throw new XunitException("Should have thrown an error");
             }
         }
 

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDBKeyEscapeTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDBKeyEscapeTests.cs
@@ -2,99 +2,98 @@
 // Licensed under the MIT License.
 
 using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Azure.Tests
 {
-    [TestClass]
-    [TestCategory("Storage")]
-    [TestCategory("Storage - CosmosDB")]
+    [Trait("TestCategory", "Storage")]
+    [Trait("TestCategory", "Storage - CosmosDB")]
     public class CosmosDBKeyEscapeTests
     {
-        [TestMethod]
+        [Fact]
         public void Sanitize_Key_Should_Fail_With_Null_Key()
         {
             // Null key should throw
-            Assert.ThrowsException<ArgumentNullException>(() => CosmosDbKeyEscape.EscapeKey(null));
+            Assert.Throws<ArgumentNullException>(() => CosmosDbKeyEscape.EscapeKey(null));
 
             // Empty string should throw
-            Assert.ThrowsException<ArgumentNullException>(() => CosmosDbKeyEscape.EscapeKey(string.Empty));
+            Assert.Throws<ArgumentNullException>(() => CosmosDbKeyEscape.EscapeKey(string.Empty));
 
             // Whitespace key should throw
-            Assert.ThrowsException<ArgumentNullException>(() => CosmosDbKeyEscape.EscapeKey("     "));
+            Assert.Throws<ArgumentNullException>(() => CosmosDbKeyEscape.EscapeKey("     "));
         }
 
-        [TestMethod]
+        [Fact]
         public void Sanitize_Key_Should_Not_Change_A_Valid_Key()
         {
-            var validKey = "Abc12345";
+            const string validKey = "Abc12345";
             var sanitizedKey = CosmosDbKeyEscape.EscapeKey(validKey);
-            Assert.AreEqual(validKey, sanitizedKey);
+            Assert.Equal(validKey, sanitizedKey);
         }
 
-        [TestMethod]
+        [Fact]
         public void Long_Key_Should_Be_Truncated()
         {
             var tooLongKey = new string('a', CosmosDbKeyEscape.MaxKeyLength + 1);
 
             var sanitizedKey = CosmosDbKeyEscape.EscapeKey(tooLongKey);
-            Assert.IsTrue(sanitizedKey.Length <= CosmosDbKeyEscape.MaxKeyLength, "Key too long");
+            Assert.True(sanitizedKey.Length <= CosmosDbKeyEscape.MaxKeyLength, "Key too long");
 
             // The resulting key should be:
             var hash = tooLongKey.GetHashCode().ToString("x");
             var correctKey = sanitizedKey.Substring(0, CosmosDbKeyEscape.MaxKeyLength - hash.Length) + hash;
 
-            Assert.AreEqual(correctKey, sanitizedKey);
+            Assert.Equal(correctKey, sanitizedKey);
         }
 
-        [TestMethod]
+        [Fact]
         public void Long_Key_With_Illegal_Characters_Should_Be_Truncated()
         {
             var tooLongKeyWithIllegalCharacters = "?test?" + new string('A', 1000);
             var sanitizedKey = CosmosDbKeyEscape.EscapeKey(tooLongKeyWithIllegalCharacters);
 
             // Verify the key ws truncated
-            Assert.IsTrue(sanitizedKey.Length <= CosmosDbKeyEscape.MaxKeyLength, "Key too long");
+            Assert.True(sanitizedKey.Length <= CosmosDbKeyEscape.MaxKeyLength, "Key too long");
 
             // Make sure the escaping still happened
-            Assert.IsTrue(sanitizedKey.StartsWith("*3ftest*3f"));
+            Assert.StartsWith("*3ftest*3f", sanitizedKey);
         }
 
-        [TestMethod]
+        [Fact]
         public void Sanitize_Key_Should_Escape_Illegal_Character()
         {
             // Ascii code of "?" is "3f".
             var sanitizedKey = CosmosDbKeyEscape.EscapeKey("?test?");
-            Assert.AreEqual(sanitizedKey, "*3ftest*3f");
+            Assert.Equal("*3ftest*3f", sanitizedKey);
 
             // Ascii code of "/" is "2f".
             var sanitizedKey2 = CosmosDbKeyEscape.EscapeKey("/test/");
-            Assert.AreEqual(sanitizedKey2, "*2ftest*2f");
+            Assert.Equal("*2ftest*2f", sanitizedKey2);
 
             // Ascii code of "\" is "5c".
             var sanitizedKey3 = CosmosDbKeyEscape.EscapeKey("\\test\\");
-            Assert.AreEqual(sanitizedKey3, "*5ctest*5c");
+            Assert.Equal("*5ctest*5c", sanitizedKey3);
 
             // Ascii code of "#" is "23".
             var sanitizedKey4 = CosmosDbKeyEscape.EscapeKey("#test#");
-            Assert.AreEqual(sanitizedKey4, "*23test*23");
+            Assert.Equal("*23test*23", sanitizedKey4);
 
             // Ascii code of "*" is "2a".
             var sanitizedKey5 = CosmosDbKeyEscape.EscapeKey("*test*");
-            Assert.AreEqual(sanitizedKey5, "*2atest*2a");
+            Assert.Equal("*2atest*2a", sanitizedKey5);
 
             // Check a compound key
             var compoundSanitizedKey = CosmosDbKeyEscape.EscapeKey("?#/");
-            Assert.AreEqual(compoundSanitizedKey, "*3f*23*2f");
+            Assert.Equal("*3f*23*2f", compoundSanitizedKey);
         }
 
-        [TestMethod]
+        [Fact]
         public void Collisions_Should_Not_Happen()
         {
-            var validKey = "*2atest*2a";
-            var validKey2 = "*test*";
+            const string validKey = "*2atest*2a";
+            const string validKey2 = "*test*";
 
-            // If we failed to esacpe the "*", then validKey2 would
+            // If we failed to escape the "*", then validKey2 would
             // escape to the same value as validKey. To prevent this
             // we makes sure to escape the *.
 
@@ -102,43 +101,43 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             var escaped1 = CosmosDbKeyEscape.EscapeKey(validKey);
             var escaped2 = CosmosDbKeyEscape.EscapeKey(validKey2);
 
-            Assert.AreNotEqual(escaped1, escaped2);
+            Assert.NotEqual(escaped1, escaped2);
         }
 
-        [TestMethod]
+        [Fact]
         public void Long_Key_Should_Not_Be_Truncated_With_False_CompatibilityMode()
         {
             var tooLongKey = new string('a', CosmosDbKeyEscape.MaxKeyLength + 1);
 
             var sanitizedKey = CosmosDbKeyEscape.EscapeKey(tooLongKey, string.Empty, false);
-            Assert.AreEqual(CosmosDbKeyEscape.MaxKeyLength + 1, sanitizedKey.Length, "Key should not have been truncated");
+            Assert.Equal(CosmosDbKeyEscape.MaxKeyLength + 1, sanitizedKey.Length);
 
             // The resulting key should be identical
-            Assert.AreEqual(tooLongKey, sanitizedKey);
+            Assert.Equal(tooLongKey, sanitizedKey);
         }
 
-        [TestMethod]
+        [Fact]
         public void Long_Key_With_Illegal_Characters_Should_Not_Be_Truncated_With_False_CompatibilityMode()
         {
             var longKeyWithIllegalCharacters = "?test?" + new string('A', 1000);
             var sanitizedKey = CosmosDbKeyEscape.EscapeKey(longKeyWithIllegalCharacters, string.Empty, false);
 
             // Verify the key was NOT truncated
-            Assert.AreEqual(1010, sanitizedKey.Length, "Key should not have been truncated");
+            Assert.Equal(1010, sanitizedKey.Length);
 
             // Make sure the escaping still happened
-            Assert.IsTrue(sanitizedKey.StartsWith("*3ftest*3f"));
+            Assert.StartsWith("*3ftest*3f", sanitizedKey);
         }
 
-        [TestMethod]
+        [Fact]
         public void KeySuffix_Is_Added_To_End_of_Key()
         {
-            var suffix = "test suffix";
-            var key = "this is a test";
+            const string suffix = "test suffix";
+            const string key = "this is a test";
             var sanitizedKey = CosmosDbKeyEscape.EscapeKey(key, suffix, false);
 
             // Verify the suffix was added to the end of the key
-            Assert.AreEqual(sanitizedKey, $"{key}{suffix}", "Suffix was not added to end of key");
+            Assert.Equal(sanitizedKey, $"{key}{suffix}");
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbPartitionStorageFixture.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbPartitionStorageFixture.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using Microsoft.Azure.Cosmos;
+
+namespace Microsoft.Bot.Builder.Azure.Tests
+{
+    public class CosmosDbPartitionStorageFixture : IDisposable
+    {
+        private const string CosmosServiceEndpoint = "https://localhost:8081";
+        private const string CosmosAuthKey = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+        private const string CosmosDatabaseName = "test-CosmosDbPartitionStorageTests";
+
+        private static readonly string EmulatorPath = Environment.ExpandEnvironmentVariables(@"%ProgramFiles%\Azure Cosmos DB Emulator\CosmosDB.Emulator.exe");
+
+        private static readonly Lazy<bool> HasEmulator = new Lazy<bool>(() =>
+        {
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_NAME")))
+            {
+                return false;
+            }
+
+            if (File.Exists(EmulatorPath))
+            {
+                var p = new Process
+                {
+                    StartInfo =
+                    {
+                        UseShellExecute = true,
+                        FileName = EmulatorPath,
+                        Arguments = "/GetStatus",
+                    },
+                };
+                p.Start();
+                p.WaitForExit();
+
+                return p.ExitCode == 2;
+            }
+
+            return false;
+        });
+
+        public CosmosDbPartitionStorageFixture()
+        {
+            if (HasEmulator.Value)
+            {
+                var client = new CosmosClient(
+                    CosmosServiceEndpoint,
+                    CosmosAuthKey,
+                    new CosmosClientOptions());
+
+                client.CreateDatabaseIfNotExistsAsync(CosmosDatabaseName);
+            }
+        }
+
+        public async void Dispose()
+        {
+            if (HasEmulator.Value)
+            {
+                var client = new CosmosClient(
+                    CosmosServiceEndpoint,
+                    CosmosAuthKey,
+                    new CosmosClientOptions());
+                try
+                {
+                    await client.GetDatabase(CosmosDatabaseName).DeleteAsync();
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine("Error cleaning up resources: {0}", ex.ToString());
+                }
+            }
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbPartitionStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbPartitionStorageTests.cs
@@ -4,121 +4,51 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Tests;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Azure.Tests
 {
-    [TestClass]
-    [TestCategory("Storage")]
-    [TestCategory("Storage - CosmosDB Partitioned")]
-    public class CosmosDbPartitionStorageTests : StorageBaseTests
+    [Trait("TestCategory", "Storage")]
+    [Trait("TestCategory", "Storage - CosmosDB Partitioned")]
+    public class CosmosDbPartitionStorageTests : StorageBaseTests, IDisposable, IClassFixture<CosmosDbPartitionStorageFixture>
     {
         // Endpoint and Authkey for the CosmosDB Emulator running locally
         private const string CosmosServiceEndpoint = "https://localhost:8081";
         private const string CosmosAuthKey = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
         private const string CosmosDatabaseName = "test-CosmosDbPartitionStorageTests";
         private const string CosmosCollectionName = "bot-storage";
-
-        private const string _noEmulatorMessage = "This test requires CosmosDB Emulator! go to https://aka.ms/documentdb-emulator-docs to download and install.";
-        private static readonly string _emulatorPath = Environment.ExpandEnvironmentVariables(@"%ProgramFiles%\Azure Cosmos DB Emulator\CosmosDB.Emulator.exe");
-        private static readonly Lazy<bool> _hasEmulator = new Lazy<bool>(() =>
-        {
-            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_NAME")))
-            {
-                return false;
-            }
-
-            if (File.Exists(_emulatorPath))
-            {
-                var p = new Process
-                {
-                    StartInfo =
-                    {
-                        UseShellExecute = true,
-                        FileName = _emulatorPath,
-                        Arguments = "/GetStatus",
-                    },
-                };
-                p.Start();
-                p.WaitForExit();
-
-                return p.ExitCode == 2;
-            }
-
-            return false;
-        });
-
         private IStorage _storage;
 
-        [ClassInitialize]
-        public static async Task AllTestsInitialize(TestContext testContext)
+        public CosmosDbPartitionStorageTests()
         {
-            if (_hasEmulator.Value)
-            {
-                var client = new CosmosClient(
-                    CosmosServiceEndpoint,
-                    CosmosAuthKey,
-                    new CosmosClientOptions());
-
-                await client.CreateDatabaseIfNotExistsAsync(CosmosDatabaseName);
-            }
+            _storage = new CosmosDbPartitionedStorage(
+                new CosmosDbPartitionedStorageOptions
+                {
+                    AuthKey = CosmosAuthKey,
+                    ContainerId = CosmosCollectionName,
+                    CosmosDbEndpoint = CosmosServiceEndpoint,
+                    DatabaseId = CosmosDatabaseName,
+                });
         }
 
-        // Use ClassCleanup to run code after all tests in a class have run
-        [ClassCleanup]
-        public static async Task AllTestsCleanup()
-        {
-            var client = new CosmosClient(
-                CosmosServiceEndpoint,
-                CosmosAuthKey,
-                new CosmosClientOptions());
-            try
-            {
-                await client.GetDatabase(CosmosDatabaseName).DeleteAsync();
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine("Error cleaning up resources: {0}", ex.ToString());
-            }
-        }
-
-        [TestInitialize]
-        public void TestInit()
-        {
-            if (_hasEmulator.Value)
-            {
-                _storage = new CosmosDbPartitionedStorage(
-                    new CosmosDbPartitionedStorageOptions
-                    {
-                        AuthKey = CosmosAuthKey,
-                        ContainerId = CosmosCollectionName,
-                        CosmosDbEndpoint = CosmosServiceEndpoint,
-                        DatabaseId = CosmosDatabaseName,
-                    });
-            }
-        }
-
-        [TestCleanup]
-        public async Task TestCleanUp()
+        public async void Dispose()
         {
             _storage = null;
         }
 
-        [TestMethod]
+        [Fact]
         public void Constructor_Should_Throw_On_InvalidOptions()
         {
             // No Options. Should throw.
-            Assert.ThrowsException<ArgumentNullException>(() => new CosmosDbPartitionedStorage(null));
+            Assert.Throws<ArgumentNullException>(() => new CosmosDbPartitionedStorage(null));
 
             // No Endpoint. Should throw.
-            Assert.ThrowsException<ArgumentException>(() => new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions()
+            Assert.Throws<ArgumentException>(() => new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions()
             {
                 AuthKey = "test",
                 ContainerId = "testId",
@@ -127,7 +57,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             }));
 
             // No Auth Key. Should throw.
-            Assert.ThrowsException<ArgumentException>(() => new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions()
+            Assert.Throws<ArgumentException>(() => new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions()
             {
                 AuthKey = null,
                 ContainerId = "testId",
@@ -136,7 +66,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             }));
 
             // No Database Id. Should throw.
-            Assert.ThrowsException<ArgumentException>(() => new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions()
+            Assert.Throws<ArgumentException>(() => new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions()
             {
                 AuthKey = "testAuthKey",
                 ContainerId = "testId",
@@ -145,7 +75,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             }));
 
             // No Container Id. Should throw.
-            Assert.ThrowsException<ArgumentException>(() => new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions()
+            Assert.Throws<ArgumentException>(() => new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions()
             {
                 AuthKey = "testAuthKey",
                 ContainerId = null,
@@ -154,7 +84,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             }));
 
             // Invalid Row Key characters in KeySuffix
-            Assert.ThrowsException<ArgumentException>(() => new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions()
+            Assert.Throws<ArgumentException>(() => new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions()
             {
                 AuthKey = "testAuthKey",
                 ContainerId = "testId",
@@ -164,7 +94,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 CompatibilityMode = false
             }));
 
-            Assert.ThrowsException<ArgumentException>(() => new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions()
+            Assert.Throws<ArgumentException>(() => new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions()
             {
                 AuthKey = "testAuthKey",
                 ContainerId = "testId",
@@ -176,106 +106,76 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [TestMethod]
-        public async Task CreateObjectTest()
+        [IgnoreOnHasNoEmulatorFact]
+        public async Task CreateObjectCosmosDBPartitionTest()
         {
-            if (CheckEmulator())
-            {
-                await CreateObjectTest(_storage);
-            }
+            await CreateObjectTest(_storage);
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [TestMethod]
-        public async Task ReadUnknownTest()
+        [IgnoreOnHasNoEmulatorFact]
+        public async Task ReadUnknownCosmosDBPartitionTest()
         {
-            if (CheckEmulator())
-            {
-                await ReadUnknownTest(_storage);
-            }
+            await ReadUnknownTest(_storage);
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [TestMethod]
-        public async Task UpdateObjectTest()
+        [IgnoreOnHasNoEmulatorFact]
+        public async Task UpdateObjectCosmosDBPartitionTest()
         {
-            if (CheckEmulator())
-            {
-                await UpdateObjectTest<CosmosException>(_storage);
-            }
+            await UpdateObjectTest<CosmosException>(_storage);
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [TestMethod]
-        public async Task DeleteObjectTest()
+        [IgnoreOnHasNoEmulatorFact]
+        public async Task DeleteObjectCosmosDBPartitionTest()
         {
-            if (CheckEmulator())
-            {
-                await DeleteObjectTest(_storage);
-            }
+            await DeleteObjectTest(_storage);
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [TestMethod]
-        public async Task DeleteUnknownObjectTest()
+        [IgnoreOnHasNoEmulatorFact]
+        public async Task DeleteUnknownObjectCosmosDBPartitionTest()
         {
-            if (CheckEmulator())
-            {
-                await _storage.DeleteAsync(new[] { "unknown_delete" });
-            }
+            await _storage.DeleteAsync(new[] { "unknown_delete" });
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [TestMethod]
-        public async Task HandleCrazyKeys()
+        [IgnoreOnHasNoEmulatorFact]
+        public async Task HandleCrazyKeysCosmosDBPartition()
         {
-            if (CheckEmulator())
-            {
-                await HandleCrazyKeys(_storage);
-            }
+            await HandleCrazyKeys(_storage);
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [TestMethod]
+        [IgnoreOnHasNoEmulatorFact]
         public async Task ReadingEmptyKeysReturnsEmptyDictionary()
         {
-            if (CheckEmulator())
-            {
-                var state = await _storage.ReadAsync(new string[] { });
-                Assert.IsInstanceOfType(state, typeof(Dictionary<string, object>));
-                Assert.AreEqual(state.Count, 0);
-            }
+            var state = await _storage.ReadAsync(new string[] { });
+            Assert.IsType<Dictionary<string, object>>(state);
+            Assert.Equal(0, state.Count);
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [TestMethod]
+        [IgnoreOnHasNoEmulatorFact]
         public async Task ReadingNullKeysThrowException()
         {
-            if (CheckEmulator())
-            {
-                await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () => await _storage.ReadAsync(null));
-            }
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await _storage.ReadAsync(null));
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [TestMethod]
+        [IgnoreOnHasNoEmulatorFact]
         public async Task WritingNullStoreItemsThrowException()
         {
-            if (CheckEmulator())
-            {
-                await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () => await _storage.WriteAsync(null));
-            }
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await _storage.WriteAsync(null));
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [TestMethod]
+        [IgnoreOnHasNoEmulatorFact]
         public async Task WritingNoStoreItemsDoesntThrow()
         {
-            if (CheckEmulator())
-            {
-                var changes = new Dictionary<string, object>();
-                await _storage.WriteAsync(changes);
-            }
+            var changes = new Dictionary<string, object>();
+            await _storage.WriteAsync(changes);
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
@@ -288,98 +188,80 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         // The problem was reintroduced when the prompt retry count feature was implemented:
         // https://github.com/microsoft/botbuilder-dotnet/issues/1859
         // The waterfall in this test has been modified to include a prompt.
-        [TestMethod]
+        [IgnoreOnHasNoEmulatorFact]
         public async Task WaterfallCosmos()
         {
-            if (CheckEmulator())
+            var convoState = new ConversationState(_storage);
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+            var dialogs = new DialogSet(dialogState);
+
+            dialogs.Add(new TextPrompt(nameof(TextPrompt), async (promptContext, cancellationToken) =>
             {
-                var convoState = new ConversationState(_storage);
-
-                var adapter = new TestAdapter()
-                    .Use(new AutoSaveStateMiddleware(convoState));
-
-                var dialogState = convoState.CreateProperty<DialogState>("dialogState");
-                var dialogs = new DialogSet(dialogState);
-
-                dialogs.Add(new TextPrompt(nameof(TextPrompt), async (promptContext, cancellationToken) =>
+                var result = promptContext.Recognized.Value;
+                if (result.Length > 3)
                 {
-                    var result = promptContext.Recognized.Value;
-                    if (result.Length > 3)
-                    {
-                        var succeededMessage = MessageFactory.Text($"You got it at the {promptContext.AttemptCount}th try!");
-                        await promptContext.Context.SendActivityAsync(succeededMessage, cancellationToken);
-                        return true;
-                    }
+                    var succeededMessage = MessageFactory.Text($"You got it at the {promptContext.AttemptCount}th try!");
+                    await promptContext.Context.SendActivityAsync(succeededMessage, cancellationToken);
+                    return true;
+                }
 
-                    var reply = MessageFactory.Text($"Please send a name that is longer than 3 characters. {promptContext.AttemptCount}");
-                    await promptContext.Context.SendActivityAsync(reply, cancellationToken);
+                var reply = MessageFactory.Text($"Please send a name that is longer than 3 characters. {promptContext.AttemptCount}");
+                await promptContext.Context.SendActivityAsync(reply, cancellationToken);
 
-                    return false;
-                }));
+                return false;
+            }));
 
-                var steps = new WaterfallStep[]
-                    {
-                        async (stepContext, ct) =>
-                        {
-                            Assert.AreEqual(stepContext.ActiveDialog.State["stepIndex"].GetType(), typeof(int));
-                            await stepContext.Context.SendActivityAsync("step1");
-                            return Dialog.EndOfTurn;
-                        },
-                        async (stepContext, ct) =>
-                        {
-                            Assert.AreEqual(stepContext.ActiveDialog.State["stepIndex"].GetType(), typeof(int));
-                            return await stepContext.PromptAsync(nameof(TextPrompt), new PromptOptions { Prompt = MessageFactory.Text("Please type your name.") }, ct);
-                        },
-                        async (stepContext, ct) =>
-                        {
-                            Assert.AreEqual(stepContext.ActiveDialog.State["stepIndex"].GetType(), typeof(int));
-                            await stepContext.Context.SendActivityAsync("step3");
-                            return Dialog.EndOfTurn;
-                        },
-                    };
-
-                dialogs.Add(new WaterfallDialog(nameof(WaterfallDialog), steps));
-
-                await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            var steps = new WaterfallStep[]
                 {
-                    var dc = await dialogs.CreateContextAsync(turnContext);
-
-                    await dc.ContinueDialogAsync();
-                    if (!turnContext.Responded)
+                    async (stepContext, ct) =>
                     {
-                        await dc.BeginDialogAsync(nameof(WaterfallDialog));
-                    }
-                })
-                    .Send("hello")
-                    .AssertReply("step1")
-                    .Send("hello")
-                    .AssertReply("Please type your name.")
-                    .Send("hi")
-                    .AssertReply("Please send a name that is longer than 3 characters. 1")
-                    .Send("hi")
-                    .AssertReply("Please send a name that is longer than 3 characters. 2")
-                    .Send("hi")
-                    .AssertReply("Please send a name that is longer than 3 characters. 3")
-                    .Send("Kyle")
-                    .AssertReply("You got it at the 4th try!")
-                    .AssertReply("step3")
-                    .StartTestAsync();
-            }
-        }
+                        Assert.Equal(typeof(int), stepContext.ActiveDialog.State["stepIndex"].GetType());
+                        await stepContext.Context.SendActivityAsync("step1");
+                        return Dialog.EndOfTurn;
+                    },
+                    async (stepContext, ct) =>
+                    {
+                        Assert.Equal(typeof(int), stepContext.ActiveDialog.State["stepIndex"].GetType());
+                        return await stepContext.PromptAsync(nameof(TextPrompt), new PromptOptions { Prompt = MessageFactory.Text("Please type your name.") }, ct);
+                    },
+                    async (stepContext, ct) =>
+                    {
+                        Assert.Equal(typeof(int), stepContext.ActiveDialog.State["stepIndex"].GetType());
+                        await stepContext.Context.SendActivityAsync("step3");
+                        return Dialog.EndOfTurn;
+                    },
+                };
 
-        public bool CheckEmulator()
-        {
-            if (!_hasEmulator.Value)
+            dialogs.Add(new WaterfallDialog(nameof(WaterfallDialog), steps));
+
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
-                Assert.Inconclusive(_noEmulatorMessage);
-            }
+                var dc = await dialogs.CreateContextAsync(turnContext);
 
-            if (Debugger.IsAttached)
-            {
-                Assert.IsTrue(_hasEmulator.Value, _noEmulatorMessage);
-            }
-
-            return _hasEmulator.Value;
+                await dc.ContinueDialogAsync();
+                if (!turnContext.Responded)
+                {
+                    await dc.BeginDialogAsync(nameof(WaterfallDialog));
+                }
+            })
+                .Send("hello")
+                .AssertReply("step1")
+                .Send("hello")
+                .AssertReply("Please type your name.")
+                .Send("hi")
+                .AssertReply("Please send a name that is longer than 3 characters. 1")
+                .Send("hi")
+                .AssertReply("Please send a name that is longer than 3 characters. 2")
+                .Send("hi")
+                .AssertReply("Please send a name that is longer than 3 characters. 3")
+                .Send("Kyle")
+                .AssertReply("You got it at the 4th try!")
+                .AssertReply("step3")
+                .StartTestAsync();
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbPartitionStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbPartitionStorageTests.cs
@@ -106,49 +106,49 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnHasNoEmulatorFact]
+        [IgnoreOnNoEmulatorFact]
         public async Task CreateObjectCosmosDBPartitionTest()
         {
             await CreateObjectTest(_storage);
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnHasNoEmulatorFact]
+        [IgnoreOnNoEmulatorFact]
         public async Task ReadUnknownCosmosDBPartitionTest()
         {
             await ReadUnknownTest(_storage);
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnHasNoEmulatorFact]
+        [IgnoreOnNoEmulatorFact]
         public async Task UpdateObjectCosmosDBPartitionTest()
         {
             await UpdateObjectTest<CosmosException>(_storage);
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnHasNoEmulatorFact]
+        [IgnoreOnNoEmulatorFact]
         public async Task DeleteObjectCosmosDBPartitionTest()
         {
             await DeleteObjectTest(_storage);
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnHasNoEmulatorFact]
+        [IgnoreOnNoEmulatorFact]
         public async Task DeleteUnknownObjectCosmosDBPartitionTest()
         {
             await _storage.DeleteAsync(new[] { "unknown_delete" });
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnHasNoEmulatorFact]
+        [IgnoreOnNoEmulatorFact]
         public async Task HandleCrazyKeysCosmosDBPartition()
         {
             await HandleCrazyKeys(_storage);
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnHasNoEmulatorFact]
+        [IgnoreOnNoEmulatorFact]
         public async Task ReadingEmptyKeysReturnsEmptyDictionary()
         {
             var state = await _storage.ReadAsync(new string[] { });
@@ -157,21 +157,21 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnHasNoEmulatorFact]
+        [IgnoreOnNoEmulatorFact]
         public async Task ReadingNullKeysThrowException()
         {
             await Assert.ThrowsAsync<ArgumentNullException>(async () => await _storage.ReadAsync(null));
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnHasNoEmulatorFact]
+        [IgnoreOnNoEmulatorFact]
         public async Task WritingNullStoreItemsThrowException()
         {
             await Assert.ThrowsAsync<ArgumentNullException>(async () => await _storage.WriteAsync(null));
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnHasNoEmulatorFact]
+        [IgnoreOnNoEmulatorFact]
         public async Task WritingNoStoreItemsDoesntThrow()
         {
             var changes = new Dictionary<string, object>();
@@ -188,7 +188,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         // The problem was reintroduced when the prompt retry count feature was implemented:
         // https://github.com/microsoft/botbuilder-dotnet/issues/1859
         // The waterfall in this test has been modified to include a prompt.
-        [IgnoreOnHasNoEmulatorFact]
+        [IgnoreOnNoEmulatorFact]
         public async Task WaterfallCosmos()
         {
             var convoState = new ConversationState(_storage);

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
@@ -14,16 +14,15 @@ using Microsoft.Azure.Documents.Client;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Tests;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Newtonsoft.Json;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Azure.Tests
 {
-    [TestClass]
-    [TestCategory("Storage")]
-    [TestCategory("Storage - CosmosDB")]
-    public class CosmosDbStorageTests : StorageBaseTests
+    [Trait("TestCategory", "Storage")]
+    [Trait("TestCategory", "Storage - CosmosDB")]
+    public class CosmosDbStorageTests : StorageBaseTests, IDisposable
     {
         // Endpoint and Authkey for the CosmosDB Emulator running locally
         private const string CosmosServiceEndpoint = "https://localhost:8081";
@@ -32,16 +31,15 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         private const string CosmosCollectionName = "bot-storage";
         private const string DocumentId = "UtteranceLog-001";
 
-        private const string NoEmulatorMessage = "This test requires CosmosDB Emulator! go to https://aka.ms/documentdb-emulator-docs to download and install.";
-        private static readonly string _emulatorPath = Environment.ExpandEnvironmentVariables(@"%ProgramFiles%\Azure Cosmos DB Emulator\CosmosDB.Emulator.exe");
-        private static readonly Lazy<bool> _hasEmulator = new Lazy<bool>(() =>
+        private static readonly string EmulatorPath = Environment.ExpandEnvironmentVariables(@"%ProgramFiles%\Azure Cosmos DB Emulator\CosmosDB.Emulator.exe");
+        private static readonly Lazy<bool> HasEmulator = new Lazy<bool>(() =>
         {
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_NAME")))
             {
                 return false;
             }
 
-            if (File.Exists(_emulatorPath))
+            if (File.Exists(EmulatorPath))
             {
                 var tries = 5;
 
@@ -49,7 +47,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 {
                     var p = new Process();
                     p.StartInfo.UseShellExecute = true;
-                    p.StartInfo.FileName = _emulatorPath;
+                    p.StartInfo.FileName = EmulatorPath;
                     p.StartInfo.Arguments = "/GetStatus";
                     p.Start();
                     p.WaitForExit();
@@ -78,16 +76,13 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         });
 
         // Item used to test delete cases
-        private readonly StoreItem itemToTest = new StoreItem { MessageList = new string[] { "hi", "how are u" }, City = "Contoso" };
+        private readonly StoreItem _itemToTest = new StoreItem { MessageList = new string[] { "hi", "how are u" }, City = "Contoso" };
 
         private IStorage _storage;
 
-        public TestContext TestContext { get; set; }
-
-        [TestInitialize]
-        public void TestInit()
+        public CosmosDbStorageTests()
         {
-            if (CheckEmulator())
+            if (HasEmulator.Value)
             {
                 _storage = new CosmosDbStorage(new CosmosDbStorageOptions
                 {
@@ -99,8 +94,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             }
         }
 
-        [TestCleanup]
-        public async Task TestCleanUp()
+        public async void Dispose()
         {
             if (_storage != null)
             {
@@ -116,27 +110,27 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             }
         }
 
-        [TestMethod]
-        public void Sanatize_Key_Should_Work()
+        [IgnoreOnHasNoEmulatorFact]
+        public void Sanitize_Key_Should_Work()
         {
-            // Note: The SanatizeKey method delegates to the CosmosDBKeyEscape class. The method is
+            // Note: The SanitizeKey method delegates to the CosmosDBKeyEscape class. The method is
             // marked as obsolete, and should no longer be used. This test is here to make sure
             // the method does actually delegate, as we can't remove it due to back-compat reasons.
 #pragma warning disable 0618
             // Ascii code of "?" is "3f".
             var sanitizedKey = CosmosDbStorage.SanitizeKey("?test?");
-            Assert.AreEqual(sanitizedKey, "*3ftest*3f");
+            Assert.Equal("*3ftest*3f", sanitizedKey);
 #pragma warning restore 0618
         }
 
-        [TestMethod]
+        [IgnoreOnHasNoEmulatorFact]
         public void Constructor_Should_Throw_On_InvalidOptions()
         {
             // No Options. Should throw.
-            Assert.ThrowsException<ArgumentNullException>(() => new CosmosDbStorage(null));
+            Assert.Throws<ArgumentNullException>(() => new CosmosDbStorage(null));
 
             // No Endpoint. Should throw.
-            Assert.ThrowsException<ArgumentException>(() => new CosmosDbStorage(new CosmosDbStorageOptions
+            Assert.Throws<ArgumentException>(() => new CosmosDbStorage(new CosmosDbStorageOptions
             {
                 AuthKey = "test",
                 CollectionId = "testId",
@@ -145,7 +139,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             }));
 
             // No Auth Key. Should throw.
-            Assert.ThrowsException<ArgumentException>(() => new CosmosDbStorage(new CosmosDbStorageOptions
+            Assert.Throws<ArgumentException>(() => new CosmosDbStorage(new CosmosDbStorageOptions
             {
                 AuthKey = null,
                 CollectionId = "testId",
@@ -154,7 +148,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             }));
 
             // No Database Id. Should throw.
-            Assert.ThrowsException<ArgumentException>(() => new CosmosDbStorage(new CosmosDbStorageOptions
+            Assert.Throws<ArgumentException>(() => new CosmosDbStorage(new CosmosDbStorageOptions
             {
                 AuthKey = "test",
                 CollectionId = "testId",
@@ -163,7 +157,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             }));
 
             // No Collection Id. Should throw.
-            Assert.ThrowsException<ArgumentException>(() => new CosmosDbStorage(new CosmosDbStorageOptions
+            Assert.Throws<ArgumentException>(() => new CosmosDbStorage(new CosmosDbStorageOptions
             {
                 AuthKey = "test",
                 CollectionId = null,
@@ -172,37 +166,37 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             }));
         }
 
-        [TestMethod]
+        [IgnoreOnHasNoEmulatorFact]
         public void CustomConstructor_Should_Throw_On_InvalidOptions()
         {
             var customClient = GetDocumentClient().Object;
 
             // No client. Should throw.
-            Assert.ThrowsException<ArgumentNullException>(() => new CosmosDbStorage(null, new CosmosDbCustomClientOptions
+            Assert.Throws<ArgumentNullException>(() => new CosmosDbStorage(null, new CosmosDbCustomClientOptions
             {
                 CollectionId = "testId",
                 DatabaseId = "testDb",
             }));
 
             // No Options. Should throw.
-            Assert.ThrowsException<ArgumentNullException>(() => new CosmosDbStorage(customClient, null));
+            Assert.Throws<ArgumentNullException>(() => new CosmosDbStorage(customClient, null));
 
             // No Database Id. Should throw.
-            Assert.ThrowsException<ArgumentException>(() => new CosmosDbStorage(customClient, new CosmosDbCustomClientOptions
+            Assert.Throws<ArgumentException>(() => new CosmosDbStorage(customClient, new CosmosDbCustomClientOptions
             {
                 CollectionId = "testId",
                 DatabaseId = null,
             }));
 
             // No Collection Id. Should throw.
-            Assert.ThrowsException<ArgumentException>(() => new CosmosDbStorage(customClient, new CosmosDbCustomClientOptions
+            Assert.Throws<ArgumentException>(() => new CosmosDbStorage(customClient, new CosmosDbCustomClientOptions
             {
                 CollectionId = null,
                 DatabaseId = "testDb",
             }));
         }
 
-        [TestMethod]
+        [IgnoreOnHasNoEmulatorFact]
         public void Connection_Policy_Configurator_Should_Be_Called_If_Present()
         {
             var wasCalled = false;
@@ -219,10 +213,10 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             };
 
             var storage = new CosmosDbStorage(optionsWithConfigurator);
-            Assert.IsTrue(wasCalled, "The Connection Policy Configurator was not called.");
+            Assert.True(wasCalled, "The Connection Policy Configurator was not called.");
         }
 
-        [TestMethod]
+        [IgnoreOnHasNoEmulatorFact]
         public async Task Database_Creation_Request_Options_Should_Be_Used()
         {
             var documentClientMock = GetDocumentClient();
@@ -246,117 +240,87 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [TestMethod]
-        public async Task CreateObjectTest()
+        [IgnoreOnHasNoEmulatorFact]
+        public async Task CreateObjectCosmosDBTest()
         {
-            if (CheckEmulator())
-            {
-                await CreateObjectTest(_storage);
-            }
+            await CreateObjectTest(_storage);
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [TestMethod]
-        public async Task ReadUnknownTest()
+        [IgnoreOnHasNoEmulatorFact]
+        public async Task ReadUnknownCosmosDBTest()
         {
-            if (CheckEmulator())
-            {
-                await ReadUnknownTest(_storage);
-            }
+            await ReadUnknownTest(_storage);
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [TestMethod]
-        public async Task UpdateObjectTest()
+        [IgnoreOnHasNoEmulatorFact]
+        public async Task UpdateObjectCosmosDBTest()
         {
-            if (CheckEmulator())
-            {
-                await UpdateObjectTest<DocumentClientException>(_storage);
-            }
+            await UpdateObjectTest<DocumentClientException>(_storage);
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [TestMethod]
-        public async Task DeleteObjectTest()
+        [IgnoreOnHasNoEmulatorFact]
+        public async Task DeleteObjectCosmosDBTest()
         {
-            if (CheckEmulator())
-            {
-                await DeleteObjectTest(_storage);
-            }
+            await DeleteObjectTest(_storage);
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [TestMethod]
-        public async Task HandleCrazyKeys()
+        [IgnoreOnHasNoEmulatorFact]
+        public async Task HandleCrazyKeysCosmosDB()
         {
-            if (CheckEmulator())
-            {
-                await HandleCrazyKeys(_storage);
-            }
+            await HandleCrazyKeys(_storage);
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [TestMethod]
+        [IgnoreOnHasNoEmulatorFact]
         public void ConnectionPolicyConfiguratorShouldBeCalled()
         {
-            if (CheckEmulator())
+            ConnectionPolicy policyRef = null;
+
+            _storage = new CosmosDbStorage(new CosmosDbStorageOptions
             {
-                ConnectionPolicy policyRef = null;
+                AuthKey = CosmosAuthKey,
+                CollectionId = CosmosCollectionName,
+                CosmosDBEndpoint = new Uri(CosmosServiceEndpoint),
+                DatabaseId = CosmosDatabaseName,
+                ConnectionPolicyConfigurator = (ConnectionPolicy policy) => policyRef = policy,
+            });
 
-                _storage = new CosmosDbStorage(new CosmosDbStorageOptions
-                {
-                    AuthKey = CosmosAuthKey,
-                    CollectionId = CosmosCollectionName,
-                    CosmosDBEndpoint = new Uri(CosmosServiceEndpoint),
-                    DatabaseId = CosmosDatabaseName,
-                    ConnectionPolicyConfigurator = (ConnectionPolicy policy) => policyRef = policy,
-                });
-
-                Assert.IsNotNull(policyRef, "ConnectionPolicy configurator was not called.");
-            }
+            Assert.NotNull(policyRef);
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [TestMethod]
+        [IgnoreOnHasNoEmulatorFact]
         public async Task ReadingEmptyKeysReturnsEmptyDictionary()
         {
-            if (CheckEmulator())
-            {
-                var state = await _storage.ReadAsync(new string[] { });
-                Assert.IsInstanceOfType(state, typeof(Dictionary<string, object>));
-                Assert.AreEqual(state.Count, 0);
-            }
+            var state = await _storage.ReadAsync(new string[] { });
+            Assert.IsType<Dictionary<string, object>>(state);
+            Assert.Equal(0, state.Count);
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [TestMethod]
+        [IgnoreOnHasNoEmulatorFact]
         public async Task ReadingNullKeysThrowException()
         {
-            if (CheckEmulator())
-            {
-                await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () => await _storage.ReadAsync(null));
-            }
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await _storage.ReadAsync(null));
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [TestMethod]
+        [IgnoreOnHasNoEmulatorFact]
         public async Task WritingNullStoreItemsThrowException()
         {
-            if (CheckEmulator())
-            {
-                await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () => await _storage.WriteAsync(null));
-            }
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await _storage.WriteAsync(null));
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [TestMethod]
+        [IgnoreOnHasNoEmulatorFact]
         public async Task WritingNoStoreItemsDoesntThrow()
         {
-            if (CheckEmulator())
-            {
-                var changes = new Dictionary<string, object>();
-                await _storage.WriteAsync(changes);
-            }
+            var changes = new Dictionary<string, object>();
+            await _storage.WriteAsync(changes);
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
@@ -369,255 +333,219 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         // The problem was reintroduced when the prompt retry count feature was implemented:
         // https://github.com/microsoft/botbuilder-dotnet/issues/1859
         // The waterfall in this test has been modified to include a prompt.
-        [TestMethod]
+        [IgnoreOnHasNoEmulatorFact]
         public async Task WaterfallCosmos()
         {
-            if (CheckEmulator())
+            var convoState = new ConversationState(_storage);
+
+            var adapter = new TestAdapter(TestAdapter.CreateConversation(nameof(WaterfallCosmos)))
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+            var dialogs = new DialogSet(dialogState);
+
+            dialogs.Add(new TextPrompt(nameof(TextPrompt), async (promptContext, cancellationToken) =>
             {
-                var convoState = new ConversationState(_storage);
-
-                var adapter = new TestAdapter(TestAdapter.CreateConversation(TestContext.TestName))
-                    .Use(new AutoSaveStateMiddleware(convoState));
-
-                var dialogState = convoState.CreateProperty<DialogState>("dialogState");
-                var dialogs = new DialogSet(dialogState);
-
-                dialogs.Add(new TextPrompt(nameof(TextPrompt), async (promptContext, cancellationToken) =>
+                var result = promptContext.Recognized.Value;
+                if (result.Length > 3)
                 {
-                    var result = promptContext.Recognized.Value;
-                    if (result.Length > 3)
+                    var succeededMessage = MessageFactory.Text($"You got it at the {promptContext.AttemptCount}th try!");
+                    await promptContext.Context.SendActivityAsync(succeededMessage, cancellationToken);
+                    return true;
+                }
+
+                var reply = MessageFactory.Text($"Please send a name that is longer than 3 characters. {promptContext.AttemptCount}");
+                await promptContext.Context.SendActivityAsync(reply, cancellationToken);
+
+                return false;
+            }));
+
+            var steps = new WaterfallStep[]
+                {
+                    async (stepContext, ct) =>
                     {
-                        var succeededMessage = MessageFactory.Text($"You got it at the {promptContext.AttemptCount}th try!");
-                        await promptContext.Context.SendActivityAsync(succeededMessage, cancellationToken);
-                        return true;
+                        Assert.Equal(typeof(int), stepContext.ActiveDialog.State["stepIndex"].GetType());
+                        await stepContext.Context.SendActivityAsync("step1");
+                        return Dialog.EndOfTurn;
+                    },
+                    async (stepContext, ct) =>
+                    {
+                        Assert.Equal(typeof(int), stepContext.ActiveDialog.State["stepIndex"].GetType());
+                        return await stepContext.PromptAsync(nameof(TextPrompt), new PromptOptions { Prompt = MessageFactory.Text("Please type your name.") }, ct);
+                    },
+                    async (stepContext, ct) =>
+                    {
+                        Assert.Equal(typeof(int), stepContext.ActiveDialog.State["stepIndex"].GetType());
+                        await stepContext.Context.SendActivityAsync("step3");
+                        return Dialog.EndOfTurn;
+                    },
+                };
+
+            dialogs.Add(new WaterfallDialog(nameof(WaterfallDialog), steps));
+
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+                {
+                    var dc = await dialogs.CreateContextAsync(turnContext);
+
+                    await dc.ContinueDialogAsync();
+                    if (!turnContext.Responded)
+                    {
+                        await dc.BeginDialogAsync(nameof(WaterfallDialog));
                     }
-
-                    var reply = MessageFactory.Text($"Please send a name that is longer than 3 characters. {promptContext.AttemptCount}");
-                    await promptContext.Context.SendActivityAsync(reply, cancellationToken);
-
-                    return false;
-                }));
-
-                var steps = new WaterfallStep[]
-                    {
-                        async (stepContext, ct) =>
-                        {
-                            Assert.AreEqual(stepContext.ActiveDialog.State["stepIndex"].GetType(), typeof(int));
-                            await stepContext.Context.SendActivityAsync("step1");
-                            return Dialog.EndOfTurn;
-                        },
-                        async (stepContext, ct) =>
-                        {
-                            Assert.AreEqual(stepContext.ActiveDialog.State["stepIndex"].GetType(), typeof(int));
-                            return await stepContext.PromptAsync(nameof(TextPrompt), new PromptOptions { Prompt = MessageFactory.Text("Please type your name.") }, ct);
-                        },
-                        async (stepContext, ct) =>
-                        {
-                            Assert.AreEqual(stepContext.ActiveDialog.State["stepIndex"].GetType(), typeof(int));
-                            await stepContext.Context.SendActivityAsync("step3");
-                            return Dialog.EndOfTurn;
-                        },
-                    };
-
-                dialogs.Add(new WaterfallDialog(nameof(WaterfallDialog), steps));
-
-                await new TestFlow(adapter, async (turnContext, cancellationToken) =>
-                    {
-                        var dc = await dialogs.CreateContextAsync(turnContext);
-
-                        await dc.ContinueDialogAsync();
-                        if (!turnContext.Responded)
-                        {
-                            await dc.BeginDialogAsync(nameof(WaterfallDialog));
-                        }
-                    })
-                    .Send("hello")
-                    .AssertReply("step1")
-                    .Send("hello")
-                    .AssertReply("Please type your name.")
-                    .Send("hi")
-                    .AssertReply("Please send a name that is longer than 3 characters. 1")
-                    .Send("hi")
-                    .AssertReply("Please send a name that is longer than 3 characters. 2")
-                    .Send("hi")
-                    .AssertReply("Please send a name that is longer than 3 characters. 3")
-                    .Send("Kyle")
-                    .AssertReply("You got it at the 4th try!")
-                    .AssertReply("step3")
-                    .StartTestAsync();
-            }
+                })
+                .Send("hello")
+                .AssertReply("step1")
+                .Send("hello")
+                .AssertReply("Please type your name.")
+                .Send("hi")
+                .AssertReply("Please send a name that is longer than 3 characters. 1")
+                .Send("hi")
+                .AssertReply("Please send a name that is longer than 3 characters. 2")
+                .Send("hi")
+                .AssertReply("Please send a name that is longer than 3 characters. 3")
+                .Send("Kyle")
+                .AssertReply("You got it at the 4th try!")
+                .AssertReply("step3")
+                .StartTestAsync();
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [TestMethod]
+        [IgnoreOnHasNoEmulatorFact]
         public async Task DeleteAsyncFromSingleCollection()
         {
-            if (CheckEmulator())
+            var storage = new CosmosDbStorage(CreateCosmosDbStorageOptions());
+            var changes = new Dictionary<string, object>
             {
-                var storage = new CosmosDbStorage(CreateCosmosDbStorageOptions());
-                var changes = new Dictionary<string, object>
-                {
-                    { DocumentId, itemToTest }
-                };
+                { DocumentId, _itemToTest }
+            };
 
-                await storage.WriteAsync(changes, CancellationToken.None);
+            await storage.WriteAsync(changes, CancellationToken.None);
 
-                var result = await Task.WhenAny(storage.DeleteAsync(new string[] { DocumentId }, CancellationToken.None)).ConfigureAwait(false);
-                Assert.IsTrue(result.IsCompletedSuccessfully);
-            }
+            var result = await Task.WhenAny(storage.DeleteAsync(new string[] { DocumentId }, CancellationToken.None)).ConfigureAwait(false);
+            Assert.True(result.IsCompletedSuccessfully);
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [TestMethod]
+        [IgnoreOnHasNoEmulatorFact]
         public async Task DeleteAsyncFromPartitionedCollection()
         {
-            if (CheckEmulator())
+            // The WriteAsync method receive a object as a parameter then encapsulate it in a object named "document"
+            // The partitionKeyPath must have the "document" value to properly route the values as partitionKey
+            // <see also cref="WriteAsync(IDictionary{string, object}, CancellationToken)"/>
+            const string partitionKeyPath = "document/city";
+
+            await CreateCosmosDbWithPartitionedCollection(partitionKeyPath);
+
+            // Connect to the cosmosDb created before with "Contoso" as partitionKey
+            var storage = new CosmosDbStorage(CreateCosmosDbStorageOptions("Contoso"));
+            var changes = new Dictionary<string, object>
             {
-                /// The WriteAsync method receive a object as a parameter then encapsulate it in a object named "document"
-                /// The partitionKeyPath must have the "document" value to properly route the values as partitionKey
-                /// <seealso cref="WriteAsync(IDictionary{string, object}, CancellationToken)"/>
-                var partitionKeyPath = "document/city";
+                { DocumentId, _itemToTest }
+            };
 
-                await CreateCosmosDbWithPartitionedCollection(partitionKeyPath);
+            await storage.WriteAsync(changes, CancellationToken.None);
 
-                // Connect to the comosDb created before with "Contoso" as partitionKey
-                var storage = new CosmosDbStorage(CreateCosmosDbStorageOptions("Contoso"));
-                var changes = new Dictionary<string, object>
-                {
-                    { DocumentId, itemToTest }
-                };
-
-                await storage.WriteAsync(changes, CancellationToken.None);
-
-                var result = await Task.WhenAny(storage.DeleteAsync(new string[] { DocumentId }, CancellationToken.None)).ConfigureAwait(false);
-                Assert.IsTrue(result.IsCompletedSuccessfully);
-            }
+            var result = await Task.WhenAny(storage.DeleteAsync(new string[] { DocumentId }, CancellationToken.None)).ConfigureAwait(false);
+            Assert.True(result.IsCompletedSuccessfully);
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [TestMethod]
+        [IgnoreOnHasNoEmulatorFact]
         public async Task DeleteAsyncFromPartitionedCollectionWithoutPartitionKey()
         {
-            if (CheckEmulator())
+            // The WriteAsync method receive a object as a parameter then encapsulate it in a object named "document"
+            // The partitionKeyPath must have the "document" value to properly route the values as partitionKey
+            // <see also cref="WriteAsync(IDictionary{string, object}, CancellationToken)"/>
+            const string partitionKeyPath = "document/city";
+
+            await CreateCosmosDbWithPartitionedCollection(partitionKeyPath);
+
+            // Connect to the cosmosDb created before
+            var storage = new CosmosDbStorage(CreateCosmosDbStorageOptions());
+            var changes = new Dictionary<string, object>
             {
-                /// The WriteAsync method receive a object as a parameter then encapsulate it in a object named "document"
-                /// The partitionKeyPath must have the "document" value to properly route the values as partitionKey
-                /// <seealso cref="WriteAsync(IDictionary{string, object}, CancellationToken)"/>
-                var partitionKeyPath = "document/city";
+                { DocumentId, _itemToTest }
+            };
 
-                await CreateCosmosDbWithPartitionedCollection(partitionKeyPath);
+            await storage.WriteAsync(changes, CancellationToken.None);
 
-                // Connect to the comosDb created before
-                var storage = new CosmosDbStorage(CreateCosmosDbStorageOptions());
-                var changes = new Dictionary<string, object>
-                {
-                    { DocumentId, itemToTest }
-                };
-
-                await storage.WriteAsync(changes, CancellationToken.None);
-
-                // Should throw InvalidOperationException: PartitionKey value must be supplied for this operation.
-                await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () => await storage.DeleteAsync(new string[] { DocumentId }, CancellationToken.None));
-            }
+            // Should throw InvalidOperationException: PartitionKey value must be supplied for this operation.
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await storage.DeleteAsync(new string[] { DocumentId }, CancellationToken.None));
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [TestMethod]
+        [IgnoreOnHasNoEmulatorFact]
         public async Task ReadAsyncWithPartitionKey()
         {
-            if (CheckEmulator())
+            // The WriteAsync method receive a object as a parameter then encapsulate it in a object named "document"
+            // The partitionKeyPath must have the "document" value to properly route the values as partitionKey
+            // <see also cref="WriteAsync(IDictionary{string, object}, CancellationToken)"/>
+            const string partitionKeyPath = "document/city";
+
+            await CreateCosmosDbWithPartitionedCollection(partitionKeyPath);
+
+            // Connect to the cosmosDb created before with "Contoso" as partitionKey
+            var storage = new CosmosDbStorage(CreateCosmosDbStorageOptions("Contoso"));
+            var changes = new Dictionary<string, object>
             {
-                /// The WriteAsync method receive a object as a parameter then encapsulate it in a object named "document"
-                /// The partitionKeyPath must have the "document" value to properly route the values as partitionKey
-                /// <seealso cref="WriteAsync(IDictionary{string, object}, CancellationToken)"/>
-                var partitionKeyPath = "document/city";
+                { DocumentId, _itemToTest }
+            };
 
-                await CreateCosmosDbWithPartitionedCollection(partitionKeyPath);
+            await storage.WriteAsync(changes, CancellationToken.None);
 
-                // Connect to the comosDb created before with "Contoso" as partitionKey
-                var storage = new CosmosDbStorage(CreateCosmosDbStorageOptions("Contoso"));
-                var changes = new Dictionary<string, object>
-                {
-                    { DocumentId, itemToTest }
-                };
-
-                await storage.WriteAsync(changes, CancellationToken.None);
-
-                var result = await storage.ReadAsync<StoreItem>(new string[] { DocumentId }, CancellationToken.None);
-                Assert.AreEqual(itemToTest.City, result[DocumentId].City);
-            }
+            var result = await storage.ReadAsync<StoreItem>(new string[] { DocumentId }, CancellationToken.None);
+            Assert.Equal(_itemToTest.City, result[DocumentId].City);
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [TestMethod]
+        [IgnoreOnHasNoEmulatorFact]
         public async Task ReadAsyncWithoutPartitionKey()
         {
-            if (CheckEmulator())
+            // The WriteAsync method receive a object as a parameter then encapsulate it in a object named "document"
+            // The partitionKeyPath must have the "document" value to properly route the values as partitionKey
+            // <see also cref="WriteAsync(IDictionary{string, object}, CancellationToken)"/>
+            const string partitionKeyPath = "document/city";
+
+            await CreateCosmosDbWithPartitionedCollection(partitionKeyPath);
+
+            // Connect to the cosmosDb created before without partitionKey
+            var storage = new CosmosDbStorage(CreateCosmosDbStorageOptions());
+            var changes = new Dictionary<string, object>
             {
-                /// The WriteAsync method receive a object as a parameter then encapsulate it in a object named "document"
-                /// The partitionKeyPath must have the "document" value to properly route the values as partitionKey
-                /// <seealso cref="WriteAsync(IDictionary{string, object}, CancellationToken)"/>
-                var partitionKeyPath = "document/city";
+                { DocumentId, _itemToTest }
+            };
 
-                await CreateCosmosDbWithPartitionedCollection(partitionKeyPath);
-
-                // Connect to the comosDb created before without partitionKey
-                var storage = new CosmosDbStorage(CreateCosmosDbStorageOptions());
-                var changes = new Dictionary<string, object>
-                {
-                    { DocumentId, itemToTest }
-                };
-
-                await storage.WriteAsync(changes, CancellationToken.None);
+            await storage.WriteAsync(changes, CancellationToken.None);
 
 #if NETCOREAPP2_1
-                // Should throw DocumentClientException: Cross partition query is required but disabled
-                await Assert.ThrowsExceptionAsync<DocumentClientException>(async () => await storage.ReadAsync<StoreItem>(new string[] { DocumentId }, CancellationToken.None));
+            // Should throw DocumentClientException: Cross partition query is required but disabled
+            await Assert.ThrowsAsync<DocumentClientException>(async () => await storage.ReadAsync<StoreItem>(new string[] { DocumentId }, CancellationToken.None));
 #else // required by NETCOREAPP3_0 (have only tested NETCOREAPP2_1 and NETCOREAPP3_0)
-                var badRequestExceptionThrown = false;
-                try
-                {
-                    await storage.ReadAsync<StoreItem>(new string[] { DocumentId }, CancellationToken.None);
-                }
-                catch (DocumentClientException ex)
-                {
-                    badRequestExceptionThrown = ex.StatusCode == HttpStatusCode.BadRequest; 
-                }
-
-                Assert.IsTrue(badRequestExceptionThrown, "Expected: DocumentClientException with HttpStatusCode.BadRequest");
-
-                // TODO: netcoreapp3.0 throws Microsoft.Azure.Documents.BadRequestException which derives from DocumentClientException, but it is internal
-                //await Assert.ThrowsExceptionAsync<DocumentClientException>(async () => await storage.ReadAsync<StoreItem>(new string[] { DocumentId }, CancellationToken.None));
-#endif
+            var badRequestExceptionThrown = false;
+            try
+            {
+                await storage.ReadAsync<StoreItem>(new string[] { DocumentId }, CancellationToken.None);
             }
+            catch (DocumentClientException ex)
+            {
+                badRequestExceptionThrown = ex.StatusCode == HttpStatusCode.BadRequest; 
+            }
+
+            Assert.True(badRequestExceptionThrown, "Expected: DocumentClientException with HttpStatusCode.BadRequest");
+
+            // TODO: netcoreapp3.0 throws Microsoft.Azure.Documents.BadRequestException which derives from DocumentClientException, but it is internal
+            //await Assert.ThrowsAsync<DocumentClientException>(async () => await storage.ReadAsync<StoreItem>(new string[] { DocumentId }, CancellationToken.None));
+#endif
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [TestMethod]
+        [IgnoreOnHasNoEmulatorFact]
         public async Task StatePersistsThroughMultiTurn_TypeNameHandlingNone()
         {
-            if (CheckEmulator())
-            {
-                var storage = new CosmosDbStorage(
-                                   CreateCosmosDbStorageOptions(),
-                                   new JsonSerializer() { TypeNameHandling = TypeNameHandling.None });
-                await StatePersistsThroughMultiTurn(storage);
-            }
-        }
-
-        public bool CheckEmulator()
-        {
-            if (!_hasEmulator.Value)
-            {
-                Assert.Inconclusive(NoEmulatorMessage);
-            }
-
-            if (Debugger.IsAttached)
-            {
-                Assert.IsTrue(_hasEmulator.Value, NoEmulatorMessage);
-            }
-
-            return _hasEmulator.Value;
+            var storage = new CosmosDbStorage(
+                               CreateCosmosDbStorageOptions(),
+                               new JsonSerializer() { TypeNameHandling = TypeNameHandling.None });
+            await StatePersistsThroughMultiTurn(storage);
         }
 
         private static async Task CreateCosmosDbWithPartitionedCollection(string partitionKey)

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             }
         }
 
-        [IgnoreOnHasNoEmulatorFact]
+        [IgnoreOnNoEmulatorFact]
         public void Sanitize_Key_Should_Work()
         {
             // Note: The SanitizeKey method delegates to the CosmosDBKeyEscape class. The method is
@@ -123,7 +123,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 #pragma warning restore 0618
         }
 
-        [IgnoreOnHasNoEmulatorFact]
+        [IgnoreOnNoEmulatorFact]
         public void Constructor_Should_Throw_On_InvalidOptions()
         {
             // No Options. Should throw.
@@ -166,7 +166,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             }));
         }
 
-        [IgnoreOnHasNoEmulatorFact]
+        [IgnoreOnNoEmulatorFact]
         public void CustomConstructor_Should_Throw_On_InvalidOptions()
         {
             var customClient = GetDocumentClient().Object;
@@ -196,7 +196,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             }));
         }
 
-        [IgnoreOnHasNoEmulatorFact]
+        [IgnoreOnNoEmulatorFact]
         public void Connection_Policy_Configurator_Should_Be_Called_If_Present()
         {
             var wasCalled = false;
@@ -216,7 +216,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             Assert.True(wasCalled, "The Connection Policy Configurator was not called.");
         }
 
-        [IgnoreOnHasNoEmulatorFact]
+        [IgnoreOnNoEmulatorFact]
         public async Task Database_Creation_Request_Options_Should_Be_Used()
         {
             var documentClientMock = GetDocumentClient();
@@ -240,42 +240,42 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnHasNoEmulatorFact]
+        [IgnoreOnNoEmulatorFact]
         public async Task CreateObjectCosmosDBTest()
         {
             await CreateObjectTest(_storage);
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnHasNoEmulatorFact]
+        [IgnoreOnNoEmulatorFact]
         public async Task ReadUnknownCosmosDBTest()
         {
             await ReadUnknownTest(_storage);
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnHasNoEmulatorFact]
+        [IgnoreOnNoEmulatorFact]
         public async Task UpdateObjectCosmosDBTest()
         {
             await UpdateObjectTest<DocumentClientException>(_storage);
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnHasNoEmulatorFact]
+        [IgnoreOnNoEmulatorFact]
         public async Task DeleteObjectCosmosDBTest()
         {
             await DeleteObjectTest(_storage);
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnHasNoEmulatorFact]
+        [IgnoreOnNoEmulatorFact]
         public async Task HandleCrazyKeysCosmosDB()
         {
             await HandleCrazyKeys(_storage);
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnHasNoEmulatorFact]
+        [IgnoreOnNoEmulatorFact]
         public void ConnectionPolicyConfiguratorShouldBeCalled()
         {
             ConnectionPolicy policyRef = null;
@@ -293,7 +293,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnHasNoEmulatorFact]
+        [IgnoreOnNoEmulatorFact]
         public async Task ReadingEmptyKeysReturnsEmptyDictionary()
         {
             var state = await _storage.ReadAsync(new string[] { });
@@ -302,21 +302,21 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnHasNoEmulatorFact]
+        [IgnoreOnNoEmulatorFact]
         public async Task ReadingNullKeysThrowException()
         {
             await Assert.ThrowsAsync<ArgumentNullException>(async () => await _storage.ReadAsync(null));
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnHasNoEmulatorFact]
+        [IgnoreOnNoEmulatorFact]
         public async Task WritingNullStoreItemsThrowException()
         {
             await Assert.ThrowsAsync<ArgumentNullException>(async () => await _storage.WriteAsync(null));
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnHasNoEmulatorFact]
+        [IgnoreOnNoEmulatorFact]
         public async Task WritingNoStoreItemsDoesntThrow()
         {
             var changes = new Dictionary<string, object>();
@@ -333,7 +333,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         // The problem was reintroduced when the prompt retry count feature was implemented:
         // https://github.com/microsoft/botbuilder-dotnet/issues/1859
         // The waterfall in this test has been modified to include a prompt.
-        [IgnoreOnHasNoEmulatorFact]
+        [IgnoreOnNoEmulatorFact]
         public async Task WaterfallCosmos()
         {
             var convoState = new ConversationState(_storage);
@@ -410,7 +410,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnHasNoEmulatorFact]
+        [IgnoreOnNoEmulatorFact]
         public async Task DeleteAsyncFromSingleCollection()
         {
             var storage = new CosmosDbStorage(CreateCosmosDbStorageOptions());
@@ -426,7 +426,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnHasNoEmulatorFact]
+        [IgnoreOnNoEmulatorFact]
         public async Task DeleteAsyncFromPartitionedCollection()
         {
             // The WriteAsync method receive a object as a parameter then encapsulate it in a object named "document"
@@ -450,7 +450,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnHasNoEmulatorFact]
+        [IgnoreOnNoEmulatorFact]
         public async Task DeleteAsyncFromPartitionedCollectionWithoutPartitionKey()
         {
             // The WriteAsync method receive a object as a parameter then encapsulate it in a object named "document"
@@ -474,7 +474,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnHasNoEmulatorFact]
+        [IgnoreOnNoEmulatorFact]
         public async Task ReadAsyncWithPartitionKey()
         {
             // The WriteAsync method receive a object as a parameter then encapsulate it in a object named "document"
@@ -498,7 +498,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnHasNoEmulatorFact]
+        [IgnoreOnNoEmulatorFact]
         public async Task ReadAsyncWithoutPartitionKey()
         {
             // The WriteAsync method receive a object as a parameter then encapsulate it in a object named "document"
@@ -539,7 +539,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnHasNoEmulatorFact]
+        [IgnoreOnNoEmulatorFact]
         public async Task StatePersistsThroughMultiTurn_TypeNameHandlingNone()
         {
             var storage = new CosmosDbStorage(

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/IgnoreOnHasNoEmulatorFact.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/IgnoreOnHasNoEmulatorFact.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Azure.Tests
+{
+    public sealed class IgnoreOnHasNoEmulatorFact : FactAttribute
+    {
+        private static readonly string EmulatorPath = Environment.ExpandEnvironmentVariables(@"%ProgramFiles%\Azure Cosmos DB Emulator\CosmosDB.Emulator.exe");
+
+        private static readonly Lazy<bool> HasEmulator = new Lazy<bool>(() =>
+        {
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_NAME")))
+            {
+                return false;
+            }
+
+            if (File.Exists(EmulatorPath))
+            {
+                var p = new Process
+                {
+                    StartInfo =
+                    {
+                        UseShellExecute = true,
+                        FileName = EmulatorPath,
+                        Arguments = "/GetStatus",
+                    },
+                };
+                p.Start();
+                p.WaitForExit();
+
+                return p.ExitCode == 2;
+            }
+
+            return false;
+        });
+
+        public IgnoreOnHasNoEmulatorFact()
+        {
+            if (!HasEmulator.Value)
+            {
+                Skip = "This test requires CosmosDB Emulator! go to https://aka.ms/documentdb-emulator-docs to download and install.";
+            }
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/IgnoreOnNoEmulatorFact.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/IgnoreOnNoEmulatorFact.cs
@@ -5,10 +5,12 @@ using Xunit;
 
 namespace Microsoft.Bot.Builder.Azure.Tests
 {
-    public sealed class IgnoreOnHasNoEmulatorFact : FactAttribute
+    public sealed class IgnoreOnNoEmulatorFact : FactAttribute
     {
+        private const string NoEmulatorMessage = "This test requires CosmosDB Emulator! go to https://aka.ms/documentdb-emulator-docs to download and install.";
+        
         private static readonly string EmulatorPath = Environment.ExpandEnvironmentVariables(@"%ProgramFiles%\Azure Cosmos DB Emulator\CosmosDB.Emulator.exe");
-
+        
         private static readonly Lazy<bool> HasEmulator = new Lazy<bool>(() =>
         {
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_NAME")))
@@ -36,11 +38,16 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             return false;
         });
 
-        public IgnoreOnHasNoEmulatorFact()
+        public IgnoreOnNoEmulatorFact()
         {
             if (!HasEmulator.Value)
             {
                 Skip = "This test requires CosmosDB Emulator! go to https://aka.ms/documentdb-emulator-docs to download and install.";
+            }
+
+            if (Debugger.IsAttached)
+            {
+                Assert.True(HasEmulator.Value, NoEmulatorMessage);
             }
         }
     }

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/Microsoft.Bot.Builder.Azure.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/Microsoft.Bot.Builder.Azure.Tests.csproj
@@ -12,6 +12,11 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/Microsoft.Bot.Builder.Azure.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/Microsoft.Bot.Builder.Azure.Tests.csproj
@@ -10,8 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/StorageEmulatorHelper.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/StorageEmulatorHelper.cs
@@ -44,7 +44,6 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         {
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_NAME")))
             {
-                // Assert.Inconclusive("This test requires Azure Storage Emulator to run and is disabled on the build server.");
                 return false;
             }
 
@@ -60,7 +59,6 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 return output.IndexOf("started") > 0;
             }
 
-            // Assert.Inconclusive("This test requires Azure Storage Emulator to run");
             return false;
         }
 

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/StorageEmulatorHelper.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/StorageEmulatorHelper.cs
@@ -5,7 +5,6 @@ using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 // These tests require Azure Storage Emulator v5.7
 // The emulator must be installed at this path C:\Program Files (x86)\Microsoft SDKs\Azure\Storage Emulator\AzureStorageEmulator.exe
@@ -45,7 +44,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         {
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_NAME")))
             {
-                Assert.Inconclusive("This test requires Azure Storage Emulator to run and is disabled on the build server.");
+                // Assert.Inconclusive("This test requires Azure Storage Emulator to run and is disabled on the build server.");
                 return false;
             }
 
@@ -61,7 +60,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 return output.IndexOf("started") > 0;
             }
 
-            Assert.Inconclusive("This test requires Azure Storage Emulator to run");
+            // Assert.Inconclusive("This test requires Azure Storage Emulator to run");
             return false;
         }
 
@@ -101,7 +100,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 "Storage Emulator",
                 "AzureStorageEmulator.exe");
 
-            StringBuilder sb = new StringBuilder();
+            var sb = new StringBuilder();
             var startIInfo = new ProcessStartInfo
             {
                 Arguments = command.ToString(),

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/TranscriptStoreBaseTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/TranscriptStoreBaseTests.cs
@@ -6,8 +6,8 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Schema;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
+using Xunit;
 using Activity = Microsoft.Bot.Schema.Activity;
 
 // These tests require Azure Storage Emulator v5.7
@@ -42,18 +42,18 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 
         protected abstract string ContainerName { get; }
 
-        [TestMethod]
+        [Fact]
         public async Task TranscriptsEmptyTest()
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {
                 var unusedChannelId = Guid.NewGuid().ToString();
                 var transcripts = await TranscriptStore.ListTranscriptsAsync(unusedChannelId);
-                Assert.AreEqual(transcripts.Items.Length, 0);
+                Assert.Empty(transcripts.Items);
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ActivityEmptyTest()
         {
             if (StorageEmulatorHelper.CheckEmulator())
@@ -61,12 +61,12 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 foreach (var convoId in ConversationSpecialIds)
                 {
                     var activities = await TranscriptStore.GetTranscriptActivitiesAsync(ChannelId, convoId);
-                    Assert.AreEqual(activities.Items.Length, 0);
+                    Assert.Empty(activities.Items);
                 }
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ActivityAddTest()
         {
             if (StorageEmulatorHelper.CheckEmulator())
@@ -81,11 +81,11 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                     loggedActivities[i] = TranscriptStore.GetTranscriptActivitiesAsync(ChannelId, ConversationIds[i]).Result.Items[0];
                 }
 
-                Assert.AreEqual(5, loggedActivities.Length);
+                Assert.Equal(5, loggedActivities.Length);
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TranscriptRemoveTest()
         {
             if (StorageEmulatorHelper.CheckEmulator())
@@ -98,12 +98,12 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 
                     var loggedActivities =
                         await TranscriptStore.GetTranscriptActivitiesAsync(ChannelId, ConversationIds[i]);
-                    Assert.AreEqual(0, loggedActivities.Items.Length);
+                    Assert.Empty(loggedActivities.Items);
                 }
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ActivityAddSpecialCharsTest()
         {
             if (StorageEmulatorHelper.CheckEmulator())
@@ -118,11 +118,11 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                     loggedActivities[i] = TranscriptStore.GetTranscriptActivitiesAsync(ChannelId, ConversationSpecialIds[i]).Result.Items[0];
                 }
 
-                Assert.AreEqual(activities.Count, loggedActivities.Length);
+                Assert.Equal(activities.Count, loggedActivities.Length);
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TranscriptRemoveSpecialCharsTest()
         {
             if (StorageEmulatorHelper.CheckEmulator())
@@ -134,12 +134,12 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 
                     var loggedActivities =
                         await TranscriptStore.GetTranscriptActivitiesAsync(ChannelId, ConversationSpecialIds[i]);
-                    Assert.AreEqual(0, loggedActivities.Items.Length);
+                    Assert.Empty(loggedActivities.Items);
                 }
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ActivityAddPagedResultTest()
         {
             if (StorageEmulatorHelper.CheckEmulator())
@@ -160,17 +160,17 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 
                 loggedPagedResult = TranscriptStore.GetTranscriptActivitiesAsync(cleanChanel, ConversationIds[0]).Result;
                 var ct = loggedPagedResult.ContinuationToken;
-                Assert.AreEqual(20, loggedPagedResult.Items.Length);
-                Assert.IsNotNull(ct);
-                Assert.IsTrue(loggedPagedResult.ContinuationToken.Length > 0);
+                Assert.Equal(20, loggedPagedResult.Items.Length);
+                Assert.NotNull(ct);
+                Assert.True(loggedPagedResult.ContinuationToken.Length > 0);
                 loggedPagedResult = TranscriptStore.GetTranscriptActivitiesAsync(cleanChanel, ConversationIds[0], ct).Result;
                 ct = loggedPagedResult.ContinuationToken;
-                Assert.AreEqual(10, loggedPagedResult.Items.Length);
-                Assert.IsNull(ct);
+                Assert.Equal(10, loggedPagedResult.Items.Length);
+                Assert.Null(ct);
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TranscriptRemovePagedTest()
         {
             if (StorageEmulatorHelper.CheckEmulator())
@@ -185,34 +185,34 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 
                 loggedActivities =
                     await TranscriptStore.GetTranscriptActivitiesAsync(ChannelId, ConversationIds[i]);
-                Assert.AreEqual(0, loggedActivities.Items.Length);
+                Assert.Empty(loggedActivities.Items);
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task NullParameterTests()
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {
                 var store = TranscriptStore;
 
-                await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
+                await Assert.ThrowsAsync<ArgumentNullException>(async () =>
                     await store.LogActivityAsync(null));
-                await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
+                await Assert.ThrowsAsync<ArgumentNullException>(async () =>
                     await store.GetTranscriptActivitiesAsync(null, ConversationIds[0]));
-                await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
+                await Assert.ThrowsAsync<ArgumentNullException>(async () =>
                     await store.GetTranscriptActivitiesAsync(ChannelId, null));
             }
         }
 
-        [TestMethod]
-        [TestCategory("Middleware")]
+        [Fact]
+        [Trait("TestCategory", "Middleware")]
         public async Task LogActivities()
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {
                 var conversation = TestAdapter.CreateConversation(Guid.NewGuid().ToString("n"));
-                TestAdapter adapter = new TestAdapter(conversation)
+                var adapter = new TestAdapter(conversation)
                     .Use(new TranscriptLoggerMiddleware(TranscriptStore));
 
                 await new TestFlow(adapter, async (context, cancellationToken) =>
@@ -227,39 +227,39 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                     await context.SendActivityAsync("echo:" + context.Activity.Text);
                 })
                     .Send("foo")
-                        .AssertReply((activity) => Assert.AreEqual(activity.Type, ActivityTypes.Typing))
+                        .AssertReply((activity) => Assert.Equal(activity.Type, ActivityTypes.Typing))
                         .AssertReply("echo:foo")
                     .Send("bar")
-                        .AssertReply((activity) => Assert.AreEqual(activity.Type, ActivityTypes.Typing))
+                        .AssertReply((activity) => Assert.Equal(activity.Type, ActivityTypes.Typing))
                         .AssertReply("echo:bar")
                     .StartTestAsync();
 
                 await Task.Delay(1000);
 
                 var pagedResult = await TranscriptStore.GetTranscriptActivitiesAsync(conversation.ChannelId, conversation.Conversation.Id);
-                Assert.AreEqual(6, pagedResult.Items.Length);
-                Assert.AreEqual("foo", pagedResult.Items[0].AsMessageActivity().Text);
-                Assert.IsNotNull(pagedResult.Items[1].AsTypingActivity());
-                Assert.AreEqual("echo:foo", pagedResult.Items[2].AsMessageActivity().Text);
-                Assert.AreEqual("bar", pagedResult.Items[3].AsMessageActivity().Text);
-                Assert.IsNotNull(pagedResult.Items[4].AsTypingActivity());
-                Assert.AreEqual("echo:bar", pagedResult.Items[5].AsMessageActivity().Text);
+                Assert.Equal(6, pagedResult.Items.Length);
+                Assert.Equal("foo", pagedResult.Items[0].AsMessageActivity().Text);
+                Assert.NotNull(pagedResult.Items[1].AsTypingActivity());
+                Assert.Equal("echo:foo", pagedResult.Items[2].AsMessageActivity().Text);
+                Assert.Equal("bar", pagedResult.Items[3].AsMessageActivity().Text);
+                Assert.NotNull(pagedResult.Items[4].AsTypingActivity());
+                Assert.Equal("echo:bar", pagedResult.Items[5].AsMessageActivity().Text);
                 foreach (var activity in pagedResult.Items)
                 {
-                    Assert.IsTrue(!string.IsNullOrWhiteSpace(activity.Id));
-                    Assert.IsTrue(activity.Timestamp > default(DateTimeOffset));
+                    Assert.True(!string.IsNullOrWhiteSpace(activity.Id));
+                    Assert.True(activity.Timestamp > default(DateTimeOffset));
                 }
             }
         }
 
-        [TestMethod]
-        [TestCategory("Middleware")]
+        [Fact]
+        [Trait("TestCategory", "Middleware")]
         public async Task LogUpdateActivities()
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {
                 var conversation = TestAdapter.CreateConversation(Guid.NewGuid().ToString("n"));
-                TestAdapter adapter = new TestAdapter(conversation)
+                var adapter = new TestAdapter(conversation)
                     .Use(new TranscriptLoggerMiddleware(TranscriptStore));
                 Activity activityToUpdate = null;
                 await new TestFlow(adapter, async (context, cancellationToken) =>
@@ -287,23 +287,22 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 await Task.Delay(1000);
 
                 var pagedResult = await TranscriptStore.GetTranscriptActivitiesAsync(conversation.ChannelId, conversation.Conversation.Id);
-                Assert.AreEqual(3, pagedResult.Items.Length);
-                Assert.AreEqual("foo", pagedResult.Items[0].AsMessageActivity().Text);
-                Assert.AreEqual("new response", pagedResult.Items[1].AsMessageActivity().Text);
-                Assert.AreEqual("update", pagedResult.Items[2].AsMessageActivity().Text);
+                Assert.Equal(3, pagedResult.Items.Length);
+                Assert.Equal("foo", pagedResult.Items[0].AsMessageActivity().Text);
+                Assert.Equal("new response", pagedResult.Items[1].AsMessageActivity().Text);
+                Assert.Equal("update", pagedResult.Items[2].AsMessageActivity().Text);
             }
         }
 
-        [TestMethod]
-        [TestCategory("Middleware")]
+        [Fact]
+        [Trait("TestCategory", "Middleware")]
         public async Task TestDateLogUpdateActivities()
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {
                 var dateTimeStartOffset1 = new DateTimeOffset(DateTime.Now);
-                var dateTimeStartOffset2 = new DateTimeOffset(DateTime.UtcNow);
                 var conversation = TestAdapter.CreateConversation(Guid.NewGuid().ToString("n"));
-                TestAdapter adapter = new TestAdapter(conversation)
+                var adapter = new TestAdapter(conversation)
                     .Use(new TranscriptLoggerMiddleware(TranscriptStore));
                 Activity activityToUpdate = null;
                 await new TestFlow(adapter, async (context, cancellationToken) =>
@@ -333,32 +332,32 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 
                 // Perform some queries
                 var pagedResult = await TranscriptStore.GetTranscriptActivitiesAsync(conversation.ChannelId, conversation.Conversation.Id, null, dateTimeStartOffset1.DateTime);
-                Assert.AreEqual(3, pagedResult.Items.Length);
-                Assert.AreEqual("foo", pagedResult.Items[0].AsMessageActivity().Text);
-                Assert.AreEqual("new response", pagedResult.Items[1].AsMessageActivity().Text);
-                Assert.AreEqual("update", pagedResult.Items[2].AsMessageActivity().Text);
+                Assert.Equal(3, pagedResult.Items.Length);
+                Assert.Equal("foo", pagedResult.Items[0].AsMessageActivity().Text);
+                Assert.Equal("new response", pagedResult.Items[1].AsMessageActivity().Text);
+                Assert.Equal("update", pagedResult.Items[2].AsMessageActivity().Text);
 
                 // Perform some queries
                 pagedResult = await TranscriptStore.GetTranscriptActivitiesAsync(conversation.ChannelId, conversation.Conversation.Id, null, DateTimeOffset.MinValue);
-                Assert.AreEqual(3, pagedResult.Items.Length);
-                Assert.AreEqual("foo", pagedResult.Items[0].AsMessageActivity().Text);
-                Assert.AreEqual("new response", pagedResult.Items[1].AsMessageActivity().Text);
-                Assert.AreEqual("update", pagedResult.Items[2].AsMessageActivity().Text);
+                Assert.Equal(3, pagedResult.Items.Length);
+                Assert.Equal("foo", pagedResult.Items[0].AsMessageActivity().Text);
+                Assert.Equal("new response", pagedResult.Items[1].AsMessageActivity().Text);
+                Assert.Equal("update", pagedResult.Items[2].AsMessageActivity().Text);
 
                 // Perform some queries
                 pagedResult = await TranscriptStore.GetTranscriptActivitiesAsync(conversation.ChannelId, conversation.Conversation.Id, null, DateTimeOffset.MaxValue);
-                Assert.AreEqual(0, pagedResult.Items.Length);
+                Assert.Empty(pagedResult.Items);
             }
         }
 
-        [TestMethod]
-        [TestCategory("Middleware")]
+        [Fact]
+        [Trait("TestCategory", "Middleware")]
         public async Task LogDeleteActivities()
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {
                 var conversation = TestAdapter.CreateConversation(Guid.NewGuid().ToString("n"));
-                TestAdapter adapter = new TestAdapter(conversation)
+                var adapter = new TestAdapter(conversation)
                     .Use(new TranscriptLoggerMiddleware(TranscriptStore));
                 string activityId = null;
                 await new TestFlow(adapter, async (context, cancellationToken) =>
@@ -382,11 +381,11 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 await Task.Delay(1000);
 
                 var pagedResult = await TranscriptStore.GetTranscriptActivitiesAsync(conversation.ChannelId, conversation.Conversation.Id);
-                Assert.AreEqual(3, pagedResult.Items.Length);
-                Assert.AreEqual("foo", pagedResult.Items[0].AsMessageActivity().Text);
-                Assert.IsNotNull(pagedResult.Items[1].AsMessageDeleteActivity());
-                Assert.AreEqual(ActivityTypes.MessageDelete, pagedResult.Items[1].Type);
-                Assert.AreEqual("deleteIt", pagedResult.Items[2].AsMessageActivity().Text);
+                Assert.Equal(3, pagedResult.Items.Length);
+                Assert.Equal("foo", pagedResult.Items[0].AsMessageActivity().Text);
+                Assert.NotNull(pagedResult.Items[1].AsMessageDeleteActivity());
+                Assert.Equal(ActivityTypes.MessageDelete, pagedResult.Items[1].Type);
+                Assert.Equal("deleteIt", pagedResult.Items[2].AsMessageActivity().Text);
             }
         }
 


### PR DESCRIPTION
Fixes# 4090

## Description
This PR migrates all of the [Microsoft.Bot.Builder.Azure.Tests](https://github.com/microsoft/botbuilder-dotnet/tree/main/tests/Microsoft.Bot.Builder.Azure.Tests) tests from **MSTest** to **xUnit**.

## Detailed Changes
- Replaced the MSTest packages with xUnit in the .csproj.
- Replaced `[TestMethod]` with `[Fact]`.
- Replaced `[TestCategory]` with `[Trait]`
- Changed Asserts.
- Replaced `[TestInitialize]` moving the code to the class constructor.
- Replaced `[TestCleanup]` implementing `IDisposable` `Dispose` method in the class.
- Replaced `TestContext.TestName` in test initialization using `TestOutputHelper` and reflection.
- Added `CosmosDbPartitionStorageFixture` class to have `CosmosDbPartitionStorage` class initialization code. 
- In `CosmosDbPartitionStorageTests` and `CosmosDbStorageTests` we used `FactAttribute` to skip tests if the Storage Emulator is not installed, removing the _CheckEmulator()_ validation.
- Added `IgnoreOnNoEmulatorFact` class to set up the _FactAttribute_ used to skip the tests.
- Renamed some tests with duplicated names to avoid xUnit1024 error.
- Removed `Assert.Inconclusive` from `StorageEmulatorHelper` class.

Also, 
- Used constants instead of variables where applicable.
- Used `var` instead of the specific type.
- Removed redundant or unreachable code.

## Testing
The following image shows the tests passing after the changes.
![image](https://user-images.githubusercontent.com/44245136/92520097-74f75500-f1f1-11ea-888a-b2f0817909f2.png)