### PR TITLE
Write unit tests for BeginSkill

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Mocks/MockBotFrameworkClient.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Mocks/MockBotFrameworkClient.cs
@@ -11,7 +11,7 @@ using Microsoft.Bot.Schema;
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.Mocks
 {
     /// <summary>
-    /// MockBotFrameworkClient mock.
+    /// BotFrameworkClient mock.
     /// </summary>
     public class MockBotFrameworkClient : BotFrameworkClient
     {
@@ -20,7 +20,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.Mocks
         {
             var responseActivity = activity;
 
-            if (activity.Text == "skill")
+            if (activity.Text.Contains("skill"))
             {
                 responseActivity = new Activity()
                 {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Mocks/MockBotFrameworkClient.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Mocks/MockBotFrameworkClient.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright(c) Microsoft Corporation.All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -23,6 +26,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.Mocks
                 {
                     Type = "message",
                     Text = "This is the skill talking: hello"
+                };
+            }
+
+            if (activity.Text.Contains("end"))
+            {
+                responseActivity = new Activity()
+                {
+                    Type = "endOfConversation"
                 };
             }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Mocks/MockBotFrameworkClient.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Mocks/MockBotFrameworkClient.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Skills;
+using Microsoft.Bot.Schema;
+
+namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.Mocks
+{
+    /// <summary>
+    /// MockBotFrameworkClient mock.
+    /// </summary>
+    public class MockBotFrameworkClient : BotFrameworkClient
+    {
+        /// <inheritdoc/>
+        public override Task<InvokeResponse<T>> PostActivityAsync<T>(string fromBotId, string toBotId, Uri toUrl, Uri serviceUrl, string conversationId, Activity activity, CancellationToken cancellationToken = default)
+        {
+            var responseActivity = activity;
+
+            if (activity.Text == "skill")
+            {
+                responseActivity = new Activity()
+                {
+                    Type = "message",
+                    Text = "This is the skill talking: hello"
+                };
+            }
+
+            var response = new InvokeResponse<ExpectedReplies>()
+            {
+                Status = 200,
+                Body = new ExpectedReplies
+                {
+                    Activities = new List<Activity>()
+                    {
+                        responseActivity
+                    }
+                }
+            };
+
+            var casted = (InvokeResponse<T>)Convert.ChangeType(response, typeof(InvokeResponse<T>), new System.Globalization.CultureInfo("en-US"));
+            var result = Task.FromResult(casted);
+            return result;
+        }
+
+        /// <inheritdoc/>
+        /// <remarks>Not implemented.</remarks>
+        public override Task<InvokeResponse> PostActivityAsync(string fromBotId, string toBotId, Uri toUrl, Uri serviceUrl, string conversationId, Activity activity, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Mocks/MockSkillBotFrameworkClient.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Mocks/MockSkillBotFrameworkClient.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.Mocks
     /// <summary>
     /// BotFrameworkClient mock.
     /// </summary>
-    public class MockBotFrameworkClient : BotFrameworkClient
+    public class MockSkillBotFrameworkClient : BotFrameworkClient
     {
         /// <inheritdoc/>
         public override Task<InvokeResponse<T>> PostActivityAsync<T>(string fromBotId, string toBotId, Uri toUrl, Uri serviceUrl, string conversationId, Activity activity, CancellationToken cancellationToken = default)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/SetBotFrameworkClientMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/SetBotFrameworkClientMiddleware.cs
@@ -1,4 +1,7 @@
-﻿using System.Threading;
+﻿// Copyright(c) Microsoft Corporation.All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.Mocks;
 using Microsoft.Bot.Builder.Skills;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/SetBotFrameworkClientMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/SetBotFrameworkClientMiddleware.cs
@@ -10,7 +10,7 @@ using Microsoft.Bot.Schema;
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
 {
     /// <summary>
-    /// Middleware to add <see cref="MockBotFrameworkClient"/> to the  <see cref="ITurnContext.TurnState"/>.
+    /// Middleware to add <see cref="MockBotFrameworkClient"/> to the <see cref="ITurnContext.TurnState"/>.
     /// </summary>
     public class SetBotFrameworkClientMiddleware : IMiddleware
     {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/SetBotFrameworkClientMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/SetBotFrameworkClientMiddleware.cs
@@ -1,0 +1,25 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.Mocks;
+using Microsoft.Bot.Builder.Skills;
+using Microsoft.Bot.Schema;
+
+namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
+{
+    /// <summary>
+    /// Middleware to add <see cref="MockBotFrameworkClient"/> to the  <see cref="ITurnContext.TurnState"/>.
+    /// </summary>
+    public class SetBotFrameworkClientMiddleware : IMiddleware
+    {
+        /// <inheritdoc/>
+        public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken = default)
+        {
+            if (turnContext.Activity.Type == ActivityTypes.Message)
+            {
+                turnContext.TurnState.Add<BotFrameworkClient>(new MockBotFrameworkClient());
+            }
+
+            await next(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/SetSkillBotFrameworkClientMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/SetSkillBotFrameworkClientMiddleware.cs
@@ -10,16 +10,16 @@ using Microsoft.Bot.Schema;
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
 {
     /// <summary>
-    /// Middleware to add <see cref="MockBotFrameworkClient"/> to the <see cref="ITurnContext.TurnState"/>.
+    /// Middleware to add <see cref="MockSkillBotFrameworkClient"/> to the <see cref="ITurnContext.TurnState"/>.
     /// </summary>
-    public class SetBotFrameworkClientMiddleware : IMiddleware
+    public class SetSkillBotFrameworkClientMiddleware : IMiddleware
     {
         /// <inheritdoc/>
         public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken = default)
         {
             if (turnContext.Activity.Type == ActivityTypes.Message)
             {
-                turnContext.TurnState.Add<BotFrameworkClient>(new MockBotFrameworkClient());
+                turnContext.TurnState.Add<BotFrameworkClient>(new MockSkillBotFrameworkClient());
             }
 
             await next(cancellationToken).ConfigureAwait(false);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/SetSkillConversationIdFactoryBaseMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/SetSkillConversationIdFactoryBaseMiddleware.cs
@@ -1,0 +1,27 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Skills;
+using Microsoft.Bot.Schema;
+using Moq;
+
+namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
+{
+    /// <summary>
+    /// Middleware to add a mocked <see cref="SkillConversationIdFactoryBase"/> to the  <see cref="ITurnContext.TurnState"/>.
+    /// </summary>
+    public class SetSkillConversationIdFactoryBaseMiddleware : IMiddleware
+    {
+        /// <inheritdoc/>
+        public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken = default)
+        {
+            if (turnContext.Activity.Type == ActivityTypes.Message)
+            {
+                var mockSkillConversationIdFactoryBase = new Mock<SkillConversationIdFactoryBase>();
+                mockSkillConversationIdFactoryBase.SetupAllProperties();
+                turnContext.TurnState.Add(mockSkillConversationIdFactoryBase.Object);
+            }
+
+            await next(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/SetSkillConversationIdFactoryBaseMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/SetSkillConversationIdFactoryBaseMiddleware.cs
@@ -10,7 +10,7 @@ using Moq;
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
 {
     /// <summary>
-    /// Middleware to add a mocked <see cref="SkillConversationIdFactoryBase"/> to the  <see cref="ITurnContext.TurnState"/>.
+    /// Middleware to add a mocked <see cref="SkillConversationIdFactoryBase"/> to the <see cref="ITurnContext.TurnState"/>.
     /// </summary>
     public class SetSkillConversationIdFactoryBaseMiddleware : IMiddleware
     {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/SetSkillConversationIdFactoryBaseMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/SetSkillConversationIdFactoryBaseMiddleware.cs
@@ -1,4 +1,7 @@
-﻿using System.Threading;
+﻿// Copyright(c) Microsoft Corporation.All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Schema;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestScript.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestScript.cs
@@ -128,7 +128,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
                 .UseStorage(storage)
                 .UseBotState(userState, convoState)
                 .Use(new TranscriptLoggerMiddleware(new TraceTranscriptLogger(traceActivity: false)))
-                .Use(new SetTestOptionsMiddleware());
+                .Use(new SetTestOptionsMiddleware())
+                .Use(new SetSkillConversationIdFactoryBaseMiddleware())
+                .Use(new SetBotFrameworkClientMiddleware());
 
             adapter.OnTurnError += (context, err) => context.SendActivityAsync(err.Message);
             return adapter;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestScript.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestScript.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
                 .Use(new TranscriptLoggerMiddleware(new TraceTranscriptLogger(traceActivity: false)))
                 .Use(new SetTestOptionsMiddleware())
                 .Use(new SetSkillConversationIdFactoryBaseMiddleware())
-                .Use(new SetBotFrameworkClientMiddleware());
+                .Use(new SetSkillBotFrameworkClientMiddleware());
 
             adapter.OnTurnError += (context, err) => context.SendActivityAsync(err.Message);
             return adapter;

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
@@ -64,6 +64,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
         }
 
         [Fact]
+        public async Task Action_BeginSkillEndDialog()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
+
+        [Fact]
         public async Task Action_CancelDialog()
         {
             await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
@@ -58,6 +58,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
         }
 
         [Fact]
+        public async Task Action_BeginSkill()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
+
+        [Fact]
         public async Task Action_CancelDialog()
         {
             await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_BeginSkill.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_BeginSkill.test.dialog
@@ -1,0 +1,68 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "recognizer": {
+              "$kind": "Microsoft.RegexRecognizer",
+              "intents": [
+                  {
+                      "intent": "SkillIntent",
+                      "pattern": "skill"
+                  }
+              ]
+        },
+      "triggers": [
+        {
+          "$kind": "Microsoft.OnIntent",
+          "intent": "SkillIntent",
+          "actions": [
+            {
+              "$kind": "Microsoft.BeginSkill",
+              "BotId": "test-bot-id",
+              "SkillHostEndpoint": "http://localhost:3978/api/skills/",
+              "SkillEndpoint": "http://localhost:39782/api/messages",
+              "SkillAppId": "test-app-id",
+              "ConnectionName": "test-skill-connection-name",
+              "activity":{
+                "$kind": "Microsoft.StaticActivityTemplate",
+                "activity": {
+                  "type": "message",
+                  "text": "skill",
+                  "deliveryMode": "expectReplies"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "$kind": "Microsoft.OnUnknownIntent",
+          "actions": [
+            {
+              "$kind": "Microsoft.SendActivity",
+              "activity": "I'm a skill bot. To get started say 'skill'"
+            }
+          ]
+        }
+      ]
+    },
+  "script": [
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "hi"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "I'm a skill bot. To get started say 'skill'"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "skill"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "This is the skill talking: hello"
+    }
+  ]
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_BeginSkill.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_BeginSkill.test.dialog
@@ -5,64 +5,64 @@
         "$kind": "Microsoft.AdaptiveDialog",
         "id": "planningTest",
         "recognizer": {
-              "$kind": "Microsoft.RegexRecognizer",
-              "intents": [
-                  {
-                      "intent": "SkillIntent",
-                      "pattern": "skill"
-                  }
-              ]
-        },
-      "triggers": [
-        {
-          "$kind": "Microsoft.OnIntent",
-          "intent": "SkillIntent",
-          "actions": [
-            {
-              "$kind": "Microsoft.BeginSkill",
-              "BotId": "test-bot-id",
-              "SkillHostEndpoint": "http://localhost:3978/api/skills/",
-              "SkillEndpoint": "http://localhost:39782/api/messages",
-              "SkillAppId": "test-app-id",
-              "ConnectionName": "test-skill-connection-name",
-              "activity":{
-                "$kind": "Microsoft.StaticActivityTemplate",
-                "activity": {
-                  "type": "message",
-                  "text": "skill",
-                  "deliveryMode": "expectReplies"
+            "$kind": "Microsoft.RegexRecognizer",
+            "intents": [
+                {
+                    "intent": "SkillIntent",
+                    "pattern": "skill"
                 }
-              }
+            ]
+        },
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnIntent",
+                "intent": "SkillIntent",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.BeginSkill",
+                        "BotId": "test-bot-id",
+                        "SkillHostEndpoint": "http://localhost:3978/api/skills/",
+                        "SkillEndpoint": "http://localhost:39782/api/messages",
+                        "SkillAppId": "test-app-id",
+                        "ConnectionName": "test-skill-connection-name",
+                        "activity": {
+                            "$kind": "Microsoft.StaticActivityTemplate",
+                            "activity": {
+                                "type": "message",
+                                "text": "skill",
+                                "deliveryMode": "expectReplies"
+                            }
+                        }
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "I'm a skill bot. To get started say 'skill'"
+                    }
+                ]
             }
-          ]
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hi"
         },
         {
-          "$kind": "Microsoft.OnUnknownIntent",
-          "actions": [
-            {
-              "$kind": "Microsoft.SendActivity",
-              "activity": "I'm a skill bot. To get started say 'skill'"
-            }
-          ]
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "I'm a skill bot. To get started say 'skill'"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "skill"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "This is the skill talking: hello"
         }
-      ]
-    },
-  "script": [
-    {
-      "$kind": "Microsoft.Test.UserSays",
-      "text": "hi"
-    },
-    {
-      "$kind": "Microsoft.Test.AssertReply",
-      "text": "I'm a skill bot. To get started say 'skill'"
-    },
-    {
-      "$kind": "Microsoft.Test.UserSays",
-      "text": "skill"
-    },
-    {
-      "$kind": "Microsoft.Test.AssertReply",
-      "text": "This is the skill talking: hello"
-    }
-  ]
+    ]
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_BeginSkillEndDialog.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_BeginSkillEndDialog.test.dialog
@@ -1,0 +1,65 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "autoEndDialog": false,
+        "id": "planningTest",
+        "recognizer": {
+            "$kind": "Microsoft.RegexRecognizer",
+            "intents": [
+                {
+                    "intent": "SkillIntent",
+                    "pattern": "skill"
+                }
+            ]
+        },
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnIntent",
+                "autoEndDialog": false,
+                "intent": "SkillIntent",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.BeginSkill",
+                        "BotId": "test-bot-id",
+                        "SkillHostEndpoint": "http://localhost:3978/api/skills/",
+                        "SkillEndpoint": "http://localhost:39782/api/messages",
+                        "SkillAppId": "test-app-id",
+                        "ConnectionName": "test-skill-connection-name",
+                        "activity": {
+                            "$kind": "Microsoft.StaticActivityTemplate",
+                            "activity": {
+                                "type": "message",
+                                "text": "skill",
+                                "deliveryMode": "expectReplies"
+                            }
+                        }
+                    },
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "Success"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "skill"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "This is the skill talking: hello"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "end"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Success"
+        }
+    ]
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_BeginSkillEndDialog.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_BeginSkillEndDialog.test.dialog
@@ -27,6 +27,7 @@
                         "SkillEndpoint": "http://localhost:39782/api/messages",
                         "SkillAppId": "test-app-id",
                         "ConnectionName": "test-skill-connection-name",
+                        "AllowInterruptions": false,
                         "activity": {
                             "$kind": "Microsoft.StaticActivityTemplate",
                             "activity": {


### PR DESCRIPTION
Fixes # 3879

## Description
This PR adds two `BeginSkill` action tests using `.dialog` files and required middleware, adding up to a **78% code coverage**.

One case tests connecting to a mocked skill via `BeginDialogAsync` while the other one tests the `ContinueDialogAsync` and `EndDialogAsync` methods specifically.

## Specific Changes

  - Adds middleware classes `SetSkillBotFrameworkClientMiddleware`, `MockSkillBotFrameworkClient`, and `SetSkillConversationIdFactoryBaseMiddleware` and their references in `TestScript`
  - Adds two `.dialog` files and their corresponding `ActionTests` references.

## Testing
The following image shows the coverage increments achieved:
![image](https://user-images.githubusercontent.com/64803884/96182290-ab6c7200-0f0b-11eb-9c8b-7c5cebd3120b.png)
