### PR TITLE
[#4022] Throwing Generic Exceptions - Azure

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.Orchestrator/OrchestratorAdaptiveRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.Orchestrator/OrchestratorAdaptiveRecognizer.cs
@@ -314,7 +314,7 @@ namespace Microsoft.Bot.Builder.AI.Orchestrator
                 }
                 catch (Exception ex)
                 {
-                    throw new Exception("Failed to find or load Model", ex);
+                    throw new InvalidOperationException("Failed to find or load Model", ex);
                 }
             }
 

--- a/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsStorage.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
                 when (ex.Status == (int)HttpStatusCode.BadRequest
                 && ex.ErrorCode == BlobErrorCode.InvalidBlockList)
                 {
-                    throw new Exception(
+                    throw new InvalidOperationException(
                         $"An error occurred while trying to write an object. The underlying '{BlobErrorCode.InvalidBlockList}' error is commonly caused due to concurrently uploading an object larger than 128MB in size.",
                         ex);
                 }

--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Bot.Builder.Azure
                 when (ex.RequestInformation.HttpStatusCode == (int)HttpStatusCode.BadRequest
                 && ex.RequestInformation.ErrorCode == BlobErrorCodeStrings.InvalidBlockList)
                 {
-                    throw new Exception(
+                    throw new InvalidOperationException(
                         $"An error ocurred while trying to write an object. The underlying '{BlobErrorCodeStrings.InvalidBlockList}' error is commonly caused due to concurrently uploading an object larger than 128MB in size.",
                         ex);
                 }

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
@@ -222,7 +222,7 @@ namespace Microsoft.Bot.Builder.Azure
                 }
                 else
                 {
-                    throw new Exception("etag empty");
+                    throw new ArgumentException("etag empty");
                 }
             }
         }

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
@@ -320,7 +320,7 @@ namespace Microsoft.Bot.Builder.Azure
                 }
                 else
                 {
-                    throw new Exception("etag empty");
+                    throw new ArgumentException("etag empty");
                 }
             }
         }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                 var dialog = FindDialog(dialogId);
                 if (dialog == null)
                 {
-                    throw new Exception(
+                    throw new ArgumentException(
                         $"DialogContext.BeginDialogAsync(): A dialog with an id of '{dialogId}' wasn't found." +
                         " The dialog must be included in the current or parent DialogSet." +
                         " For example, if subclassing a ComponentDialog you can call AddDialog() within your constructor.");
@@ -287,7 +287,7 @@ namespace Microsoft.Bot.Builder.Dialogs
 
                     if (dialog == null)
                     {
-                        throw new Exception($"Failed to continue dialog. A dialog with id {this.ActiveDialog.Id} could not be found.");
+                        throw new InvalidOperationException($"Failed to continue dialog. A dialog with id {this.ActiveDialog.Id} could not be found.");
                     }
 
                     // Continue dialog execution
@@ -353,7 +353,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                     var dialog = this.FindDialog(ActiveDialog.Id);
                     if (dialog == null)
                     {
-                        throw new Exception($"DialogContext.EndDialogAsync(): Can't resume previous dialog. A dialog with an id of '{ActiveDialog.Id}' wasn't found.");
+                        throw new InvalidOperationException($"DialogContext.EndDialogAsync(): Can't resume previous dialog. A dialog with an id of '{ActiveDialog.Id}' wasn't found.");
                     }
 
                     // Return result to previous dialog
@@ -540,7 +540,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                         var dialog = this.FindDialog(ActiveDialog.Id);
                         if (dialog == null)
                         {
-                            throw new Exception($"DialogSet.RepromptDialogAsync(): Can't find A dialog with an id of '{ActiveDialog.Id}'.");
+                            throw new InvalidOperationException($"DialogSet.RepromptDialogAsync(): Can't find A dialog with an id of '{ActiveDialog.Id}'.");
                         }
 
                         // Ask dialog to re-prompt if supported

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogStateManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogStateManager.cs
@@ -344,7 +344,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
         {
             if (value is Task)
             {
-                throw new Exception($"{path} = You can't pass an unresolved Task to SetValue");
+                throw new ArgumentException($"{path} = You can't pass an unresolved Task to SetValue");
             }
 
             if (value != null)

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/DialogMemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/DialogMemoryScope.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
                 dc.ActiveDialog.State = (IDictionary<string, object>)memory;
             }
 
-            throw new Exception("Cannot set DialogMemoryScope. There is no active dialog dialog or parent dialog in the context");
+            throw new InvalidOperationException("Cannot set DialogMemoryScope. There is no active dialog dialog or parent dialog in the context");
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/DialogMemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/DialogMemoryScope.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
                 dc.ActiveDialog.State = (IDictionary<string, object>)memory;
             }
 
-            throw new InvalidOperationException("Cannot set DialogMemoryScope. There is no active dialog dialog or parent dialog in the context");
+            throw new InvalidOperationException("Cannot set DialogMemoryScope. There is no active dialog or parent dialog in the context");
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/WaterfallStepContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/WaterfallStepContext.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             // Ensure next hasn't been called
             if (_nextCalled)
             {
-                throw new Exception($"WaterfallStepContext.NextAsync(): method already called for dialog and step '{_parentWaterfall.Id}[{Index}]'.");
+                throw new InvalidOperationException($"WaterfallStepContext.NextAsync(): method already called for dialog and step '{_parentWaterfall.Id}[{Index}]'.");
             }
 
             // Trigger next step

--- a/libraries/Microsoft.Bot.Builder/Streaming/StreamingHttpClient.cs
+++ b/libraries/Microsoft.Bot.Builder/Streaming/StreamingHttpClient.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Bot.Builder.Streaming
 
                 if (serverResponse == null)
                 {
-                    throw new Exception("Server response from streaming request is null");
+                    throw new InvalidOperationException("Server response from streaming request is null");
                 }
 
                 if (serverResponse.StatusCode == (int)HttpStatusCode.OK)

--- a/libraries/Microsoft.Bot.Builder/Streaming/StreamingRequestHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/Streaming/StreamingRequestHandler.cs
@@ -383,7 +383,7 @@ namespace Microsoft.Bot.Builder.Streaming
             {
                 if (!_serverIsConnected)
                 {
-                    throw new Exception("Error while attempting to send: Streaming transport is disconnected.");
+                    throw new InvalidOperationException("Error while attempting to send: Streaming transport is disconnected.");
                 }
 
                 var serverResponse = await _server.SendAsync(request, cancellationToken).ConfigureAwait(false);
@@ -415,7 +415,7 @@ namespace Microsoft.Bot.Builder.Streaming
             {
                 if (!_serverIsConnected)
                 {
-                    throw new Exception("Error while attempting to send: Streaming transport is disconnected.");
+                    throw new InvalidOperationException("Error while attempting to send: Streaming transport is disconnected.");
                 }
 
                 var serverResponse = await _server.SendAsync(request, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Addresses # 4022

## Description

This PR replaces all 15 generic exceptions found within the _Streaming_ directory of `Bot.Builder` and the libraries `AI.Orchestrator`, `Azure`, and `Dialogs` with proper exceptions according to the [Standard Exception Types](https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/using-standard-exception-types).

## Specific Changes

- Replaces all 15 generic exceptions within:
  - libraries\Microsoft.Bot.Builder\Streaming\
  - libraries\Microsoft.Bot.Builder.AI.Orchestrator\
  - libraries\Microsoft.Bot.Builder.Azure\
  - libraries\Microsoft.Bot.Builder.Dialogs\

## Testing
Here's a screenshot of the tests for these files working correctly with the changes applied:
![image](https://user-images.githubusercontent.com/64803884/98708031-7531df00-235f-11eb-924c-bc3555d02139.png)
