### PR TITLE
Apply feedback on PR# 5068

### DIFF
--- a/BotBuilder-DotNet.ruleset
+++ b/BotBuilder-DotNet.ruleset
@@ -12,6 +12,11 @@
   <Rules AnalyzerId="Microsoft.NetCore.CSharp.Analyzers" RuleNamespace="Microsoft.NetCore.CSharp.Analyzers">
     <Rule Id="CA1309" Action="Error" /> <!-- Use ordinal StringComparison -->
   </Rules>
+  <Rules AnalyzerId="Microsoft.VisualStudio.Threading.Analyzers.CSharp" RuleNamespace="Microsoft.VisualStudio.Threading.Analyzers.CSharp">
+    <Rule Id="VSTHRD002" Action="None" /> <!-- Avoid problematic synchronous waits -->
+    <Rule Id="VSTHRD003" Action="None" /> <!-- Avoid awaiting foreign Tasks -->
+    <Rule Id="VSTHRD011" Action="None" /> <!-- Use AsyncLazy<T> -->
+  </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <Rule Id="SA0001" Action="None" />
     <Rule Id="SA0002" Action="Error" />

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackClientWrapper.cs
@@ -50,9 +50,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
             }
 
             _api = new SlackTaskClient(options.SlackBotToken);
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             LoginWithSlackAsync(default).Wait();
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         }
 
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexClientWrapper.cs
@@ -147,12 +147,10 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
             var encoding = new ASCIIEncoding();
             var bytes = encoding.GetBytes(parsedContent);
 
-#pragma warning disable VSTHRD103 // Call async methods when in an async method
-            var newStream = http.GetRequestStream();
-#pragma warning restore VSTHRD103 // Call async methods when in an async method
-#pragma warning disable VSTHRD103 // Call async methods when in an async method
-            newStream.Write(bytes, 0, bytes.Length);
-#pragma warning restore VSTHRD103 // Call async methods when in an async method
+            var newStream = await http.GetRequestStreamAsync().ConfigureAwait(false);
+
+            await newStream.WriteAsync(bytes, 0, bytes.Length, cancellationToken).ConfigureAwait(false);
+
             newStream.Close();
 
             var response = await http.GetResponseAsync().ConfigureAwait(false);

--- a/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsTranscriptStore.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsTranscriptStore.cs
@@ -92,11 +92,7 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
                     if (!_checkedContainers.Contains(containerName))
                     {
                         _checkedContainers.Add(containerName);
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
-#pragma warning disable VSTHRD011 // Use AsyncLazy<T>
                         containerClient.CreateIfNotExistsAsync().Wait();
-#pragma warning restore VSTHRD011 // Use AsyncLazy<T>
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
                     }
 
                     return containerClient;

--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
@@ -199,9 +199,9 @@ namespace Microsoft.Bot.Builder.Azure
                     using (var streamWriter = new StreamWriter(memoryStream))
                     {
                         _jsonSerializer.Serialize(streamWriter, newValue);
-                        
+
                         await streamWriter.FlushAsync().ConfigureAwait(false);
-                        
+
                         memoryStream.Seek(0, SeekOrigin.Begin);
                         await blobReference.UploadFromStreamAsync(memoryStream, accessCondition, blobRequestOptions, operationContext, cancellationToken).ConfigureAwait(false);
                     }

--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
@@ -199,9 +199,9 @@ namespace Microsoft.Bot.Builder.Azure
                     using (var streamWriter = new StreamWriter(memoryStream))
                     {
                         _jsonSerializer.Serialize(streamWriter, newValue);
-#pragma warning disable VSTHRD103 // Call async methods when in an async method
-                        streamWriter.Flush();
-#pragma warning restore VSTHRD103 // Call async methods when in an async method
+                        
+                        await streamWriter.FlushAsync().ConfigureAwait(false);
+                        
                         memoryStream.Seek(0, SeekOrigin.Begin);
                         await blobReference.UploadFromStreamAsync(memoryStream, accessCondition, blobRequestOptions, operationContext, cancellationToken).ConfigureAwait(false);
                     }

