### PR TITLE
[#4022] Throwing Generic Exceptions - Adaptive Expressions

### DIFF
--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/TwilioNumberTests.cs
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/TwilioNumberTests.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Bot.Builder.FunctionalTests
                 return lastMessage;
             }
 
-            throw new Exception("Echo message not found");
+            throw new InvalidOperationException("Echo message not found");
         }
 
         private Dictionary<string, string> GetParameters(string message)

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioClientWrapper.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
             
             var twilioSignature = httpRequest.Headers.ContainsKey(TwilioSignature)
                 ? httpRequest.Headers[TwilioSignature].ToString()
-                : throw new Exception($"HttpRequest is missing \"{TwilioSignature}\"");
+                : throw new ArgumentNullException($"HttpRequest is missing \"{TwilioSignature}\"");
 
             if (string.IsNullOrWhiteSpace(urlString))
             {

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Accessor.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Accessor.cs
@@ -53,17 +53,17 @@ namespace AdaptiveExpressions.BuiltinFunctions
                 || !(children[0] is Constant cnst)
                 || cnst.ReturnType != ReturnType.String)
             {
-                throw new Exception($"{expression} must have a string as first argument.");
+                throw new ArgumentException($"{expression} must have a string as first argument.");
             }
 
             if (children.Length > 2)
             {
-                throw new Exception($"{expression} has more than 2 children.");
+                throw new ArgumentException($"{expression} has more than 2 children.");
             }
 
             if (children.Length == 2 && (children[1].ReturnType & ReturnType.Object) == 0)
             {
-                throw new Exception($"{expression} must have an object as its second argument.");
+                throw new ArgumentException($"{expression} must have an object as its second argument.");
             }
         }
     }

--- a/libraries/AdaptiveExpressions/Memory/StackedMemory.cs
+++ b/libraries/AdaptiveExpressions/Memory/StackedMemory.cs
@@ -78,7 +78,7 @@ namespace AdaptiveExpressions.Memory
         /// <param name="value">Value to set.</param>
         public void SetValue(string path, object value)
         {
-            throw new Exception($"Can't set value to {path}, stacked memory is read-only");
+            throw new InvalidOperationException($"Can't set value to {path}, stacked memory is read-only");
         }
 
         /// <summary>

--- a/libraries/AdaptiveExpressions/RegexErrorListener.cs
+++ b/libraries/AdaptiveExpressions/RegexErrorListener.cs
@@ -13,7 +13,7 @@ namespace AdaptiveExpressions
 
         public override void SyntaxError(TextWriter output, IRecognizer recognizer, IToken offendingSymbol, int line, int charPositionInLine, string msg, RecognitionException e)
         {
-            throw new Exception($"Regular expression is invalid.");
+            throw new InvalidOperationException($"Regular expression is invalid.");
         }
     }
 }

--- a/libraries/AdaptiveExpressions/parser/ExpressionParser.cs
+++ b/libraries/AdaptiveExpressions/parser/ExpressionParser.cs
@@ -196,7 +196,7 @@ namespace AdaptiveExpressions
                     return Expression.ConstantExpression(doubleValue);
                 }
 
-                throw new Exception($"{context.GetText()} is not a number in expression '{context.GetText()}'");
+                throw new ArgumentException($"{context.GetText()} is not a number in expression \"{context.GetText()}\"");
             }
 
             public override Expression VisitParenthesisExp([NotNull] ExpressionAntlrParser.ParenthesisExpContext context) => Visit(context.expression());
@@ -220,7 +220,7 @@ namespace AdaptiveExpressions
                 }
                 else
                 {
-                    throw new Exception($"Invalid string {text}");
+                    throw new ArgumentException($"Invalid string {text}");
                 }
 
                 return Expression.ConstantExpression(EvalEscape(text));

