### PR TITLE
Add test for Slack Adapter file sharing

### DIFF
--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/Files/MessageBodyWithFileShare.json
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/Files/MessageBodyWithFileShare.json
@@ -1,0 +1,30 @@
+{
+  "token": "VerificationToken",
+  "team_id": "teamId",
+  "api_app_id": "apiAppId",
+  "event": {
+    "type": "message",
+    "text": "Hello",
+    "user": "userId",
+    "display_as_bot": false,
+    "ts": "1568915625.001000",
+    "channel": "channelId",
+    "subtype": "file_share",
+    "event_ts": "1568915625.001000",
+    "channel_type": "im",
+    "files": [
+      {
+        "id": "fileId",
+        "mimetype": "image/png",
+        "name": "fileName",
+        "url_private_download": "https://files.slack.com/files-pri/teamId-fileId/download/fileName.png"
+      }
+    ]
+  },
+  "type": "event_callback",
+  "event_id": "eventId",
+  "event_time": 1568915625,
+  "authed_users": [
+    "userId"
+  ]
+}

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/Microsoft.Bot.Builder.Adapters.Slack.Tests.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/Microsoft.Bot.Builder.Adapters.Slack.Tests.csproj
@@ -62,6 +62,9 @@
     <None Update="Files\MessageBody.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Files\MessageBodyWithFileShare.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/SlackHelperTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/SlackHelperTests.cs
@@ -155,6 +155,8 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Tests
 
             var activity = SlackHelper.EventToActivity(slackBody, slackApi.Object);
 
+            Assert.Equal(ActivityTypes.Message, activity.Type);
+            Assert.Equal(slackBody.Event.Type, activity.Type);
             Assert.Equal(slackBody.Event.AdditionalProperties["text"].ToString(), activity.Text);
             Assert.Equal(slackBody.Event.AdditionalProperties["files"][0]["mimetype"].ToString(), activity.Attachments[0].ContentType);
             Assert.Equal(slackBody.Event.AdditionalProperties["files"][0]["url_private_download"].ToString(), activity.Attachments[0].ContentUrl);

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/SlackHelperTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/SlackHelperTests.cs
@@ -146,6 +146,22 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Tests
         }
 
         [Fact]
+        public void EventToActivityAsyncShouldReturnActivityWithAttachmentsWhenFileSharing()
+        {
+            var slackApi = new Mock<SlackClientWrapper>(_testOptions);
+
+            var payload = File.ReadAllText(Directory.GetCurrentDirectory() + @"/Files/MessageBodyWithFileShare.json");
+            var slackBody = JsonConvert.DeserializeObject<EventRequest>(payload);
+
+            var activity = SlackHelper.EventToActivity(slackBody, slackApi.Object);
+
+            Assert.Equal(slackBody.Event.AdditionalProperties["text"].ToString(), activity.Text);
+            Assert.Equal(slackBody.Event.AdditionalProperties["files"][0]["mimetype"].ToString(), activity.Attachments[0].ContentType);
+            Assert.Equal(slackBody.Event.AdditionalProperties["files"][0]["url_private_download"].ToString(), activity.Attachments[0].ContentUrl);
+            Assert.Equal(slackBody.Event.AdditionalProperties["files"][0]["name"].ToString(), activity.Attachments[0].Name);
+        }
+
+        [Fact]
         public void EventToActivityAsyncShouldReturnActivityWithTeamId()
         {
             var slackApi = new Mock<SlackClientWrapper>(_testOptions);


### PR DESCRIPTION
Internal PR for adding tests to the `southworks/update/slack-adapter-attachments` branch.