### PR TITLE
[#4022] Throwing Generic Exceptions - Dialogs Adaptive Inputs

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/LanguageGeneratorManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/LanguageGeneratorManager.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
                 var resource = resources.FirstOrDefault(u => LGResourceLoader.ParseLGFileName(u.Id).prefix.ToLowerInvariant() == LGResourceLoader.ParseLGFileName(resourceName).prefix.ToLowerInvariant());
                 if (resource == null)
                 {
-                    throw new Exception($"There is no matching LG resource for {resourceName}");
+                    throw new InvalidOperationException($"There is no matching LG resource for {resourceName}");
                 }
                 else
                 {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/MultiLanguageGeneratorBase.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/MultiLanguageGeneratorBase.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
 
             if (fallbackLocales.Count == 0)
             {
-                throw new Exception($"No supported language found for {targetLocale}");
+                throw new InvalidOperationException($"No supported language found for {targetLocale}");
             }
 
             var generators = new List<LanguageGenerator>();
@@ -91,7 +91,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
 
             if (generators.Count == 0)
             {
-                throw new Exception($"No generator found for language {targetLocale}");
+                throw new InvalidOperationException($"No generator found for language {targetLocale}");
             }
 
             var errors = new List<string>();
@@ -109,7 +109,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
                 }
             }
 
-            throw new Exception(string.Join(",\n", errors.Distinct()));
+            throw new InvalidOperationException(string.Join(",\n", errors.Distinct()));
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/TemplateEngineLanguageGenerator.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/TemplateEngineLanguageGenerator.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
             {
                 if (!string.IsNullOrEmpty(this.Id))
                 {
-                    throw new Exception($"{Id}:{err.Message}");
+                    throw new InvalidOperationException($"{Id}:{err.Message}");
                 }
 
                 throw;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInput.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
                 var (choices, error) = this.Choices.TryGetValue(dc.State);
                 if (error != null)
                 {
-                    throw new Exception(error);
+                    throw new ArgumentException(error);
                 }
 
                 op.Choices = choices;
@@ -224,7 +224,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             var (choices, error) = this.Choices.TryGetValue(dc.State);
             if (error != null)
             {
-                throw new Exception(error);
+                throw new InvalidOperationException(error);
             }
 
             return this.AppendChoices(prompt.AsMessageActivity(), channelId, choices, this.Style.GetValue(dc.State), choiceOptions);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInput.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
                 var (choices, error) = this.Choices.TryGetValue(dc.State);
                 if (error != null)
                 {
-                    throw new ArgumentException(error);
+                    throw new InvalidOperationException(error);
                 }
 
                 op.Choices = choices;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ConfirmInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ConfirmInput.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
                             }
                             else
                             {
-                                throw new Exception($"OutputFormat Expression evaluation resulted in an error. Expression: {OutputFormat.ToString()}. Error: {error}");
+                                throw new InvalidOperationException($"OutputFormat Expression evaluation resulted in an error. Expression: {OutputFormat.ToString()}. Error: {error}");
                             }
                         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/DateTimeInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/DateTimeInput.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
                     }
                     else
                     {
-                        throw new Exception($"OutputFormat Expression evaluation resulted in an error. Expression: {this.OutputFormat}. Error: {error}");
+                        throw new InvalidOperationException($"OutputFormat Expression evaluation resulted in an error. Expression: {this.OutputFormat}. Error: {error}");
                     }
                 }
             }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
@@ -506,7 +506,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
                 var (value, valueError) = this.Value.TryGetValue(dc.State);
                 if (valueError != null)
                 {
-                    throw new Exception($"In InputDialog, this.Value expression evaluation resulted in an error. Expression: {this.Value}. Error: {valueError}");
+                    throw new InvalidOperationException($"In InputDialog, this.Value expression evaluation resulted in an error. Expression: {this.Value}. Error: {valueError}");
                 }
 
                 input = value;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/NumberInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/NumberInput.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
                 }
                 else
                 {
-                    throw new Exception($"In TextInput, OutputFormat Expression evaluation resulted in an error. Expression: {this.OutputFormat}. Error: {error}");
+                    throw new InvalidOperationException($"In TextInput, OutputFormat Expression evaluation resulted in an error. Expression: {this.OutputFormat}. Error: {error}");
                 }
             }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/TextInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/TextInput.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
                 }
                 else
                 {
-                    throw new Exception($"In TextInput, OutputFormat Expression evaluation resulted in an error. Expression: {OutputFormat.ToString()}. Error: {error}");
+                    throw new InvalidOperationException($"In TextInput, OutputFormat Expression evaluation resulted in an error. Expression: {OutputFormat.ToString()}. Error: {error}");
                 }
             }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/LGResourceLoader.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/LGResourceLoader.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
                 return string.Empty;
             }
 
-            throw new Exception($"there is no locale fallback for {locale}");
+            throw new InvalidOperationException($"there is no locale fallback for {locale}");
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnCondition.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnCondition.cs
@@ -236,7 +236,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
                 }
                 catch (Exception e)
                 {
-                    throw new Exception($"Invalid constraint expression: {this.Condition}, {e.Message}");
+                    throw new InvalidOperationException($"Invalid constraint expression: {this.Condition}, {e.Message}");
                 }
             }
         }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/LGGeneratorTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/LGGeneratorTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             Assert.Equal("from c.en.lg", result);
 
             // there is no 'greeting' template in b.en-us.lg, no more fallback to b.lg
-            var ex = await Assert.ThrowsAsync<Exception>(async () => await generator.GenerateAsync(GetDialogContext(), "${greeting()}", null));
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () => await generator.GenerateAsync(GetDialogContext(), "${greeting()}", null));
             Assert.Contains("greeting does not have an evaluator", ex.Message);
 
             resource = resourceExplorer.GetResource("a.lg") as FileResource;


### PR DESCRIPTION
Addresses # 4022

## Description
This PR replaces all the generic expressions in `Dialogs.Adaptive` root, Generators, Input, and TriggerConditions folders.

## Specific Changes
Replaced generic exceptions in:
- `Dialogs.Adaptive` library.
  - Root folder.
  - Input folder.
  - Generators folder.
  - TriggersConditions folder.

No tests required updates.

## Testing
![image](https://user-images.githubusercontent.com/38112957/98710803-e757f300-2362-11eb-8124-0ce6babf83d0.png)