### PR TITLE
[#387] Increase Microsoft.Bot.Builder.Azure code coverage

### DIFF
--- a/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobTranscriptStoreTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobTranscriptStoreTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Auth;
 using Microsoft.WindowsAzure.Storage.Blob;
 using Xunit;
 using Xunit.Abstractions;
@@ -70,7 +71,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                     var a = CreateActivity(0, 0, LongId);
 
                     await TranscriptStore.LogActivityAsync(a);
-                    
+
                     throw new XunitException("Should have thrown an error");
                 }
                 catch (StorageException)
@@ -88,6 +89,8 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             {
                 Assert.Throws<FormatException>(() => new AzureBlobTranscriptStore("123", ContainerName));
 
+                Assert.Throws<ArgumentNullException>(() => new AzureBlobTranscriptStore(new CloudStorageAccount(new StorageCredentials(), false), string.Empty));
+
                 Assert.Throws<ArgumentNullException>(() =>
                     new AzureBlobTranscriptStore((CloudStorageAccount)null, ContainerName));
 
@@ -98,6 +101,16 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                     new AzureBlobTranscriptStore((CloudStorageAccount)null, null));
 
                 Assert.Throws<ArgumentNullException>(() => new AzureBlobTranscriptStore((string)null, null));
+            }
+        }
+
+        // These tests require Azure Storage Emulator v5.7
+        [Fact]
+        public async void ListTranscriptsAsyncWithEmptyChannelIdShouldFail()
+        {
+            if (StorageEmulatorHelper.CheckEmulator())
+            {
+                await Assert.ThrowsAsync<ArgumentNullException>(() => TranscriptStore.ListTranscriptsAsync(string.Empty));
             }
         }
     }

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/BlobStorageBaseTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/BlobStorageBaseTests.cs
@@ -49,6 +49,59 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
+        public async Task TestBlobStorageWriteWithNullChangesShouldFail()
+        {
+            if (StorageEmulatorHelper.CheckEmulator())
+            {
+                // Arrange
+                var storage = GetStorage();
+
+                // Assert
+                await Assert.ThrowsAsync<ArgumentNullException>(() => storage.WriteAsync(null));
+            }
+        }
+
+        [Fact]
+        public async Task TestBlobStorageWriteWithEmptyKeyChangesShouldFail()
+        {
+            if (StorageEmulatorHelper.CheckEmulator())
+            {
+                // Arrange
+                var storage = GetStorage();
+
+                var changes = new Dictionary<string, object>
+                {
+                    { string.Empty, "hello" },
+                };
+
+                // Act
+                await Assert.ThrowsAsync<ArgumentNullException>(() => storage.WriteAsync(changes));
+            }
+        }
+
+        [Fact]
+        public async Task TestBlobStorageWriteReadWithNullKeysShouldFail()
+        {
+            if (StorageEmulatorHelper.CheckEmulator())
+            {
+                // Arrange
+                var storage = GetStorage();
+
+                var changes = new Dictionary<string, object>
+                {
+                    { "x", "hello" },
+                    { "y", "world" },
+                };
+
+                // Act
+                await storage.WriteAsync(changes);
+
+                // Assert
+                await Assert.ThrowsAsync<ArgumentNullException>(() => storage.ReadAsync(null));
+            }
+        }
+
+        [Fact]
         public async Task TestBlobStorageWriteDeleteRead()
         {
             if (StorageEmulatorHelper.CheckEmulator())
@@ -70,6 +123,28 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 // Assert
                 Assert.Equal(1, result.Count);
                 Assert.Equal("world", result["y"]);
+            }
+        }
+
+        [Fact]
+        public async Task TestBlobStorageWriteDeleteWithNullKeysShouldFail()
+        {
+            if (StorageEmulatorHelper.CheckEmulator())
+            {
+                // Arrange
+                var storage = GetStorage();
+
+                var changes = new Dictionary<string, object>
+                {
+                    { "x", "hello" },
+                    { "y", "world" },
+                };
+
+                // Act
+                await storage.WriteAsync(changes);
+
+                // Assert
+                await Assert.ThrowsAsync<ArgumentNullException>(() => storage.DeleteAsync(null));
             }
         }
 

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDBKeyEscapeTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDBKeyEscapeTests.cs
@@ -60,6 +60,14 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
+        public void Sanitize_Key_With_Shuffix_Should_Escape_Illegal_Character()
+        {
+            // Ascii code of "?" is "3f".
+            var sanitizedKey = CosmosDbKeyEscape.EscapeKey("?test?", "test", true);
+            Assert.Equal("*3ftest*3ftest", sanitizedKey);
+        }
+
+        [Fact]
         public void Sanitize_Key_Should_Escape_Illegal_Character()
         {
             // Ascii code of "?" is "3f".
@@ -81,6 +89,10 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             // Ascii code of "*" is "2a".
             var sanitizedKey5 = CosmosDbKeyEscape.EscapeKey("*test*");
             Assert.Equal("*2atest*2a", sanitizedKey5);
+
+            // Ascii code of "*" is "2a".
+            var sanitizedKey6 = CosmosDbKeyEscape.EscapeKey("test*");
+            Assert.Equal("test*2a", sanitizedKey6);
 
             // Check a compound key
             var compoundSanitizedKey = CosmosDbKeyEscape.EscapeKey("?#/");

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbPartitionStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbPartitionStorageTests.cs
@@ -54,6 +54,9 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             // No Options. Should throw.
             Assert.Throws<ArgumentNullException>(() => new CosmosDbPartitionedStorage(null));
 
+            // No JsonSerializer. Should throw.
+            Assert.Throws<ArgumentException>(() => new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions(), null));
+
             // No Endpoint. Should throw.
             Assert.Throws<ArgumentException>(() => new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions()
             {
@@ -183,6 +186,13 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         {
             var changes = new Dictionary<string, object>();
             await _storage.WriteAsync(changes);
+        }
+
+        // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
+        [IgnoreOnNoEmulatorFact]
+        public async Task DeletingNullStoreItemsThrowException()
+        {
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _storage.DeleteAsync(null));
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/TranscriptStoreBaseTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/TranscriptStoreBaseTests.cs
@@ -104,6 +104,32 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
+        public async Task TranscriptListTestWithContinuationToken()
+        {
+            if (StorageEmulatorHelper.CheckEmulator())
+            {
+                var a = CreateActivity(0, 0, ConversationIds);
+                await TranscriptStore.LogActivityAsync(a);
+                var result = await TranscriptStore.ListTranscriptsAsync(a.ChannelId, a.Id);
+
+                Assert.Empty(result.Items);
+            }
+        }
+
+        [Fact]
+        public async Task TranscriptListTestWithoutContinuationToken()
+        {
+            if (StorageEmulatorHelper.CheckEmulator())
+            {
+                var a = CreateActivity(0, 0, ConversationIds);
+                await TranscriptStore.LogActivityAsync(a);
+                var result = await TranscriptStore.ListTranscriptsAsync(a.ChannelId);
+
+                Assert.Single(result.Items);
+            }
+        }
+
+        [Fact]
         public async Task ActivityAddSpecialCharsTest()
         {
             if (StorageEmulatorHelper.CheckEmulator())


### PR DESCRIPTION
Fixes #387 (SW Repo)

## Description
This PR increases the code coverage for the `Microsoft.Bot.Builder.Azure` from **85%** up to **89%**.
Originally the coverage was 45%, this was because CosmosDB tests were skipped due to not having [CosmosDBEmulator](https://docs.microsoft.com/en-us/azure/cosmos-db/local-emulator?tabs=ssl-netstd21) locally installed in the machine. After installing it and running again the coverage tests, it went from **45%** to **85%**, we took the opportunity to add more tests to increase a bit more the code coverage.

## Specific Changes
- Added unit tests for:
  - AzureBlobTranscriptStore
  - BlobStorageBase
  - CosmosDBKeyEscape
  - CosmosDbPartitionStorage
  - TranscriptStoreBase

## Testing
The following image shows the before and after the changes that increased the code coverage and the tests that were skipped due to CosmosDBEmulator not being installed.
![imagen](https://user-images.githubusercontent.com/62260472/127552562-6b69f48a-3480-45c7-a621-3aeaf6003db9.png)