--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobTranscriptStore.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobTranscriptStore.cs
@@ -69,11 +69,7 @@ namespace Microsoft.Bot.Builder.Azure
                 if (!_checkedContainers.Contains(containerName))
                 {
                     _checkedContainers.Add(containerName);
-#pragma warning disable VSTHRD011 // Use AsyncLazy<T>
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
                     container.CreateIfNotExistsAsync().Wait();
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
-#pragma warning restore VSTHRD011 // Use AsyncLazy<T>
                 }
 
                 return container;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Converters/JObjectConverter.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Converters/JObjectConverter.cs
@@ -43,9 +43,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Converters
             if (resourceExplorer.IsRef(jsonObject))
             {
                 // We can't do this asynchronously as the Json.NET interface is synchronous
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
                 jsonObject = resourceExplorer.ResolveRefAsync(jsonObject, sourceContext).GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
             }
 
             return jsonObject as JObject;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/LanguageGeneratorManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/LanguageGeneratorManager.cs
@@ -75,9 +75,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
                 }
                 else
                 {
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
                     var content = resource.ReadTextAsync().GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
                     return new LGResource(resource.Id, resource.FullName, content);
                 }
             };

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/TemplateEngineLanguageGenerator.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/TemplateEngineLanguageGenerator.cs
@@ -95,9 +95,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
 
             var (_, locale) = LGResourceLoader.ParseLGFileName(Id);
             var importResolver = LanguageGeneratorManager.ResourceExplorerResolver(locale, resourceMapping);
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             var content = resource.ReadTextAsync().GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
             var lgResource = new LGResource(Id, resource.FullName, content);
             this.lg = LanguageGeneration.Templates.ParseResource(lgResource, importResolver);
             RegisterSourcemap(lg, resource);
@@ -147,9 +145,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
             TaskFactory.StartNew(() =>
             {
                 return func();
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             }).Unwrap().GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
 #pragma warning restore CA2008 // Do not create tasks without passing a TaskScheduler
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Base/ActiveObject.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Base/ActiveObject.cs
@@ -29,9 +29,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging.Base
 
         public void Dispose()
         {
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             DisposeAsync().GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         }
 
         public async Task DisposeAsync()
