### PR TITLE
[#5166] Add unit tests for Microsoft.Bot.Builder.Dialogs.OAuthPrompt

### DIFF
--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/OAuthPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/OAuthPromptTests.cs
@@ -566,7 +566,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
             var initialActivity = new Activity()
             {
-                ChannelId = Channels.Cortana,
+                ChannelId = Channels.Skype,
                 Text = "hello"
             };
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/OAuthPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/OAuthPromptTests.cs
@@ -19,9 +19,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         private const string UserId = "user-id";
         private const string ConnectionName = "connection-name";
         private const string ChannelId = "channel-id";
+        private const string MagicCode = "888999";
         private const string Token = "token123";
         private const string ExchangeToken = "exch123";
-
+        
         [Fact]
         public void OAuthPromptWithEmptySettingsShouldFail()
         {
@@ -113,8 +114,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var adapter = new TestAdapter()
                 .Use(new AutoSaveStateMiddleware(convoState));
 
-            const string magicCode = "888999";
-
             // Create new DialogSet.
             var dialogs = new DialogSet(dialogState);
             dialogs.Add(new OAuthPrompt("OAuthPrompt", new OAuthPromptSettings() { Text = "Please sign in", ConnectionName = ConnectionName, Title = "Sign in" }));
@@ -164,9 +163,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 Assert.Equal(InputHints.AcceptingInput, ((Activity)activity).InputHint);
 
                 // Add a magic code to the adapter
-                adapter.AddUserToken(ConnectionName, activity.ChannelId, activity.Recipient.Id, Token, magicCode);
+                adapter.AddUserToken(ConnectionName, activity.ChannelId, activity.Recipient.Id, Token, MagicCode);
             })
-            .Send(magicCode)
+            .Send(MagicCode)
             .AssertReply("Logged in.")
             .StartTestAsync();
         }
@@ -233,8 +232,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var adapter = new TestAdapter()
                 .Use(new AutoSaveStateMiddleware(convoState));
 
-            const string magicCode = "888999";
-
             // Create new DialogSet
             var dialogs = new DialogSet(dialogState);
             dialogs.Add(new OAuthPrompt("OAuthPrompt", new OAuthPromptSettings() { Text = "Please sign in", ConnectionName = ConnectionName, Title = "Sign in" }));
