### PR TITLE
[#3905] Replace AsyncUsageAnalyzers with Microsoft.VisualStudio.Threading

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackClientWrapper.cs
@@ -50,7 +50,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
             }
 
             _api = new SlackTaskClient(options.SlackBotToken);
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             LoginWithSlackAsync(default).Wait();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         }
 
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexClientWrapper.cs
@@ -147,8 +147,12 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
             var encoding = new ASCIIEncoding();
             var bytes = encoding.GetBytes(parsedContent);
 
+#pragma warning disable VSTHRD103 // Call async methods when in an async method
             var newStream = http.GetRequestStream();
+#pragma warning restore VSTHRD103 // Call async methods when in an async method
+#pragma warning disable VSTHRD103 // Call async methods when in an async method
             newStream.Write(bytes, 0, bytes.Length);
+#pragma warning restore VSTHRD103 // Call async methods when in an async method
             newStream.Close();
 
             var response = await http.GetResponseAsync().ConfigureAwait(false);

--- a/libraries/Directory.Build.props
+++ b/libraries/Directory.Build.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.8.55">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsTranscriptStore.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsTranscriptStore.cs
@@ -71,7 +71,11 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
                     if (!_checkedContainers.Contains(containerName))
                     {
                         _checkedContainers.Add(containerName);
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
+#pragma warning disable VSTHRD011 // Use AsyncLazy<T>
                         containerClient.CreateIfNotExistsAsync().Wait();
+#pragma warning restore VSTHRD011 // Use AsyncLazy<T>
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
                     }
 
                     return containerClient;

--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
@@ -199,7 +199,9 @@ namespace Microsoft.Bot.Builder.Azure
                     using (var streamWriter = new StreamWriter(memoryStream))
                     {
                         _jsonSerializer.Serialize(streamWriter, newValue);
+#pragma warning disable VSTHRD103 // Call async methods when in an async method
                         streamWriter.Flush();
+#pragma warning restore VSTHRD103 // Call async methods when in an async method
                         memoryStream.Seek(0, SeekOrigin.Begin);
                         await blobReference.UploadFromStreamAsync(memoryStream, accessCondition, blobRequestOptions, operationContext, cancellationToken).ConfigureAwait(false);
                     }

--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobTranscriptStore.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobTranscriptStore.cs
@@ -69,7 +69,11 @@ namespace Microsoft.Bot.Builder.Azure
                 if (!_checkedContainers.Contains(containerName))
                 {
                     _checkedContainers.Add(containerName);
+#pragma warning disable VSTHRD011 // Use AsyncLazy<T>
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
                     container.CreateIfNotExistsAsync().Wait();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
+#pragma warning restore VSTHRD011 // Use AsyncLazy<T>
                 }
 
                 return container;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Converters/JObjectConverter.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Converters/JObjectConverter.cs
@@ -41,7 +41,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Converters
             if (resourceExplorer.IsRef(jsonObject))
             {
                 // We can't do this asynchronously as the Json.NET interface is synchronous
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
                 jsonObject = resourceExplorer.ResolveRefAsync(jsonObject, sourceContext).GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
             }
 
             return jsonObject as JObject;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/LanguageGeneratorManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/LanguageGeneratorManager.cs
@@ -75,7 +75,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
                 }
                 else
                 {
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
                     var content = resource.ReadTextAsync().GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
                     return new LGResource(resource.Id, resource.FullName, content);
                 }
             };

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/TemplateEngineLanguageGenerator.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/TemplateEngineLanguageGenerator.cs
@@ -95,7 +95,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
 
             var (_, locale) = LGResourceLoader.ParseLGFileName(Id);
             var importResolver = LanguageGeneratorManager.ResourceExplorerResolver(locale, resourceMapping);
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             var content = resource.ReadTextAsync().GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
             var lgResource = new LGResource(Id, resource.FullName, content);
             this.lg = LanguageGeneration.Templates.ParseResource(lgResource, importResolver);
             RegisterSourcemap(lg, resource);
@@ -145,7 +147,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
             TaskFactory.StartNew(() =>
             {
                 return func();
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             }).Unwrap().GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
 #pragma warning restore CA2008 // Do not create tasks without passing a TaskScheduler
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Base/ActiveObject.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Base/ActiveObject.cs
@@ -29,7 +29,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging.Base
 
         public void Dispose()
         {
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             DisposeAsync().GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         }
 
         public async Task DisposeAsync()
@@ -39,12 +41,16 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging.Base
 
             // dispose all owned objects
             using (_cancellationToken)
+#pragma warning disable VSTHRD107 // Await Task within using expression
             using (_task)
