### PR TITLE
[#5676] BotFrameworkAdapter CreateConversationAsync overrides conversationParameters.ChannelData

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -1359,7 +1359,9 @@ namespace Microsoft.Bot.Builder
                 if (tenantId != null)
                 {
                     // Putting tenantId in channelData is a temporary solution while we wait for the Teams API to be updated
-                    conversationParameters.ChannelData = new { tenant = new { tenantId } };
+                    var channelData = JObject.FromObject(conversationParameters.ChannelData ?? new { });
+                    channelData["tenant"] = JToken.FromObject(new { tenantId = reference.Conversation.TenantId });
+                    conversationParameters.ChannelData = channelData;
 
                     // Permanent solution is to put tenantId in parameters.tenantId
                     conversationParameters.TenantId = tenantId;


### PR DESCRIPTION
Fixes # 5676

## Description
This PR updates the [CreateConversationAsync](https://github.com/microsoft/botbuilder-dotnet/blob/baf78d01d4c0b8ddae2d117a52d2a4bca1479683/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs#L1362) method to stop overriding the _conversationParameters.ChannelData_ with the TenantId.

### Detailed Changes
- Updated **_BotFrameworkAdapter_** class to add the TenantId as a new property in _conversationParameters.ChannelData_ instead of overriding the object.

## Testing
These images show a Teams bot failing on the _createConversation_ before the fix and working after applying it.
![image](https://user-images.githubusercontent.com/44245136/123104357-41e32280-d40d-11eb-82fe-4860da4c442e.png)
