### PR TITLE
Microsoft.Bot.Builder.Dialogs.Tests remove MSTest packages

### DIFF
--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/Microsoft.Bot.Builder.Dialogs.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/Microsoft.Bot.Builder.Dialogs.Tests.csproj
@@ -20,8 +20,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/TestUtilities.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/TestUtilities.cs
@@ -11,11 +11,9 @@ using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Bot.Builder.Dialogs.Tests
 {
-    [TestClass]
     public class TestUtilities
     {
         private static string rootFolder = PathUtils.NormalizePath(@"..\..\..");


### PR DESCRIPTION
Addresses # 4096

> **Note:** This PR must be merged after the following xUnit Migration PRs (# 4624, # 4625, # 4630, # 4631).

## Description
This PR removes **MSTest** packages from [Microsoft.Bot.Builder.Dialogs.Tests](https://github.com/microsoft/botbuilder-dotnet/blob/main/tests/Microsoft.Bot.Builder.Dialogs.Tests/Microsoft.Bot.Builder.Dialogs.Tests.csproj#L23) project.

## Specific Changes
- Removed `MSTest` packages to `.csproj`.
- Removed `[TestClass]` from `TestUtilities`.