### PR TITLE
[#4022] Throwing Generic Exceptions - Adaptive Actions

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Actions/GetMeetingParticipant.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Actions/GetMeetingParticipant.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 
             if (dc.Context.Activity.ChannelId != Channels.Msteams)
             {
-                throw new Exception("TeamsInfo.GetMeetingParticipantAsync() works only on the Teams channel.");
+                throw new InvalidOperationException("TeamsInfo.GetMeetingParticipantAsync() works only on the Teams channel.");
             }
 
             string meetingId = GetValueOrNull(dc, this.MeetingId);
@@ -144,7 +144,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                 var (value, valueError) = stringExpression.TryGetValue(dc.State);
                 if (valueError != null)
                 {
-                    throw new Exception($"Expression evaluation resulted in an error. Expression: {stringExpression.ExpressionText}. Error: {valueError}");
+                    throw new InvalidOperationException($"Expression evaluation resulted in an error. Expression: \"{stringExpression.ExpressionText}\". Error: {valueError}");
                 }
 
                 return value as string;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Actions/AssertCondition.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Actions/AssertCondition.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.Actions
             if ((bool)result == false)
             {
                 var desc = Description?.GetValue(dc.State) ?? Condition.ToString();
-                throw new Exception(desc);
+                throw new InvalidOperationException(desc);
             }
 
             return await dc.EndDialogAsync().ConfigureAwait(false);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ActionScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ActionScope.cs
@@ -194,7 +194,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             else
             {
                 // we have not found the goto id.
-                throw new Exception($"GotoAction: could not find an action of '{actionScopeResult.ActionId}'.");
+                throw new ArgumentException($"GotoAction: could not find an action of \"{actionScopeResult.ActionId}\".");
             }
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BaseInvokeDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BaseInvokeDialog.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             // NOTE: we want the result of the expression as a string so we can look up the string using external FindDialog().
             var se = new StringExpression($"={this.Dialog.ExpressionText}");
             var dialogId = se.GetValue(dc.State);
-            return dc.FindDialog(dialogId ?? throw new Exception($"{this.Dialog.ToString()} not found."));
+            return dc.FindDialog(dialogId ?? throw new InvalidOperationException($"{this.Dialog.ToString()} not found."));
         }
 
         /// <summary>
@@ -123,7 +123,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 
                 if (error != null)
                 {
-                    throw new Exception(error);
+                    throw new InvalidOperationException($"Unable to get a value for \"{binding.Value}\" from state. {error}");
                 }
 
                 if (val != null)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/EditActions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/EditActions.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             }
             else
             {
-                throw new Exception("`EditActions` should only be used in the context of an adaptive dialog.");
+                throw new InvalidOperationException("`EditActions` should only be used in the context of an adaptive dialog.");
             }
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/EditArray.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/EditArray.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 
             if (this.ItemsProperty == null)
             {
-                throw new Exception($"EditArray: \"{changeType}\" operation couldn't be performed because the {nameof(ItemsProperty)} wasn't specified.");
+                throw new InvalidOperationException($"EditArray: \"{changeType}\" operation couldn't be performed because the {nameof(ItemsProperty)} wasn't specified.");
             }
 
             var property = this.ItemsProperty.GetValue(dc.State);
@@ -266,7 +266,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         {
             if (Value == null)
             {
-                throw new Exception($"EditArray: \"{ChangeType}\" operation couldn't be performed for array \"{ItemsProperty}\" because a value wasn't specified.");
+                throw new InvalidOperationException($"EditArray: \"{ChangeType}\" operation couldn't be performed for array \"{ItemsProperty}\" because a value wasn't specified.");
             }
         }
     }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/EndDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/EndDialog.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 
                 if (error != null)
                 {
-                    throw new Exception($"Expression evaluation resulted in an error. Expression: {this.Value.ToString()}. Error: {error}");
+                    throw new InvalidOperationException($"Expression evaluation resulted in an error. Expression: \"{this.Value.ToString()}\". Error: {error}");
                 }
 
                 if (result != null)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/GetActivityMembers.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/GetActivityMembers.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             var bfAdapter = dc.Context.Adapter as BotFrameworkAdapter;
             if (bfAdapter == null)
             {
-                throw new Exception("GetActivityMembers() only works with BotFrameworkAdapter");
+                throw new InvalidOperationException("GetActivityMembers() only works with BotFrameworkAdapter");
             }
 
             string id = dc.Context.Activity.Id;
