### PR TITLE
[#4894] Binary compatibility checks need updating

### DIFF
--- a/build/yaml/ci-api-validation-steps.yml
+++ b/build/yaml/ci-api-validation-steps.yml
@@ -34,20 +34,20 @@ steps:
 - powershell: |
     $FileName = "$(Build.ArtifactStagingDirectory)\$(BotBuilderDll).$(ApiCompatVersion).CompatResults.txt"
     if (Test-Path $FileName) {
-        $FileContent = @(Get-Content $FileName)
-    
-        $FileContent[0] = $FileContent[0] + " compared against [version $(ApiCompatVersion)](https://www.nuget.org/packages/$(BotBuilderDll)/$(ApiCompatVersion))"
-          
-        if ($FileContent.Length -eq 1) {
-        [system.io.file]::WriteAllText($fileName,$FileContent)
-        } else {
-        Set-Content $fileName $FileContent
-        }
+      $FileContent = @(Get-Content $FileName)
+
+      $FileContent[0] = $FileContent[0] + " compared against [version $(ApiCompatVersion)](https://www.nuget.org/packages/$(BotBuilderDll)/$(ApiCompatVersion))"
         
-        Write-Host "The updated line 1: `n$FileContent[0]"
+      if ($FileContent.Length -eq 1) {
+        [system.io.file]::WriteAllText($fileName,$FileContent)
+      } else {
+        Set-Content $fileName $FileContent
+      }
+
+      Write-Host "The updated line 1: `n$FileContent[0]"
     } else {
-        $FileContent = The binary compatibility report for library '$(BotBuilderDll)' wasn't generated. This may have happened because the NuGet library '$(BotBuilderDll)' for version '$(ApiCompatVersion)' was unavailable or a connectivity issue.
-        New-Item -Path '$(Build.ArtifactStagingDirectory)' -Name '$(BotBuilderDll).$(ApiCompatVersion).CompatResults.txt' -ItemType "file" -Value $FileContent
+      $FileContent = The binary compatibility report for library '$(BotBuilderDll)' wasn't generated. This may have happened because the NuGet library '$(BotBuilderDll)' for version '$(ApiCompatVersion)' was unavailable or a connectivity issue.
+      New-Item -Path '$(Build.ArtifactStagingDirectory)' -Name '$(BotBuilderDll).$(ApiCompatVersion).CompatResults.txt' -ItemType "file" -Value $FileContent
     }
   displayName: 'Insert nuget link into ApiCompat results file.'
   condition: succeededOrFailed()

--- a/build/yaml/ci-api-validation-steps.yml
+++ b/build/yaml/ci-api-validation-steps.yml
@@ -32,19 +32,25 @@ steps:
     useBaseline: false
 
 - powershell: |
-   $FileName = "$(Build.ArtifactStagingDirectory)\$(BotBuilderDll).$(ApiCompatVersion).CompatResults.txt"
-   $FileContent = @(Get-Content $FileName)
+    $FileName = "$(Build.ArtifactStagingDirectory)\$(BotBuilderDll).$(ApiCompatVersion).CompatResults.txt"
+    if (Test-Path $FileName) {
+        $FileContent = @(Get-Content $FileName)
     
-   $FileContent[0] = $FileContent[0] + " compared against [version $(ApiCompatVersion)](https://www.nuget.org/packages/$(BotBuilderDll)/$(ApiCompatVersion))"
-    
-   if ($FileContent.Length -eq 1) {
-   [system.io.file]::WriteAllText($fileName,$FileContent)
-   } else {
-   Set-Content $fileName $FileContent
-   }
-   
-   Write-Host "The updated line 1: `n$FileContent[0]"
+        $FileContent[0] = $FileContent[0] + " compared against [version $(ApiCompatVersion)](https://www.nuget.org/packages/$(BotBuilderDll)/$(ApiCompatVersion))"
+          
+        if ($FileContent.Length -eq 1) {
+        [system.io.file]::WriteAllText($fileName,$FileContent)
+        } else {
+        Set-Content $fileName $FileContent
+        }
+        
+        Write-Host "The updated line 1: `n$FileContent[0]"
+    } else {
+        $FileContent = The binary compatibility report for library '$(BotBuilderDll)' wasn't generated. This may have happened because the NuGet library '$(BotBuilderDll)' for version '$(ApiCompatVersion)' was unavailable or a connectivity issue.
+        New-Item -Path '$(Build.ArtifactStagingDirectory)' -Name '$(BotBuilderDll).$(ApiCompatVersion).CompatResults.txt' -ItemType "file" -Value $FileContent
+    }
   displayName: 'Insert nuget link into ApiCompat results file.'
+  condition: succeededOrFailed()
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Compat Results artifact'


### PR DESCRIPTION
Fixes # 4894

## Description
The issue states that the report is not uploaded when the comparer fails, but we couldn't reproduce this issue.
Instead, we found that the report is not uploaded when any of the previous steps of the job fails.
The comparer is skipped when any previous step job fails, and no report is created.

The most likely step to fail is _NuGet install_, which downloads the library to be compared and can fail if it doesn't find it.

This PR introduces a default report file creation.
If the report file is not found, it will be created with the following text:

> The binary compatibility report for library LibraryName wasn't generated. This may have happened because the NuGet library LibraryName for version VersionNumber was unavailable or a connectivity issue.

## Specific Changes

  - Updates _Insert nuget link into ApiCompat results file_ to run always.
  - Adds to a file validation and default report file creation.

## Testing
Here we can see a test where the _NuGet install_ step failed and the report file was uploaded anyways:
![image](https://user-images.githubusercontent.com/64803884/98268785-b5621d80-1f6b-11eb-875c-e48a834fa38c.png)