--- a/libraries/Microsoft.Bot.Builder/Adapters/TestAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/Adapters/TestAdapter.cs
@@ -866,7 +866,7 @@ namespace Microsoft.Bot.Builder.Adapters
             {
                 if (token == ExceptionExpected)
                 {
-                    throw new Exception("Exception occurred during exchanging tokens");
+                    throw new InvalidOperationException("Exception occurred during exchanging tokens");
                 }
 
                 return Task.FromResult(new TokenResponse()

--- a/libraries/Microsoft.Bot.Builder/Adapters/TestFlow.cs
+++ b/libraries/Microsoft.Bot.Builder/Adapters/TestFlow.cs
@@ -287,7 +287,7 @@ namespace Microsoft.Bot.Builder.Adapters
                     {
                         if (!equalityComparer.Equals(expected, reply))
                         {
-                            throw new ArgumentException($"Expected:{expected}\nReceived:{reply}");
+                            throw new InvalidOperationException($"Expected:{expected}\nReceived:{reply}");
                         }
                     }
                     else

--- a/libraries/Microsoft.Bot.Builder/Adapters/TestFlow.cs
+++ b/libraries/Microsoft.Bot.Builder/Adapters/TestFlow.cs
@@ -234,12 +234,12 @@ namespace Microsoft.Bot.Builder.Adapters
                     {
                         if (description == null)
                         {
-                            throw new ArgumentException(
+                            throw new InvalidOperationException(
                                 $"Expected:{expected}\nReceived:{replyAsMessageActivity?.Text ?? "Not a Message Activity"}");
                         }
                         else
                         {
-                            throw new ArgumentException(
+                            throw new InvalidOperationException(
                                 $"{description}:\nExpected:{expected}\nReceived:{replyAsMessageActivity?.Text ?? "Not a Message Activity"}");
                         }
                     }
@@ -280,7 +280,7 @@ namespace Microsoft.Bot.Builder.Adapters
                     description = description ?? expected.AsMessageActivity()?.Text.Trim();
                     if (expected.Type != reply.Type)
                     {
-                        throw new ArgumentException($"{description}: Type should match");
+                        throw new InvalidOperationException($"{description}: Type should match");
                     }
 
                     if (equalityComparer != null)
@@ -296,11 +296,11 @@ namespace Microsoft.Bot.Builder.Adapters
                         {
                             if (description == null)
                             {
-                                throw new ArgumentException($"Expected:{expected.AsMessageActivity().Text}\nReceived:{reply.AsMessageActivity().Text}");
+                                throw new InvalidOperationException($"Expected:{expected.AsMessageActivity().Text}\nReceived:{reply.AsMessageActivity().Text}");
                             }
                             else
                             {
-                                throw new ArgumentException($"{description}:\nExpected:{expected.AsMessageActivity().Text}\nReceived:{reply.AsMessageActivity().Text}");
+                                throw new InvalidOperationException($"{description}:\nExpected:{expected.AsMessageActivity().Text}\nReceived:{reply.AsMessageActivity().Text}");
                             }
                         }
                     }
@@ -530,7 +530,7 @@ namespace Microsoft.Bot.Builder.Adapters
                         }
                     }
 
-                    throw new ArgumentException(description ?? $"Text \"{text}\" does not match one of candidates: {string.Join("\n", candidates)}");
+                    throw new InvalidOperationException(description ?? $"Text \"{text}\" does not match one of candidates: {string.Join("\n", candidates)}");
                 },
                 description,
                 timeout);

--- a/libraries/Microsoft.Bot.Builder/Adapters/TestFlow.cs
+++ b/libraries/Microsoft.Bot.Builder/Adapters/TestFlow.cs
@@ -234,12 +234,12 @@ namespace Microsoft.Bot.Builder.Adapters
                     {
                         if (description == null)
                         {
-                            throw new Exception(
+                            throw new ArgumentException(
                                 $"Expected:{expected}\nReceived:{replyAsMessageActivity?.Text ?? "Not a Message Activity"}");
                         }
                         else
                         {
-                            throw new Exception(
+                            throw new ArgumentException(
                                 $"{description}:\nExpected:{expected}\nReceived:{replyAsMessageActivity?.Text ?? "Not a Message Activity"}");
                         }
                     }
@@ -280,14 +280,14 @@ namespace Microsoft.Bot.Builder.Adapters
                     description = description ?? expected.AsMessageActivity()?.Text.Trim();
                     if (expected.Type != reply.Type)
                     {
-                        throw new Exception($"{description}: Type should match");
+                        throw new ArgumentException($"{description}: Type should match");
                     }
 
                     if (equalityComparer != null)
                     {
                         if (!equalityComparer.Equals(expected, reply))
                         {
-                            throw new Exception($"Expected:{expected}\nReceived:{reply}");
+                            throw new ArgumentException($"Expected:{expected}\nReceived:{reply}");
                         }
                     }
                     else
@@ -296,11 +296,11 @@ namespace Microsoft.Bot.Builder.Adapters
                         {
                             if (description == null)
                             {
-                                throw new Exception($"Expected:{expected.AsMessageActivity().Text}\nReceived:{reply.AsMessageActivity().Text}");
+                                throw new ArgumentException($"Expected:{expected.AsMessageActivity().Text}\nReceived:{reply.AsMessageActivity().Text}");
                             }
                             else
                             {
-                                throw new Exception($"{description}:\nExpected:{expected.AsMessageActivity().Text}\nReceived:{reply.AsMessageActivity().Text}");
+                                throw new ArgumentException($"{description}:\nExpected:{expected.AsMessageActivity().Text}\nReceived:{reply.AsMessageActivity().Text}");
                             }
                         }
                     }
@@ -365,7 +365,7 @@ namespace Microsoft.Bot.Builder.Adapters
                         if (replyActivity != null)
                         {
                             // if we have a reply
-                            throw new Exception($"{replyActivity.ToString()} is repsonded when waiting for no reply:'{description}'");
+                            throw new InvalidOperationException($"{replyActivity.ToString()} is responded when waiting for no reply:'{description}'");
                         }
                     }
                     catch (TaskCanceledException)
