### PR TITLE
[internal] Fixes southworks/add/BeginSkill-test

### DIFF
--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/SchemaMergeTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/SchemaMergeTests.cs
@@ -116,9 +116,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
                 if (!schema.StartsWith("http"))
                 {
                     Assert.True(File.Exists(Path.Combine(folder, PathUtils.NormalizePath(schema))), $"$schema {schema}");
-
-                    // Bug filed with Newtonsoft: https://stackoverflow.com/questions/63493078/why-does-validation-fail-in-code-but-work-in-newtonsoft-web-validator
+                    
                     // NOTE: Microsoft.SendActivity in the first file fails validation even though it is valid, same as Microsoft.StaticActivityTemplate on the last two.
+                    // Bug filed with Newtonsoft: https://stackoverflow.com/questions/63493078/why-does-validation-fail-in-code-but-work-in-newtonsoft-web-validator
                     var omit = new List<string>
                     {
                         "Action_SendActivity.test.dialog",

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/SchemaMergeTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/SchemaMergeTests.cs
@@ -117,9 +117,16 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
                 {
                     Assert.True(File.Exists(Path.Combine(folder, PathUtils.NormalizePath(schema))), $"$schema {schema}");
 
-                    // NOTE: Microsoft.SendActivity in this file fails validation even though it is valid.  
                     // Bug filed with Newtonsoft: https://stackoverflow.com/questions/63493078/why-does-validation-fail-in-code-but-work-in-newtonsoft-web-validator
-                    if (!fileResource.FullName.Contains("Action_SendActivity.test.dialog"))
+                    // NOTE: Microsoft.SendActivity in the first file fails validation even though it is valid, same as Microsoft.StaticActivityTemplate on the last two.
+                    var omit = new List<string>
+                    {
+                        "Action_SendActivity.test.dialog",
+                        "Action_BeginSkill.test.dialog",
+                        "Action_BeginSkillEndDialog.test.dialog"
+                    };
+
+                    if (!omit.Any(e => fileResource.FullName.Contains(e)))
                     {
                         jToken.Validate(Schema);
                     }


### PR DESCRIPTION
This change omits our dialog tests from the schema validation pool, making the pipeline succeed.

> We believe the schema validation comes up with a false negative. 
> Given that there is a precedent of omitting dialogs in the tet itself, we add our dialogs to it.

![image](https://user-images.githubusercontent.com/64803884/96737310-e818ed00-1393-11eb-8029-fab9d59d340d.png)
