### PR TITLE
[#371][OAuthCard] TokenExchangeResource property is missing JsonProperty attribute name

### DIFF
--- a/libraries/Microsoft.Bot.Schema/OAuthCard.cs
+++ b/libraries/Microsoft.Bot.Schema/OAuthCard.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Bot.Schema
         /// Gets or sets the resource to try to perform token exchange with.
         /// </summary>
         /// <value>The resource to try to perform token exchange with.</value>
+        [JsonProperty(PropertyName = "tokenExchangeResource")]
         public TokenExchangeResource TokenExchangeResource { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Fixes # XXX

## Description
This PR adds the missing JsonProperty attribute to the [TokenExchangeResource](https://github.com/microsoft/botbuilder-dotnet/blob/main/libraries/Microsoft.Bot.Schema/OAuthCard.cs#L57) property of the OAuthCard class.

## Specific Changes
- Updated **_OAuthCard_** class to add JsonProperty name to _TokenExchangeResource_ property.

## Testing
This image shows the test passing after the change.
[image]