@@ -530,7 +530,7 @@ namespace Microsoft.Bot.Builder.Adapters
                         }
                     }
 
-                    throw new Exception(description ?? $"Text \"{text}\" does not match one of candidates: {string.Join("\n", candidates)}");
+                    throw new ArgumentException(description ?? $"Text \"{text}\" does not match one of candidates: {string.Join("\n", candidates)}");
                 },
                 description,
                 timeout);

--- a/libraries/Microsoft.Bot.Builder/MemoryStorage.cs
+++ b/libraries/Microsoft.Bot.Builder/MemoryStorage.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Bot.Builder
                                 &&
                            newStoreItem.ETag != oldStateETag)
                         {
-                            throw new Exception($"Etag conflict.\r\n\r\nOriginal: {newStoreItem.ETag}\r\nCurrent: {oldStateETag}");
+                            throw new ArgumentException($"Etag conflict.\r\n\r\nOriginal: {newStoreItem.ETag}\r\nCurrent: {oldStateETag}");
                         }
 
                         newState["eTag"] = (_eTag++).ToString(CultureInfo.InvariantCulture);

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotMessageHandlerBase.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotMessageHandlerBase.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi.Handlers
                         }
                         catch (Exception exception)
                         {
-                            throw new Exception($"An exception occurred attempting to resolve an {nameof(IBot)} service via the dependency resolver. Please check the inner exception for more details.", exception);
+                            throw new InvalidOperationException($"An exception occurred attempting to resolve an {nameof(IBot)} service via the dependency resolver. Please check the inner exception for more details.", exception);
                         }
 
                         if (bot == null)

--- a/tests/Microsoft.Bot.Builder.Tests/Adapters/TestFlowTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Adapters/TestFlowTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Bot.Builder.Tests.Adapters
             const string exceptionDescription = "Description message";
             const string stringThatNotSubstring = "some string";
             var message = "Just a sample string".Replace(stringThatNotSubstring, string.Empty);
-            await Assert.ThrowsAsync<Exception>(async () =>
+            await Assert.ThrowsAsync<ArgumentException>(async () =>
             {
                 await new TestFlow(new TestAdapter(), async (turnContext, cancellationToken) =>
                     {
@@ -79,7 +79,7 @@ namespace Microsoft.Bot.Builder.Tests.Adapters
         {
             const string exceptionDescription = "Description message";
             const string message = "Just a sample string";
-            await Assert.ThrowsAsync<Exception>(async () =>
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
                 await new TestFlow(new TestAdapter(), async (turnContext, cancellationToken) =>
                     {

--- a/tests/Microsoft.Bot.Builder.Tests/Adapters/TestFlowTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Adapters/TestFlowTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Bot.Builder.Tests.Adapters
             const string exceptionDescription = "Description message";
             const string stringThatNotSubstring = "some string";
             var message = "Just a sample string".Replace(stringThatNotSubstring, string.Empty);
-            await Assert.ThrowsAsync<ArgumentException>(async () =>
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
                 await new TestFlow(new TestAdapter(), async (turnContext, cancellationToken) =>
                     {


### PR DESCRIPTION
Addresses # 4022

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
This PR replaces all the generic expressions in `AdaptiveExpressions`, `Adapters`, `integration`, `FunctionalTests`, and part of `BotBuilder` libraries. Also, updates the affected testes to assert the proper exception.

## Specific Changes
Replaced generic exceptions in:
- FunctionalTests
- libraries\Adapters
- libraries\AdaptiveExpressions
- libraries\integration
- libraries\Microsoft.Bot.Builder\Adapters

Updated tests to assert proper exception:
- tests\Microsoft.Bot.Builder.Tests\Adapters\TestFlowTests.cs

## Testing
![image](https://user-images.githubusercontent.com/38112957/98693082-9938f480-234e-11eb-8304-93d11e2dafaa.png)