+#pragma warning restore VSTHRD107 // Await Task within using expression
             {
                 try
                 {
                     // wait for the completion of the task
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
                     await _task.ConfigureAwait(false);
+#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
                 }
                 catch (OperationCanceledException error) when (error.CancellationToken == _cancellationToken.Token)
                 {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DialogDebugAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DialogDebugAdapter.cs
@@ -162,7 +162,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
                     try
                     {
                         // TODO: remove synchronous waits
+#pragma warning disable VSTHRD103 // Call async methods when in an async method
                         UpdateThreadPhaseAsync(thread, item, cancellationToken).GetAwaiter().GetResult();
+#pragma warning restore VSTHRD103 // Call async methods when in an async method
 
                         // while the stopped condition is true, atomically release the mutex
                         while (!(run.Phase == Phase.Started || run.Phase == Phase.Continue || run.Phase == Phase.Next))
@@ -177,7 +179,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
                         }
 
                         // TODO: remove synchronous waits
+#pragma warning disable VSTHRD103 // Call async methods when in an async method
                         UpdateThreadPhaseAsync(thread, item, cancellationToken).GetAwaiter().GetResult();
+#pragma warning restore VSTHRD103 // Call async methods when in an async method
 
                         // allow one step to progress since next was requested
                         if (run.Phase == Phase.Next)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Converters/InterfaceConverter.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Converters/InterfaceConverter.cs
@@ -75,7 +75,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Converters
                     refDialogName = jToken.Value<string>();
 
                     // We can't do this asynchronously as the Json.NET interface is synchronous
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
                     jToken = this.resourceExplorer.ResolveRefAsync(jToken, sourceContext).GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
                 }
 
                 var kind = (string)jToken["$kind"];

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
@@ -180,7 +180,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
         /// <returns>created type.</returns>
         public T LoadType<T>(Resource resource)
         {
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             return LoadTypeAsync<T>(resource).GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         }
 
         /// <summary>
@@ -663,7 +665,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
                     cancelReloadToken = new CancellationTokenSource();
 #pragma warning disable CA2008 // Do not create tasks without passing a TaskScheduler (this code looks problematic but excluding the rule for now, we need to analyze threading and re-entrance in more detail before trying to change it).
                     Task.Delay(1000, cancelReloadToken.Token)
+#pragma warning disable VSTHRD105 // Avoid method overloads that assume TaskScheduler.Current
                         .ContinueWith(t =>
+#pragma warning restore VSTHRD105 // Avoid method overloads that assume TaskScheduler.Current
                         {
                             if (t.IsCanceled)
                             {
@@ -673,7 +677,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
                             var changed = changedResources.ToArray();
                             changedResources = new ConcurrentBag<Resource>();
                             this.OnChanged(changed);
+#pragma warning disable VSTHRD105 // Avoid method overloads that assume TaskScheduler.Current
+#pragma warning disable VSTHRD110 // Observe result of async calls
                         }).ContinueWith(t => t.Status);
+#pragma warning restore VSTHRD110 // Observe result of async calls
+#pragma warning restore VSTHRD105 // Avoid method overloads that assume TaskScheduler.Current
 #pragma warning restore CA2008 // Do not create tasks without passing a TaskScheduler
                 }
             }

--- a/libraries/Microsoft.Bot.Builder.TemplateManager/ITemplateRenderer.cs
+++ b/libraries/Microsoft.Bot.Builder.TemplateManager/ITemplateRenderer.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Bot.Builder.TemplateManager
         /// <param name="templateId">template to render.</param>
         /// <param name="data">data object to use to render.</param>
         /// <returns>Task.</returns>
-#pragma warning disable UseAsyncSuffix // Use Async suffix (we can't change this without breaking compat)
+#pragma warning disable VSTHRD200 // Use "Async" suffix for async methods (can't change this without breaking binary compat)
         Task<object> RenderTemplate(ITurnContext turnContext, string language, string templateId, object data);
-#pragma warning restore UseAsyncSuffix // Use Async suffix
+#pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
     }
 }

--- a/libraries/Microsoft.Bot.Builder.TemplateManager/TemplateManager.cs
+++ b/libraries/Microsoft.Bot.Builder.TemplateManager/TemplateManager.cs
@@ -112,9 +112,9 @@ namespace Microsoft.Bot.Builder.TemplateManager
         /// <param name="templateId">Id of the template.</param>
         /// <param name="data">Data to render the template.</param>
         /// <returns>Task.</returns>
-#pragma warning disable UseAsyncSuffix // Use Async suffix (we can't change this without breaking compat)
+#pragma warning disable VSTHRD200 // Use "Async" suffix for async methods (can't change this without breaking binary compat)
         public async Task ReplyWith(ITurnContext turnContext, string templateId, object data = null)