@@ -48,9 +46,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging.Base
                 try
                 {
                     // wait for the completion of the task
-#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
                     await _task.ConfigureAwait(false);
-#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
                 }
                 catch (OperationCanceledException error) when (error.CancellationToken == _cancellationToken.Token)
                 {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DialogDebugAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DialogDebugAdapter.cs
@@ -161,10 +161,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
                     Monitor.Enter(run.Gate);
                     try
                     {
-                        // TODO: remove synchronous waits
-#pragma warning disable VSTHRD103 // Call async methods when in an async method
-                        UpdateThreadPhaseAsync(thread, item, cancellationToken).GetAwaiter().GetResult();
-#pragma warning restore VSTHRD103 // Call async methods when in an async method
+                        await UpdateThreadPhaseAsync(thread, item, cancellationToken).ConfigureAwait(false);
 
                         // while the stopped condition is true, atomically release the mutex
                         while (!(run.Phase == Phase.Started || run.Phase == Phase.Continue || run.Phase == Phase.Next))
@@ -178,10 +175,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
                             run.Phase = Phase.Continue;
                         }
 
-                        // TODO: remove synchronous waits
-#pragma warning disable VSTHRD103 // Call async methods when in an async method
-                        UpdateThreadPhaseAsync(thread, item, cancellationToken).GetAwaiter().GetResult();
-#pragma warning restore VSTHRD103 // Call async methods when in an async method
+                        await UpdateThreadPhaseAsync(thread, item, cancellationToken).ConfigureAwait(false);
 
                         // allow one step to progress since next was requested
                         if (run.Phase == Phase.Next)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Converters/InterfaceConverter.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Converters/InterfaceConverter.cs
@@ -70,14 +70,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Converters
             using (new SourceScope(sourceContext, range))
             {
                 string refDialogName = null;
-                if (this.resourceExplorer.IsRef(jToken))
+                if (resourceExplorer.IsRef(jToken))
                 {
                     refDialogName = jToken.Value<string>();
 
                     // We can't do this asynchronously as the Json.NET interface is synchronous
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
-                    jToken = this.resourceExplorer.ResolveRefAsync(jToken, sourceContext).GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
+                    jToken = resourceExplorer.ResolveRefAsync(jToken, sourceContext).GetAwaiter().GetResult();
                 }
 
                 var kind = (string)jToken["$kind"];

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
@@ -682,7 +682,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
 
         private void ResourceProvider_Changed(object sender, IEnumerable<Resource> resources)
         {
-            if (this.Changed != null)
+            if (Changed != null)
             {
                 foreach (var resource in resources)
                 {
@@ -693,11 +693,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
                 {
                     cancelReloadToken.Cancel();
                     cancelReloadToken = new CancellationTokenSource();
-#pragma warning disable CA2008 // Do not create tasks without passing a TaskScheduler (this code looks problematic but excluding the rule for now, we need to analyze threading and re-entrance in more detail before trying to change it).
+
                     Task.Delay(1000, cancelReloadToken.Token)
-#pragma warning disable VSTHRD105 // Avoid method overloads that assume TaskScheduler.Current
-                        .ContinueWith(t =>
-#pragma warning restore VSTHRD105 // Avoid method overloads that assume TaskScheduler.Current
+                        .ContinueWith(
+                            t =>
                         {
                             if (t.IsCanceled)
                             {
@@ -706,13 +705,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
 
                             var changed = changedResources.ToArray();
                             changedResources = new ConcurrentBag<Resource>();
-                            this.OnChanged(changed);
-#pragma warning disable VSTHRD105 // Avoid method overloads that assume TaskScheduler.Current
+                            OnChanged(changed);
 #pragma warning disable VSTHRD110 // Observe result of async calls
-                        }).ContinueWith(t => t.Status);
+                        }, TaskScheduler.Default).ContinueWith(t => t.Status, TaskScheduler.Default);
 #pragma warning restore VSTHRD110 // Observe result of async calls
-#pragma warning restore VSTHRD105 // Avoid method overloads that assume TaskScheduler.Current
-#pragma warning restore CA2008 // Do not create tasks without passing a TaskScheduler
                 }
             }
         }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
@@ -197,9 +197,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
         /// <returns>created type.</returns>
         public T LoadType<T>(Resource resource)
         {
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             return LoadTypeAsync<T>(resource).GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder/Adapters/TestFlow.cs
+++ b/libraries/Microsoft.Bot.Builder/Adapters/TestFlow.cs
@@ -85,9 +85,7 @@ namespace Microsoft.Bot.Builder.Adapters
         /// <remarks>This methods sends the activities from the user to the bot and
         /// checks the responses from the bot based on the activities described in the
         /// current test flow.</remarks>
-#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
         public Task StartTestAsync() => _testTask;
-#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
 
         /// <summary>
         /// Adds a message activity from the user to the bot.
@@ -105,9 +103,7 @@ namespace Microsoft.Bot.Builder.Adapters
             return new TestFlow(
                 async () =>
                 {
-#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
-                    await this._testTask.ConfigureAwait(false);
-#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
+                    await _testTask.ConfigureAwait(false);
 
                     await _adapter.SendTextToBotAsync(userSays, _callback, default(CancellationToken)).ConfigureAwait(false);
                 },
@@ -134,9 +130,7 @@ namespace Microsoft.Bot.Builder.Adapters
                     //  methods, and you handle them by enclosing the call in a try/catch statement. If a task is the
                     //  parent of attached child tasks, or if you are waiting on multiple tasks, multiple exceptions
                     //  could be thrown.
-#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
-                    await this._testTask.ConfigureAwait(false);
-#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
+                    await _testTask.ConfigureAwait(false);
 
                     var cu = Activity.CreateConversationUpdateActivity();
                     cu.MembersAdded.Add(this._adapter.Conversation.User);
@@ -162,9 +156,7 @@ namespace Microsoft.Bot.Builder.Adapters
                 async () =>
                 {
                     // NOTE: See details code in above method.
-#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
-                    await this._testTask.ConfigureAwait(false);
-#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
+                    await _testTask.ConfigureAwait(false);
 
                     await _adapter.ProcessActivityAsync((Activity)userActivity, _callback, default(CancellationToken)).ConfigureAwait(false);
                 },
@@ -183,9 +175,7 @@ namespace Microsoft.Bot.Builder.Adapters
                 async () =>
                 {
                     // NOTE: See details code in above method.
-#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
-                    await this._testTask.ConfigureAwait(false);
-#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
+                    await _testTask.ConfigureAwait(false);
 
                     await Task.Delay((int)ms).ConfigureAwait(false);
                 },
@@ -204,9 +194,7 @@ namespace Microsoft.Bot.Builder.Adapters
                 async () =>
                 {
                     // NOTE: See details code in above method.
-#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
-                    await this._testTask.ConfigureAwait(false);
-#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
+                    await _testTask.ConfigureAwait(false);
 
                     await Task.Delay(timespan).ConfigureAwait(false);
                 },
@@ -338,9 +326,7 @@ namespace Microsoft.Bot.Builder.Adapters
                 async () =>
                 {
                     // NOTE: See details code in above method.
-#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
-                    await this._testTask.ConfigureAwait(false);
-#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
+                    await _testTask.ConfigureAwait(false);
 
                     if (System.Diagnostics.Debugger.IsAttached)
                     {
@@ -369,9 +355,7 @@ namespace Microsoft.Bot.Builder.Adapters
                 async () =>
                 {
                     // NOTE: See details code in above method.
-#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
-                    await this._testTask.ConfigureAwait(false);
-#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
+                    await _testTask.ConfigureAwait(false);
 
                     try
                     {

--- a/libraries/Microsoft.Bot.Configuration/BotConfiguration.cs
+++ b/libraries/Microsoft.Bot.Configuration/BotConfiguration.cs
@@ -114,9 +114,7 @@ namespace Microsoft.Bot.Configuration
                 throw new ArgumentNullException(nameof(folder));
             }
 
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             return BotConfiguration.LoadFromFolderAsync(folder, secret).GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         }
 
         /// <summary>
@@ -164,9 +162,7 @@ namespace Microsoft.Bot.Configuration
                 throw new ArgumentNullException(nameof(file));
             }
 
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             return BotConfiguration.LoadAsync(file, secret).GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         }
 
         /// <summary>
@@ -186,9 +182,7 @@ namespace Microsoft.Bot.Configuration
         /// Save the file with secret.
         /// </summary>
         /// <param name="secret">Secret for encryption. </param>
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
         public void Save(string secret = null) => this.SaveAsync(secret).GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
 
         /// <summary>
         /// Save the configuration to a .bot file.
@@ -260,9 +254,7 @@ namespace Microsoft.Bot.Configuration
 #pragma warning restore CA2208 // Instantiate argument exceptions correctly
             }
 
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
-            this.SaveAsAsync(path, secret).GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
+            SaveAsAsync(path, secret).GetAwaiter().GetResult();
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Connector/Authentication/AdalAuthenticator.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AdalAuthenticator.cs
@@ -269,9 +269,8 @@ namespace Microsoft.Bot.Connector.Authentication
                 // with and without the semaphore (and different configs for the semaphore), not limiting concurrency actually
                 // results in higher response times overall. Without the use of this semaphore calls to AcquireTokenAsync can take up
                 // to 5 seconds under high concurrency scenarios.
-#pragma warning disable VSTHRD103 // Call async methods when in an async method
-                acquired = tokenRefreshSemaphore.Wait(SemaphoreTimeout);
-#pragma warning restore VSTHRD103 // Call async methods when in an async method
+
+                acquired = await tokenRefreshSemaphore.WaitAsync(SemaphoreTimeout).ConfigureAwait(false);
 
                 // If we are allowed to enter the semaphore, acquire the token.
                 if (acquired)

--- a/libraries/Microsoft.Bot.Connector/ConversationsEx.cs
+++ b/libraries/Microsoft.Bot.Connector/ConversationsEx.cs
@@ -23,9 +23,7 @@ namespace Microsoft.Bot.Connector
         /// <returns>ConversationResourceResponse.</returns>
         public static ConversationResourceResponse CreateDirectConversation(this IConversations operations, ChannelAccount bot, ChannelAccount user, Activity activity = null)
         {
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             return Task.Factory.StartNew(s => ((IConversations)s).CreateConversationAsync(GetDirectParameters(bot, user, activity)), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         }
 
         /// <summary>
@@ -53,9 +51,7 @@ namespace Microsoft.Bot.Connector
         /// <returns>ConversationResourceResponse.</returns>
         public static ConversationResourceResponse CreateDirectConversation(this IConversations operations, string botAddress, string userAddress, Activity activity = null)
         {
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             return Task.Factory.StartNew(s => ((IConversations)s).CreateConversationAsync(GetDirectParameters(botAddress, userAddress, activity)), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         }
 
         /// <summary>
@@ -85,9 +81,7 @@ namespace Microsoft.Bot.Connector
         /// <returns>ResourceResponse.</returns>
         public static ResourceResponse SendToConversation(this IConversations operations, Activity activity)
         {
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             return Task.Factory.StartNew(s => ((IConversations)s).SendToConversationAsync(activity.Conversation.Id, activity), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         }
 
         /// <summary>
@@ -120,9 +114,7 @@ namespace Microsoft.Bot.Connector
         /// <returns>ResourceResponse.</returns>
         public static ResourceResponse ReplyToActivity(this IConversations operations, Activity activity)
         {
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             return Task.Factory.StartNew(s => ((IConversations)s).ReplyToActivityAsync(activity.Conversation.Id, activity.ReplyToId, activity), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         }
 
         /// <summary>
@@ -160,9 +152,7 @@ namespace Microsoft.Bot.Connector
         /// <returns>ResourceResponse.</returns>
         public static ResourceResponse UpdateActivity(this IConversations operations, Activity activity)
         {
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             return Task.Factory.StartNew(s => ((IConversations)s).UpdateActivityAsync(activity.Conversation.Id, activity.Id, activity), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Streaming/ProtocolAdapter.cs
+++ b/libraries/Microsoft.Bot.Streaming/ProtocolAdapter.cs
@@ -49,9 +49,7 @@ namespace Microsoft.Bot.Streaming
             cancellationToken.ThrowIfCancellationRequested();
             await Task.WhenAll(requestTask, responseTask).ConfigureAwait(false);
 
-#pragma warning disable VSTHRD103 // Call async methods when in an async method
-            return responseTask.Result;
-#pragma warning restore VSTHRD103 // Call async methods when in an async method
+            return await responseTask.ConfigureAwait(false);
         }
 
         private async Task OnReceiveRequestAsync(Guid id, ReceiveRequest request)

--- a/libraries/Microsoft.Bot.Streaming/ReceiveRequestExtensions.cs
+++ b/libraries/Microsoft.Bot.Streaming/ReceiveRequestExtensions.cs
@@ -25,9 +25,7 @@ namespace Microsoft.Bot.Streaming
         /// </returns>
         public static T ReadBodyAsJson<T>(this ReceiveRequest request)
         {
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             return request.ReadBodyAsJsonAsync<T>().GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         }
 
         /// <summary>
@@ -68,9 +66,7 @@ namespace Microsoft.Bot.Streaming
         /// </returns>
         public static string ReadBodyAsString(this ReceiveRequest request)
         {
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             return request.ReadBodyAsStringAsync().GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Streaming/ReceiveResponseExtensions.cs
+++ b/libraries/Microsoft.Bot.Streaming/ReceiveResponseExtensions.cs
@@ -54,9 +54,7 @@ namespace Microsoft.Bot.Streaming
         /// </returns>
         public static string ReadBodyAsString(this ReceiveResponse response)
         {
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             return response.ReadBodyAsStringAsync().GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Streaming/Transport/WebSocket/WebSocketTransport.cs
+++ b/libraries/Microsoft.Bot.Streaming/Transport/WebSocket/WebSocketTransport.cs
@@ -38,9 +38,7 @@ namespace Microsoft.Bot.Streaming.Transport.WebSockets
             {
                 try
                 {
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
                     Task.WaitAll(_socket.CloseAsync(
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
                         WebSocketCloseStatus.NormalClosure,
                         "Closed by the WebSocketTransport",
                         CancellationToken.None));


### PR DESCRIPTION
#minor
## Description
This PR applies the feedback left on PR# 5068.

## Specific Changes
- Fixed issues related to rule VSTHRD103 by adding `await` and `ConfigureAwait(false)`.
- Ignored rules VSTHRD002, VSTHRD003, and VSTHRD011 in **_BotBuilder-DotNet.ruleset_**, and removed related _pragma_ sentences.
- Fix the VSTHRD105 issue by adding `TaskScheduler.Default`.

## Testing
These images show the pipeline running and the test passing after the changes.
![image](https://user-images.githubusercontent.com/44245136/117682787-d0675180-b189-11eb-9e57-71ecc060b23a.png)