@@ -95,7 +95,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                 var (value, valueError) = this.ActivityId.TryGetValue(dc.State);
                 if (valueError != null)
                 {
-                    throw new Exception($"Expression evaluation resulted in an error. Expression: {this.ActivityId}. Error: {valueError}");
+                    throw new InvalidOperationException($"Expression evaluation resulted in an error. Expression: \"{this.ActivityId}\". Error: {valueError}");
                 }
 
                 id = value as string;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/GetConversationMembers.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/GetConversationMembers.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             var bfAdapter = dc.Context.Adapter as BotFrameworkAdapter;
             if (bfAdapter == null)
             {
-                throw new Exception("GetActivityMembers() only works with BotFrameworkAdapter");
+                throw new InvalidOperationException("GetActivityMembers() only works with BotFrameworkAdapter");
             }
 
             var result = await bfAdapter.GetConversationMembersAsync(dc.Context, cancellationToken).ConfigureAwait(false);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SetProperties.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SetProperties.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                 var (val, valueError) = propValue.Value.TryGetValue(dc.State);
                 if (valueError != null)
                 {
-                    throw new Exception($"Expression evaluation resulted in an error. Expression: {propValue.Value.ToString()}. Error: {valueError}");
+                    throw new InvalidOperationException($"Expression evaluation resulted in an error. Expression: \"{propValue.Value.ToString()}\". Error: {valueError}");
                 }
 
                 if (val != null)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SetProperty.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SetProperty.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                 var (val, valueError) = this.Value.TryGetValue(dc.State);
                 if (valueError != null)
                 {
-                    throw new Exception($"Expression evaluation resulted in an error. Expression: {this.Value.ToString()}. Error: {valueError}");
+                    throw new InvalidOperationException($"Expression evaluation resulted in an error. Expression: \"{this.Value.ToString()}\". Error: {valueError}");
                 }
 
                 if (val != null)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ThrowException.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ThrowException.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                 value = this.ErrorValue.GetValue(dc.State);
             }
 
-            throw new Exception(value?.ToString());
+            throw new InvalidOperationException(value?.ToString());
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/TraceActivity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/TraceActivity.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                 var (val, valError) = this.Value.TryGetValue(dc.State);
                 if (valError != null)
                 {
-                    throw new Exception(valError);
+                    throw new InvalidOperationException($"Expression evaluation resulted in an error. Expression: \"{this.Value.ToString()}\". Error: {valError}");
                 }
 
                 value = val;

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_ThrowException.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_ThrowException.test.dialog
@@ -83,7 +83,7 @@
         },
         {
             "$kind": "Microsoft.Test.AssertReply",
-            "text": "System.Exception: This is an exception message."
+            "text": "System.InvalidOperationException: This is an exception message."
         },
         {
             "$kind": "Microsoft.Test.UserSays",


### PR DESCRIPTION
Addresses # 4022

## Description

This PR replaces all 17 generic exceptions found within the _Actions_ directory for `Dialogs.Adaptive`, `Dialogs.Adaptive.Teams`, and `Dialogs.Adaptive.Testing` libraries with proper exceptions according to the [Standard Exception Types](https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/using-standard-exception-types).

## Specific Changes

- Replaces all 17 generic exceptions within:
  - libraries\Microsoft.Bot.Builder.Dialogs.Adaptive\Actions
  - libraries\Microsoft.Bot.Builder.Dialogs.Adaptive.Teams\Actions\
  - libraries\Microsoft.Bot.Builder.Dialogs.Adaptive.Testing\Actions\
- Updates test `Action_ThrowException.test.dialog` to comply with the changes

## Testing
Here's a screenshot of the tests for these files working correctly with the changes applied:
![image](https://user-images.githubusercontent.com/64803884/98699021-6f370080-2355-11eb-9d97-ad7a14fed0bf.png)