-#pragma warning restore UseAsyncSuffix // Use Async suffix
+#pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
         {
             BotAssert.ContextNotNull(turnContext);
 
@@ -137,9 +137,9 @@ namespace Microsoft.Bot.Builder.TemplateManager
         /// <param name="templateId">The id of the template.</param>
         /// <param name="data">Data to render the template with.</param>
         /// <returns>Task.</returns>
-#pragma warning disable UseAsyncSuffix // Use Async suffix (we can't change this without breaking compat)
+#pragma warning disable VSTHRD200 // Use "Async" suffix for async methods (can't change this without breaking binary compat)
         public async Task<Activity> RenderTemplate(ITurnContext turnContext, string language, string templateId, object data = null)
-#pragma warning restore UseAsyncSuffix // Use Async suffix
+#pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
         {
             var fallbackLocales = new List<string>(LanguageFallback);
 

--- a/libraries/Microsoft.Bot.Builder/Adapters/TestFlow.cs
+++ b/libraries/Microsoft.Bot.Builder/Adapters/TestFlow.cs
@@ -85,7 +85,9 @@ namespace Microsoft.Bot.Builder.Adapters
         /// <remarks>This methods sends the activities from the user to the bot and
         /// checks the responses from the bot based on the activities described in the
         /// current test flow.</remarks>
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
         public Task StartTestAsync() => _testTask;
+#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
 
         /// <summary>
         /// Adds a message activity from the user to the bot.
@@ -103,7 +105,9 @@ namespace Microsoft.Bot.Builder.Adapters
             return new TestFlow(
                 async () =>
                 {
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
                     await this._testTask.ConfigureAwait(false);
+#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
 
                     await _adapter.SendTextToBotAsync(userSays, _callback, default(CancellationToken)).ConfigureAwait(false);
                 },
@@ -130,7 +134,9 @@ namespace Microsoft.Bot.Builder.Adapters
                     //  methods, and you handle them by enclosing the call in a try/catch statement. If a task is the
                     //  parent of attached child tasks, or if you are waiting on multiple tasks, multiple exceptions
                     //  could be thrown.
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
                     await this._testTask.ConfigureAwait(false);
+#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
 
                     var cu = Activity.CreateConversationUpdateActivity();
                     cu.MembersAdded.Add(this._adapter.Conversation.User);
@@ -156,7 +162,9 @@ namespace Microsoft.Bot.Builder.Adapters
                 async () =>
                 {
                     // NOTE: See details code in above method.
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
                     await this._testTask.ConfigureAwait(false);
+#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
 
                     await _adapter.ProcessActivityAsync((Activity)userActivity, _callback, default(CancellationToken)).ConfigureAwait(false);
                 },
@@ -175,7 +183,9 @@ namespace Microsoft.Bot.Builder.Adapters
                 async () =>
                 {
                     // NOTE: See details code in above method.
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
                     await this._testTask.ConfigureAwait(false);
+#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
 
                     await Task.Delay((int)ms).ConfigureAwait(false);
                 },
@@ -194,7 +204,9 @@ namespace Microsoft.Bot.Builder.Adapters
                 async () =>
                 {
                     // NOTE: See details code in above method.
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
                     await this._testTask.ConfigureAwait(false);
+#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
 
                     await Task.Delay(timespan).ConfigureAwait(false);
                 },
@@ -326,7 +338,9 @@ namespace Microsoft.Bot.Builder.Adapters
                 async () =>
                 {
                     // NOTE: See details code in above method.
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
                     await this._testTask.ConfigureAwait(false);
+#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
 
                     if (System.Diagnostics.Debugger.IsAttached)
                     {
@@ -355,7 +369,9 @@ namespace Microsoft.Bot.Builder.Adapters
                 async () =>
                 {
                     // NOTE: See details code in above method.
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
                     await this._testTask.ConfigureAwait(false);
+#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
 
                     try
                     {

--- a/libraries/Microsoft.Bot.Builder/TokenResolver.cs
+++ b/libraries/Microsoft.Bot.Builder/TokenResolver.cs
@@ -59,7 +59,9 @@ namespace Microsoft.Bot.Builder
                 // Run the poll operations in the background.
                 // On retrieving a token from the token service the TokenResolver creates an Activity to route the token to the bot to continue the conversation.
                 // If these Tasks are awaited and the user doesn't complete the login flow, the bot may timeout in sending its response to the channel which can cause the streaming connection to disconnect.
+#pragma warning disable VSTHRD110 // Observe result of async calls
                 Task.WhenAll(pollTokenTasks.ToArray());
+#pragma warning restore VSTHRD110 // Observe result of async calls
             }
         }
 

--- a/libraries/Microsoft.Bot.Configuration/BotConfiguration.cs
+++ b/libraries/Microsoft.Bot.Configuration/BotConfiguration.cs
@@ -114,7 +114,9 @@ namespace Microsoft.Bot.Configuration
                 throw new ArgumentNullException(nameof(folder));
             }
 
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             return BotConfiguration.LoadFromFolderAsync(folder, secret).GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         }
 
         /// <summary>
@@ -162,7 +164,9 @@ namespace Microsoft.Bot.Configuration
                 throw new ArgumentNullException(nameof(file));
             }
 
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             return BotConfiguration.LoadAsync(file, secret).GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         }
 
         /// <summary>
@@ -182,7 +186,9 @@ namespace Microsoft.Bot.Configuration
         /// Save the file with secret.
         /// </summary>
         /// <param name="secret">Secret for encryption. </param>
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
         public void Save(string secret = null) => this.SaveAsync(secret).GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
 
         /// <summary>
         /// Save the configuration to a .bot file.
@@ -254,7 +260,9 @@ namespace Microsoft.Bot.Configuration
 #pragma warning restore CA2208 // Instantiate argument exceptions correctly
             }
 
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             this.SaveAsAsync(path, secret).GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Connector/Authentication/AdalAuthenticator.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AdalAuthenticator.cs
@@ -269,7 +269,9 @@ namespace Microsoft.Bot.Connector.Authentication
                 // with and without the semaphore (and different configs for the semaphore), not limiting concurrency actually
                 // results in higher response times overall. Without the use of this semaphore calls to AcquireTokenAsync can take up
                 // to 5 seconds under high concurrency scenarios.
