### PR TITLE
[Slack Adapter] Make messages with attachments into message activities

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Bot.Builder.Adapters.Slack.Model;
 using Microsoft.Bot.Builder.Adapters.Slack.Model.Events;
 using Microsoft.Bot.Schema;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 #if SIGNASSEMBLY
@@ -244,10 +245,49 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
             {
                 var message = JObject.FromObject(innerEvent).ToObject<MessageEvent>();
 
-                if (message.SubType == null)
+                if (message.SubType == null || message.SubType == "file_share")
                 {
                     activity.Type = ActivityTypes.Message;
                     activity.Text = message.Text;
+                    if (message.AdditionalProperties.ContainsKey("files"))
+                    {
+                        var attachments = new List<Attachment>();
+                        foreach (var attachment in message.AdditionalProperties["files"])
+                        {
+                            var attachmentProperties = attachment.Value<JObject>().Properties();
+
+                            var contentType = string.Empty;
+                            var contentUrl = string.Empty;
+                            var name = string.Empty;
+
+                            foreach (var property in attachmentProperties)
+                            {
+                                if (property.Name == "mimetype")
+                                {
+                                    contentType = property.Value.ToString();
+                                }
+
+                                if (property.Name == "url_private_download")
+                                {
+                                    contentUrl = property.Value.ToString();
+                                }
+
+                                if (property.Name == "name")
+                                {
+                                    name = property.Value.ToString();
+                                }
+                            }
+
+                            attachments.Add(new Attachment
+                            { 
+                                ContentType = contentType,
+                                ContentUrl = contentUrl,
+                                Name = name
+                            });
+                        }
+
+                        activity.Attachments = attachments;
+                    }
                 }
 
                 activity.Conversation.Properties["channel_type"] = message.ChannelType;

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
@@ -14,7 +14,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Bot.Builder.Adapters.Slack.Model;
 using Microsoft.Bot.Builder.Adapters.Slack.Model.Events;
 using Microsoft.Bot.Schema;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 #if SIGNASSEMBLY


### PR DESCRIPTION
Fixes # 4888

## Description
Updates the Slack Adapter to resolve received messages with attachments as `ActivityTypes.Message`, allowing users to access the _text_ and _attachment_ properties from the root activity.

**THIS IS A BREAKING CHANGE 
Messages with attachments will be received "on message" activities instead of "on event" activities.**

The change makes attachment messages more akin to ABS, which also interprets them as message activities but lacks the text property, using the attachment name instead.

![image](https://user-images.githubusercontent.com/64803884/110321565-a01bff00-7ff0-11eb-9e64-c6305b0c8ae9.png)

## Specific Changes

  - Adds received messages with attachments to the filter to resolve them as message activities.
    - Obtains each file's properties manually to parse them into `Attachments`

## Testing
The changes were tested in unit and functional tests with no issues, since there are no message with attachment tests affected.
![image](https://user-images.githubusercontent.com/64803884/110172139-76d65580-7ddb-11eb-9d66-b8a32074d9cc.png)
