### PR TITLE
Fix refresh token load

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Authentication/AdalAuthenticator.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AdalAuthenticator.cs
@@ -269,8 +269,9 @@ namespace Microsoft.Bot.Connector.Authentication
                 // with and without the semaphore (and different configs for the semaphore), not limiting concurrency actually
                 // results in higher response times overall. Without the use of this semaphore calls to AcquireTokenAsync can take up
                 // to 5 seconds under high concurrency scenarios.
-
-                acquired = await tokenRefreshSemaphore.WaitAsync(SemaphoreTimeout).ConfigureAwait(false);
+#pragma warning disable VSTHRD103 // Call async methods when in an async method
+                acquired = tokenRefreshSemaphore.Wait(SemaphoreTimeout);
+#pragma warning restore VSTHRD103 // Call async methods when in an async method
 
                 // If we are allowed to enter the semaphore, acquire the token.
                 if (acquired)


### PR DESCRIPTION
#minor

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
This PR reverts the change made in PR# 5068 in the token refresh, causing the functional test  `TokenTests_RefreshTestLoad` in `GetTokenRefreshTests` to fail.

## Specific Changes
<!-- Please list the changes in a concise manner. -->
Reverted the change from `WaitAsync` to `Wait`  usage for Sempahore used in the refresh token.
Added the pragma warning for `VSTHRD103` removed in the change.

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->
![image](https://user-images.githubusercontent.com/38112957/118714858-46f2f780-b7f9-11eb-9cca-faf8881b069e.png)