+#pragma warning disable VSTHRD103 // Call async methods when in an async method
                 acquired = tokenRefreshSemaphore.Wait(SemaphoreTimeout);
+#pragma warning restore VSTHRD103 // Call async methods when in an async method
 
                 // If we are allowed to enter the semaphore, acquire the token.
                 if (acquired)

--- a/libraries/Microsoft.Bot.Connector/Authentication/ChannelValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ChannelValidation.cs
@@ -57,9 +57,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <returns>
         /// A valid ClaimsIdentity.
         /// </returns>
-#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
+#pragma warning disable VSTHRD200 // Use "Async" suffix for async methods (can't change this without breaking binary compat)
         public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, HttpClient httpClient, string channelId)
-#pragma warning restore UseAsyncSuffix // Use Async suffix
+#pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
         {
             return await AuthenticateChannelToken(authHeader, credentials, httpClient, channelId, new AuthenticationConfiguration()).ConfigureAwait(false);
         }
@@ -80,9 +80,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <returns>
         /// A valid ClaimsIdentity.
         /// </returns>
-#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
+#pragma warning disable VSTHRD200 // Use "Async" suffix for async methods (can't change this without breaking binary compat)
         public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, HttpClient httpClient, string channelId, AuthenticationConfiguration authConfig)
-#pragma warning restore UseAsyncSuffix // Use Async suffix
+#pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
         {
             if (authConfig == null)
             {
@@ -152,9 +152,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// setup and teardown, so a shared HttpClient is recommended.</param>
         /// <param name="channelId">The ID of the channel to validate.</param>
         /// <returns>ClaimsIdentity.</returns>
-#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
+#pragma warning disable VSTHRD200 // Use "Async" suffix for async methods (can't change this without breaking binary compat)
         public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, string serviceUrl, HttpClient httpClient, string channelId)
-#pragma warning restore UseAsyncSuffix // Use Async suffix
+#pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
         {
             return await AuthenticateChannelToken(authHeader, credentials, serviceUrl, httpClient, channelId, new AuthenticationConfiguration()).ConfigureAwait(false);
         }
@@ -171,9 +171,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="channelId">The ID of the channel to validate.</param>
         /// <param name="authConfig">The authentication configuration.</param>
         /// <returns>ClaimsIdentity.</returns>
-#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
+#pragma warning disable VSTHRD200 // Use "Async" suffix for async methods (can't change this without breaking binary compat)
         public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, string serviceUrl, HttpClient httpClient, string channelId, AuthenticationConfiguration authConfig)
