### PR TITLE
Add ObsoleteAttribute to AzureBlobTranscriptStore and AzureBlobStorage pointing to new 'blobs' classes

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Bot.Builder.Azure
     /// property value to the blob's ETag upon read. Afterward, an <see cref="AccessCondition"/> with the ETag value
     /// will be generated during Write. New entities start with a null ETag.
     /// </remarks>
+    [Obsolete("This class is deprecated. Please use BlobsStorage from Microsoft.Bot.Builder.Azure.Blobs instead.")]
     public class AzureBlobStorage : IStorage
     {
         private static readonly JsonSerializer JsonSerializer = JsonSerializer.Create(new JsonSerializerSettings

--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobTranscriptStore.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobTranscriptStore.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Bot.Builder.Azure
     /// Each activity is stored as json blob in structure of
     /// container/{channelId]/{conversationId}/{Timestamp.ticks}-{activity.id}.json.
     /// </remarks>
+    [Obsolete("This class is deprecated. Please use BlobsTranscriptStore from Microsoft.Bot.Builder.Azure.Blobs instead.")]
     public class AzureBlobTranscriptStore : ITranscriptStore
     {
         private static readonly JsonSerializer _jsonSerializer = JsonSerializer.Create(new JsonSerializerSettings()


### PR DESCRIPTION
Fixes # 4511

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
Adds ObsoleteAttribute to [AzureBlobTranscriptStore](https://github.com/microsoft/botbuilder-dotnet/blob/main/libraries/Microsoft.Bot.Builder.Azure/AzureBlobTranscriptStore.cs) and [AzureBlobStorage](https://github.com/microsoft/botbuilder-dotnet/blob/main/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs) classes, pointing to use [BlobsTranscriptStore](https://github.com/microsoft/botbuilder-dotnet/blob/main/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsTranscriptStore.cs) and [BlobsStorage](https://github.com/microsoft/botbuilder-dotnet/blob/main/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsStorage.cs) instead, which are in the new package [Microsoft.Bot.Builder.Azure.Blobs](https://www.nuget.org/packages/Microsoft.Bot.Builder.Azure.Blobs)

## Specific Changes
<!-- Please list the changes in a concise manner. -->
Added ObsoleteAttribute (`[Obsolete]()`) to [AzureBlobTranscriptStore](https://github.com/microsoft/botbuilder-dotnet/blob/main/libraries/Microsoft.Bot.Builder.Azure/AzureBlobTranscriptStore.cs) and [AzureBlobStorage](https://github.com/microsoft/botbuilder-dotnet/blob/main/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs) classes, with a message indicating to use [BlobsTranscriptStore](https://github.com/microsoft/botbuilder-dotnet/blob/main/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsTranscriptStore.cs) and [BlobsStorage](https://github.com/microsoft/botbuilder-dotnet/blob/main/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsStorage.cs) instead.