@@ -242,7 +239,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             BotCallbackHandler botCallbackHandler = async (turnContext, cancellationToken) =>
             {
                 // Add a magic code to the adapter preemptively so that we can test if the message that triggers BeginDialogAsync uses magic code detection
-                adapter.AddUserToken(ConnectionName, turnContext.Activity.ChannelId, turnContext.Activity.From.Id, Token, magicCode);
+                adapter.AddUserToken(ConnectionName, turnContext.Activity.ChannelId, turnContext.Activity.From.Id, Token, MagicCode);
 
                 var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
 
@@ -261,7 +258,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
             // Call BeginDialogAsync by sending the magic code as the first message. It SHOULD respond with an OAuthPrompt since we haven't authenticated yet
             await new TestFlow(adapter, botCallbackHandler)
-            .Send(magicCode)
+            .Send(MagicCode)
             .AssertReply(activity =>
             {
                 Assert.Single(((Activity)activity).Attachments);
@@ -804,8 +801,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var adapter = new TestAdapter()
                 .Use(new AutoSaveStateMiddleware(convoState));
 
-            const string magicCode = "888999";
-
             // Create new DialogSet.
             var dialogs = new DialogSet(dialogState);
 
@@ -843,7 +838,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 Assert.Equal(OAuthCard.ContentType, ((Activity)activity).Attachments[0].ContentType);
 
                 // Add a magic code to the adapter
-                adapter.AddUserToken(ConnectionName, activity.ChannelId, activity.Recipient.Id, Token, magicCode);
+                adapter.AddUserToken(ConnectionName, activity.ChannelId, activity.Recipient.Id, Token, MagicCode);
 
                 // Add an exchangable token to the adapter
                 adapter.AddExchangeableToken(ConnectionName, activity.ChannelId, activity.Recipient.Id, ExchangeToken, Token);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/OAuthPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/OAuthPromptTests.cs
@@ -663,37 +663,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         }
 
         [Fact]
-        public async Task GetUserTokenShouldReturnToken()
-        {
-            var oauthPromptSettings = new OAuthPromptSettings
-            {
-                ConnectionName = ConnectionName,
-                Text = "Please sign in",
-                Title = "Sign in",
-            };
-
-            var prompt = new OAuthPrompt("OAuthPrompt", oauthPromptSettings);
-            var convoState = new ConversationState(new MemoryStorage());
-            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
-
-            var adapter = new TestAdapter()
-                .Use(new AutoSaveStateMiddleware(convoState));
-
-            adapter.AddUserToken(ConnectionName, ChannelId, UserId, Token);
-
-            // Create new DialogSet.
-            var dialogs = new DialogSet(dialogState);
-            dialogs.Add(prompt);
-
-            var activity = new Activity { ChannelId = ChannelId, From = new ChannelAccount { Id = UserId } };
-            var turnContext = new TurnContext(adapter, activity);
-
-            var userToken = await prompt.GetUserTokenAsync(turnContext, CancellationToken.None);
-            
-            Assert.Equal(Token, userToken.Token);
-        }
-
-        [Fact]
         public async Task OAuthPromptEndOnInvalidMessageSetting()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -742,6 +711,37 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .Send("blah")
             .AssertReply("Ended.")
             .StartTestAsync();
+        }
+
+        [Fact]
+        public async Task GetUserTokenShouldReturnToken()
+        {
+            var oauthPromptSettings = new OAuthPromptSettings
+            {
+                ConnectionName = ConnectionName,
+                Text = "Please sign in",
+                Title = "Sign in",
+            };
+
+            var prompt = new OAuthPrompt("OAuthPrompt", oauthPromptSettings);
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            adapter.AddUserToken(ConnectionName, ChannelId, UserId, Token);
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+            dialogs.Add(prompt);
+
+            var activity = new Activity { ChannelId = ChannelId, From = new ChannelAccount { Id = UserId } };
+            var turnContext = new TurnContext(adapter, activity);
+
+            var userToken = await prompt.GetUserTokenAsync(turnContext, CancellationToken.None);
+            
+            Assert.Equal(Token, userToken.Token);
         }
 
         private async Task OAuthPrompt(IStorage storage)

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/OAuthPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/OAuthPromptTests.cs
@@ -693,6 +693,57 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.Equal(Token, userToken.Token);
         }
 
+        [Fact]
+        public async Task OAuthPromptEndOnInvalidMessageSetting()
+        {
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+            dialogs.Add(new OAuthPrompt("OAuthPrompt", new OAuthPromptSettings() { Text = "Please sign in", ConnectionName = ConnectionName, Title = "Sign in", EndOnInvalidMessage = true }));
+
+            BotCallbackHandler botCallbackHandler = async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    await dc.PromptAsync("OAuthPrompt", new PromptOptions(), cancellationToken: cancellationToken);
+                }
+                else if (results.Status == DialogTurnStatus.Waiting)
+                {
+                    throw new InvalidOperationException("Test OAuthPromptEndOnInvalidMessageSetting expected DialogTurnStatus.Complete");
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    if (results.Result is TokenResponse)
+                    {
+                        await turnContext.SendActivityAsync(MessageFactory.Text("Logged in."), cancellationToken);
+                    }
+                    else
+                    {
+                        await turnContext.SendActivityAsync(MessageFactory.Text("Ended."), cancellationToken);
+                    }
+                }
+            };
+
+            await new TestFlow(adapter, botCallbackHandler)
+            .Send("hello")
+            .AssertReply(activity =>
+            {
+                Assert.Single(((Activity)activity).Attachments);
+                Assert.Equal(OAuthCard.ContentType, ((Activity)activity).Attachments[0].ContentType);
+            })
+            .Send("blah")
+            .AssertReply("Ended.")
+            .StartTestAsync();
+        }
+
         private async Task OAuthPrompt(IStorage storage)
         {
             var convoState = new ConversationState(storage);


### PR DESCRIPTION
Addresses # 5166
## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
This PR updates `OAuthPromptTests.cs` to increase code coverage for `OAuthPrompt.cs` from 64% to 84%.

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - Added unit tests for different parts of the `OAuthPrompt.cs` class.
  - Moved reused variables to properties.
  - Set OAuthPromptEndOnInvalidMessageSetting test to public to make it available

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->
![image](https://user-images.githubusercontent.com/38112957/122114600-d7712780-cdf9-11eb-8f49-225e72635669.png)