-#pragma warning restore UseAsyncSuffix // Use Async suffix
+#pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
         {
             if (authConfig == null)
             {

--- a/libraries/Microsoft.Bot.Connector/Authentication/EmulatorValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/EmulatorValidation.cs
@@ -94,9 +94,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <remarks>
         /// A token issued by the Bot Framework will FAIL this check. Only Emulator tokens will pass.
         /// </remarks>
-#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
+#pragma warning disable VSTHRD200 // Use "Async" suffix for async methods (can't change this without breaking binary compat)
         public static async Task<ClaimsIdentity> AuthenticateEmulatorToken(string authHeader, ICredentialProvider credentials, IChannelProvider channelProvider, HttpClient httpClient, string channelId)
-#pragma warning restore UseAsyncSuffix // Use Async suffix
+#pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
         {
             return await AuthenticateEmulatorToken(authHeader, credentials, channelProvider, httpClient, channelId, new AuthenticationConfiguration()).ConfigureAwait(false);
         }
@@ -118,9 +118,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <remarks>
         /// A token issued by the Bot Framework will FAIL this check. Only Emulator tokens will pass.
         /// </remarks>
-#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
+#pragma warning disable VSTHRD200 // Use "Async" suffix for async methods (can't change this without breaking binary compat)
         public static async Task<ClaimsIdentity> AuthenticateEmulatorToken(string authHeader, ICredentialProvider credentials, IChannelProvider channelProvider, HttpClient httpClient, string channelId, AuthenticationConfiguration authConfig)
-#pragma warning restore UseAsyncSuffix // Use Async suffix
+#pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
         {
             if (authConfig == null)
             {

--- a/libraries/Microsoft.Bot.Connector/Authentication/EnterpriseChannelValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/EnterpriseChannelValidation.cs
@@ -45,9 +45,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// setup and teardown, so a shared HttpClient is recommended.</param>
         /// <param name="channelId">The ID of the channel to validate.</param>
         /// <returns>ClaimsIdentity.</returns>
-#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
+#pragma warning disable VSTHRD200 // Use "Async" suffix for async methods (can't change this without breaking binary compat)
         public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, IChannelProvider channelProvider, string serviceUrl, HttpClient httpClient, string channelId)
-#pragma warning restore UseAsyncSuffix // Use Async suffix
+#pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
         {
             return await AuthenticateChannelToken(authHeader, credentials, channelProvider, serviceUrl, httpClient, channelId, new AuthenticationConfiguration()).ConfigureAwait(false);
         }
@@ -65,9 +65,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="channelId">The ID of the channel to validate.</param>
         /// <param name="authConfig">The authentication configuration.</param>
         /// <returns>ClaimsIdentity.</returns>
-#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
+#pragma warning disable VSTHRD200 // Use "Async" suffix for async methods (can't change this without breaking binary compat)
         public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, IChannelProvider channelProvider, string serviceUrl, HttpClient httpClient, string channelId, AuthenticationConfiguration authConfig)
-#pragma warning restore UseAsyncSuffix // Use Async suffix
+#pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
         {
             if (authConfig == null)
             {
@@ -96,9 +96,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="credentials">The credentials to use for validation.</param>
         /// <param name="serviceUrl">The service URL to validate.</param>
         /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
-#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
+#pragma warning disable VSTHRD200 // Use "Async" suffix for async methods (can't change this without breaking binary compat)
         public static async Task ValidateIdentity(ClaimsIdentity identity, ICredentialProvider credentials, string serviceUrl)
-#pragma warning restore UseAsyncSuffix // Use Async suffix
+#pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
         {
             if (identity == null)
             {

--- a/libraries/Microsoft.Bot.Connector/Authentication/GovernmentChannelValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/GovernmentChannelValidation.cs
@@ -53,9 +53,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// setup and teardown, so a shared HttpClient is recommended.</param>
         /// <param name="channelId">The ID of the channel to validate.</param>
         /// <returns>ClaimsIdentity.</returns>
-#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
+#pragma warning disable VSTHRD200 // Use "Async" suffix for async methods (can't change this without breaking binary compat)
         public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, string serviceUrl, HttpClient httpClient, string channelId)
-#pragma warning restore UseAsyncSuffix // Use Async suffix
+#pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
         {
             return await AuthenticateChannelToken(authHeader, credentials, serviceUrl, httpClient, channelId, new AuthenticationConfiguration()).ConfigureAwait(false);
         }
@@ -72,9 +72,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="channelId">The ID of the channel to validate.</param>
         /// <param name="authConfig">The authentication configuration.</param>
         /// <returns>ClaimsIdentity.</returns>
-#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
+#pragma warning disable VSTHRD200 // Use "Async" suffix for async methods (can't change this without breaking binary compat)
         public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, string serviceUrl, HttpClient httpClient, string channelId, AuthenticationConfiguration authConfig)
-#pragma warning restore UseAsyncSuffix // Use Async suffix
+#pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
         {
             if (authConfig == null)
             {
@@ -101,9 +101,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="credentials">The user defined set of valid credentials, such as the AppId.</param>
         /// <param name="serviceUrl">The service url from the request.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
+#pragma warning disable VSTHRD200 // Use "Async" suffix for async methods (can't change this without breaking binary compat)
         public static async Task ValidateIdentity(ClaimsIdentity identity, ICredentialProvider credentials, string serviceUrl)
-#pragma warning restore UseAsyncSuffix // Use Async suffix
+#pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
         {
             if (identity == null)
             {

--- a/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
@@ -30,9 +30,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <returns>A task that represents the work queued to execute.</returns>
         /// <remarks>If the task completes successfully, the result contains the claims-based
         /// identity for the request.</remarks>
-#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
+#pragma warning disable VSTHRD200 // Use "Async" suffix for async methods (can't change this without breaking binary compat)
         public static async Task<ClaimsIdentity> AuthenticateRequest(IActivity activity, string authHeader, ICredentialProvider credentials, IChannelProvider provider, HttpClient httpClient = null)
-#pragma warning restore UseAsyncSuffix // Use Async suffix
+#pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
         {
             return await AuthenticateRequest(activity, authHeader, credentials, provider, new AuthenticationConfiguration(), httpClient).ConfigureAwait(false);
         }
@@ -50,9 +50,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <returns>A task that represents the work queued to execute.</returns>
         /// <remarks>If the task completes successfully, the result contains the claims-based
         /// identity for the request.</remarks>
-#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
+#pragma warning disable VSTHRD200 // Use "Async" suffix for async methods (can't change this without breaking binary compat)
         public static async Task<ClaimsIdentity> AuthenticateRequest(IActivity activity, string authHeader, ICredentialProvider credentials, IChannelProvider provider, AuthenticationConfiguration authConfig, HttpClient httpClient = null)
-#pragma warning restore UseAsyncSuffix // Use Async suffix
+#pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
         {
             if (authConfig == null)
             {
@@ -99,9 +99,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <returns>A task that represents the work queued to execute.</returns>
         /// <remarks>If the task completes successfully, the result contains the claims-based
         /// identity for the request.</remarks>
-#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
+#pragma warning disable VSTHRD200 // Use "Async" suffix for async methods (can't change this without breaking binary compat)
         public static async Task<ClaimsIdentity> ValidateAuthHeader(string authHeader, ICredentialProvider credentials, IChannelProvider channelProvider, string channelId, string serviceUrl = null, HttpClient httpClient = null)
-#pragma warning restore UseAsyncSuffix // Use Async suffix
+#pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
         {
             return await ValidateAuthHeader(authHeader, credentials, channelProvider, channelId, new AuthenticationConfiguration(), serviceUrl, httpClient).ConfigureAwait(false);
         }
@@ -119,9 +119,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <returns>A task that represents the work queued to execute.</returns>
         /// <remarks>If the task completes successfully, the result contains the claims-based
         /// identity for the request.</remarks>
-#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
+#pragma warning disable VSTHRD200 // Use "Async" suffix for async methods (can't change this without breaking binary compat)
         public static async Task<ClaimsIdentity> ValidateAuthHeader(string authHeader, ICredentialProvider credentials, IChannelProvider channelProvider, string channelId, AuthenticationConfiguration authConfig, string serviceUrl = null, HttpClient httpClient = null)
-#pragma warning restore UseAsyncSuffix // Use Async suffix
+#pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
         {
             if (string.IsNullOrEmpty(authHeader))
             {

--- a/libraries/Microsoft.Bot.Connector/Authentication/Retry.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/Retry.cs
@@ -19,9 +19,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="task">A reference to the action to retry.</param>
         /// <param name="retryExceptionHandler">A reference to the method that handles exceptions.</param>
         /// <returns>A result object.</returns>
-#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
+#pragma warning disable VSTHRD200 // Use "Async" suffix for async methods (can't change this without breaking binary compat)
         public static async Task<TResult> Run<TResult>(Func<Task<TResult>> task, Func<Exception, int, RetryParams> retryExceptionHandler)
-#pragma warning restore UseAsyncSuffix // Use Async suffix
+#pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
         {
             RetryParams retry;
             var exceptions = new List<Exception>();

--- a/libraries/Microsoft.Bot.Connector/Authentication/SkillValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/SkillValidation.cs
@@ -131,9 +131,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="channelId">The ID of the channel to validate.</param>
         /// <param name="authConfig">The authentication configuration.</param>
         /// <returns>A <see cref="ClaimsIdentity"/> instance if the validation is successful.</returns>
-#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
+#pragma warning disable VSTHRD200 // Use "Async" suffix for async methods (can't change this without breaking binary compat)
         public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, IChannelProvider channelProvider, HttpClient httpClient, string channelId, AuthenticationConfiguration authConfig)
-#pragma warning restore UseAsyncSuffix // Use Async suffix
+#pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
         {
             if (authConfig == null)
             {

--- a/libraries/Microsoft.Bot.Connector/ConversationsEx.cs
+++ b/libraries/Microsoft.Bot.Connector/ConversationsEx.cs
@@ -24,7 +24,9 @@ namespace Microsoft.Bot.Connector
         /// <returns>ConversationResourceResponse.</returns>
         public static ConversationResourceResponse CreateDirectConversation(this IConversations operations, ChannelAccount bot, ChannelAccount user, Activity activity = null)
         {
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             return Task.Factory.StartNew(s => ((IConversations)s).CreateConversationAsync(GetDirectParameters(bot, user, activity)), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         }
 
         /// <summary>
@@ -58,7 +60,9 @@ namespace Microsoft.Bot.Connector
         /// <returns>ConversationResourceResponse.</returns>
         public static ConversationResourceResponse CreateDirectConversation(this IConversations operations, string botAddress, string userAddress, Activity activity = null)
         {
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             return Task.Factory.StartNew(s => ((IConversations)s).CreateConversationAsync(GetDirectParameters(botAddress, userAddress, activity)), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         }
 
         /// <summary>
@@ -94,7 +98,9 @@ namespace Microsoft.Bot.Connector
         /// <returns>ResourceResponse.</returns>
         public static ResourceResponse SendToConversation(this IConversations operations, Activity activity)
         {
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             return Task.Factory.StartNew(s => ((IConversations)s).SendToConversationAsync(activity.Conversation.Id, activity), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         }
 
         /// <summary>
@@ -127,7 +133,9 @@ namespace Microsoft.Bot.Connector
         /// <returns>ResourceResponse.</returns>
         public static ResourceResponse ReplyToActivity(this IConversations operations, Activity activity)
         {
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             return Task.Factory.StartNew(s => ((IConversations)s).ReplyToActivityAsync(activity.Conversation.Id, activity.ReplyToId, activity), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         }
 
         /// <summary>
@@ -165,7 +173,9 @@ namespace Microsoft.Bot.Connector
         /// <returns>ResourceResponse.</returns>
         public static ResourceResponse UpdateActivity(this IConversations operations, Activity activity)
         {
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             return Task.Factory.StartNew(s => ((IConversations)s).UpdateActivityAsync(activity.Conversation.Id, activity.Id, activity), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Streaming/Payloads/Disassemblers/CancelDisassembler.cs
+++ b/libraries/Microsoft.Bot.Streaming/Payloads/Disassemblers/CancelDisassembler.cs
@@ -35,9 +35,9 @@ namespace Microsoft.Bot.Streaming.Payloads
         /// A task that initiates the process of disassembling the request and signals the <see cref="PayloadSender"/> to begin sending.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
-#pragma warning disable UseAsyncSuffix // Use Async suffix  (we can't change this without breaking binary compat)
+#pragma warning disable VSTHRD200 // Use "Async" suffix for async methods (can't change this without breaking binary compat)
         public Task Disassemble()
-#pragma warning restore UseAsyncSuffix // Use Async suffix
+#pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
         {
             var header = new Header()
             {

--- a/libraries/Microsoft.Bot.Streaming/Payloads/RequestManager.cs
+++ b/libraries/Microsoft.Bot.Streaming/Payloads/RequestManager.cs
@@ -37,7 +37,9 @@ namespace Microsoft.Bot.Streaming.Payloads
         {
             if (_responseTasks.TryGetValue(requestId, out TaskCompletionSource<ReceiveResponse> signal))
             {
+#pragma warning disable VSTHRD110 // Observe result of async calls
                 Task.Run(() => { signal.TrySetResult(response); });
+#pragma warning restore VSTHRD110 // Observe result of async calls
                 return Task.FromResult(true);
             }
 

--- a/libraries/Microsoft.Bot.Streaming/ProtocolAdapter.cs
+++ b/libraries/Microsoft.Bot.Streaming/ProtocolAdapter.cs
@@ -49,7 +49,9 @@ namespace Microsoft.Bot.Streaming
             cancellationToken.ThrowIfCancellationRequested();
             await Task.WhenAll(requestTask, responseTask).ConfigureAwait(false);
 
+#pragma warning disable VSTHRD103 // Call async methods when in an async method
             return responseTask.Result;
+#pragma warning restore VSTHRD103 // Call async methods when in an async method
         }
 
         private async Task OnReceiveRequestAsync(Guid id, ReceiveRequest request)

--- a/libraries/Microsoft.Bot.Streaming/ReceiveRequestExtensions.cs
+++ b/libraries/Microsoft.Bot.Streaming/ReceiveRequestExtensions.cs
@@ -25,7 +25,9 @@ namespace Microsoft.Bot.Streaming
         /// </returns>
         public static T ReadBodyAsJson<T>(this ReceiveRequest request)
         {
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             return request.ReadBodyAsJsonAsync<T>().GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         }
 
         /// <summary>
@@ -66,7 +68,9 @@ namespace Microsoft.Bot.Streaming
         /// </returns>
         public static string ReadBodyAsString(this ReceiveRequest request)
         {
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             return request.ReadBodyAsStringAsync().GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Streaming/ReceiveResponseExtensions.cs
+++ b/libraries/Microsoft.Bot.Streaming/ReceiveResponseExtensions.cs
@@ -54,7 +54,9 @@ namespace Microsoft.Bot.Streaming
         /// </returns>
         public static string ReadBodyAsString(this ReceiveResponse response)
         {
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             return response.ReadBodyAsStringAsync().GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Streaming/Transport/WebSocket/WebSocketClient.cs
+++ b/libraries/Microsoft.Bot.Streaming/Transport/WebSocket/WebSocketClient.cs
@@ -103,9 +103,9 @@ namespace Microsoft.Bot.Streaming.Transport.WebSockets
         /// </param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> used to signal this operation should be cancelled.</param>
         /// <returns>A <see cref="Task"/> that will not resolve until the client stops listening for incoming messages.</returns>
-#pragma warning disable UseAsyncSuffix // Use Async suffix (we can't change this without breaking binary compat)
+#pragma warning disable VSTHRD200 // Use "Async" suffix for async methods (can't change this without breaking binary compat)
         public async Task ConnectAsyncEx(IDictionary<string, string> requestHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
-#pragma warning restore UseAsyncSuffix // Use Async suffix
+#pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
         {
             if (IsConnected)
             {

--- a/libraries/Microsoft.Bot.Streaming/Transport/WebSocket/WebSocketTransport.cs
+++ b/libraries/Microsoft.Bot.Streaming/Transport/WebSocket/WebSocketTransport.cs
@@ -38,7 +38,9 @@ namespace Microsoft.Bot.Streaming.Transport.WebSockets
             {
                 try
                 {
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
                     Task.WaitAll(_socket.CloseAsync(
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
                         WebSocketCloseStatus.NormalClosure,
                         "Closed by the WebSocketTransport",
                         CancellationToken.None));

--- a/libraries/Microsoft.Bot.Streaming/Utilities/Background.cs
+++ b/libraries/Microsoft.Bot.Streaming/Utilities/Background.cs
@@ -31,7 +31,9 @@ namespace Microsoft.Bot.Streaming.Utilities
         public static void Run(Func<CancellationToken, Task> task, IDictionary<string, object> properties = null)
 #pragma warning restore CA1801 // Review unused parameters
         {
+#pragma warning disable VSTHRD110 // Observe result of async calls
             Task.Run(() => TrackAsRequestAsync(() => task(CancellationToken.None)));
+#pragma warning restore VSTHRD110 // Observe result of async calls
         }
 
         /// <summary>

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/TelemetrySaveBodyASPMiddleware.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/TelemetrySaveBodyASPMiddleware.cs
@@ -38,7 +38,9 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
         /// </summary>
         /// <param name="httpContext">The HttpContext.</param>
         /// <returns>A task that represents the work queued to execute.</returns>
+#pragma warning disable VSTHRD200 // Use "Async" suffix for async methods (can't change this without breaking binary compat)
         public async Task Invoke(HttpContext httpContext)
+#pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
         {
             var request = httpContext.Request;
 


### PR DESCRIPTION
Fixes # 3905

## Description

Replaces the [AsyncUsageAnalyzers](https://www.nuget.org/packages/AsyncUsageAnalyzers/) library with the latest version of its superseder [Microsoft.VisualStudio.Threading](https://www.nuget.org/packages/Microsoft.VisualStudio.Threading/).
All additional rules are explicitly suppressed in source, all pre-existing suppressions have been updated.
The following table describes all rule equivalences between both libraries:

|  Old | New | Description |
|---|---|---|
| [AvoidAsyncVoid](https://github.com/DotNetAnalyzers/AsyncUsageAnalyzers/blob/master/documentation/AvoidAsyncVoid.md) | [VSTHRD100](https://github.com/microsoft/vs-threading/blob/v16.8.55/doc/analyzers/VSTHRD100.md) | Avoid `async void` methods |
| [UseConfigureAwait](https://github.com/DotNetAnalyzers/AsyncUsageAnalyzers/blob/master/documentation/UseConfigureAwait.md) | [VSTHRD111](https://github.com/microsoft/vs-threading/blob/v16.8.55/doc/analyzers/VSTHRD100.md) | Use `.ConfigureAwait(bool)` |
| [AvoidAsyncSuffix](https://github.com/DotNetAnalyzers/AsyncUsageAnalyzers/blob/master/documentation/AvoidAsyncSuffix.md) & [UseAsyncSuffix](https://github.com/DotNetAnalyzers/AsyncUsageAnalyzers/blob/master/documentation/AvoidAsyncVoid.md) | [VSTHRD200](https://github.com/microsoft/vs-threading/blob/v16.8.55/doc/analyzers/VSTHRD200.md) | Use `Async` naming convention |
 
## Specific Changes

 - Replaces `AsyncUsageAnalyzers` with `Microsoft.VisualStudio.Threading.Analyzers` version `16.8.55` in `libraries/Directory.Build.props`
 - Suppresses all additional rules provided by the new library
 - Updates all pre-existing suppressions

## Testing
This is a screenshot of all the tests working with no errors for the changes introduced in this PR:
![image](https://user-images.githubusercontent.com/64803884/102660051-2abf3180-4159-11eb-8a5e-ba09b07fe1fc.png)