### PR TITLE
Increase Microsoft.Bot.Builder.Dialogs.Debugging code coverage

### DIFF
--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/Base/ActiveObjectTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/Base/ActiveObjectTests.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Bot.Builder.Dialogs.Debugging.Base;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests.Base
+{
+    public sealed class ActiveObjectTests
+    {
+        [Fact]
+        public void ActiveObject_NullInvokeAsync_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new ActiveObject(null));
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/Base/ReaderWriterLockTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/Base/ReaderWriterLockTests.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using ReaderWriterLock = Microsoft.Bot.Builder.Dialogs.Debugging.Base.ReaderWriterLock;
+
+namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests.Base
+{
+    public sealed class ReaderWriterLockTests
+    {
+        [Fact]
+        public void ReadWriterLock_DefaultWriter()
+        {
+            Assert.NotNull(new ReaderWriterLock());
+        }
+
+        [Fact]
+        public void ReadWriterLock_WriterTrue()
+        {
+            Assert.NotNull(new ReaderWriterLock(true));
+        }
+
+        [Fact]
+        public async Task ReadWriterLock_Dispose()
+        {
+            var readerWriter = new ReaderWriterLock(true);
+
+            readerWriter.Dispose();
+
+            await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+            {
+                await readerWriter.TryEnterReadAsync(default);
+            });
+        }
+
+        [Fact]
+        public async Task ReadWriterLock_TryEnterReadAsync_AcquiredReader()
+        {
+            var readerWriter = new ReaderWriterLock();
+
+            var acquired = await readerWriter.TryEnterReadAsync(default);
+
+            Assert.True(acquired);
+        }
+
+        [Fact]
+        public async Task ReadWriterLock_TryEnterReadAsync_NoAcquiredReader()
+        {
+            var readerWriter = new ReaderWriterLock(true);
+            
+            var acquired = await readerWriter.TryEnterReadAsync(default);
+
+            Assert.False(acquired);
+        }
+
+        [Fact]
+        public async Task ReadWriterLock_ExitReadAsync()
+        {
+            var readerWriter = new ReaderWriterLock();
+            var token = new CancellationToken();
+
+            var acquired = await readerWriter.TryEnterReadAsync(token);
+            Assert.True(acquired);
+
+            await readerWriter.ExitReadAsync(token);
+
+            var secondAcquired = await readerWriter.TryEnterReadAsync(token);
+            Assert.True(secondAcquired);
+        }
+
+        [Fact]
+        public void ReadWriterLock_ExitWrite()
+        {
+            var readerWriter = new ReaderWriterLock(true);
+
+            // Release the semaphore once.
+            readerWriter.ExitWrite();
+
+            // When trying to release it again it should throw exception
+            Assert.Throws<SemaphoreFullException>(() =>
+            {
+                readerWriter.ExitWrite();
+            });
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/Base/ReleaserTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/Base/ReleaserTests.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using Xunit;
+using Releaser = Microsoft.Bot.Builder.Dialogs.Debugging.Base.Releaser;
+
+namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests.Base
+{
+    public sealed class ReleaserTests
+    {
+        [Fact]
+        public void Releaser_Constructor()
+        {
+            var semaphore = new SemaphoreSlim(1);
+            var releaser = new Releaser(semaphore);
+
+            Assert.Equal(semaphore, releaser.Semaphore);
+        }
+
+        [Fact]
+        public void Releaser_Constructor_NullSemaphore_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Releaser(null));
+        }
+
+        [Fact]
+        public void Releaser_Dispose()
+        {
+            var semaphore = new SemaphoreSlim(1);
+            var releaser = new Releaser(semaphore);
+
+            releaser.Dispose();
+
+            Assert.Equal(2, releaser.Semaphore.CurrentCount);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/CodeModels/CodeModelTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/CodeModels/CodeModelTests.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions;
+using Microsoft.Bot.Builder.Dialogs.Debugging.CodeModels;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests.CodeModels
+{
+    public sealed class CodeModelTests
+    {
+        [Fact]
+        public void CodeModel_NameFor_String_Item()
+        {
+            ICodeModel codeModel = new CodeModel();
+
+            var returnedValue = codeModel.NameFor("item");
+
+            Assert.Equal("String", returnedValue);
+        }
+
+        [Fact]
+        public void CodeModel_NameFor_Dialog_Item()
+        {
+            ICodeModel codeModel = new CodeModel();
+            var item = new WaterfallDialog("dialog-id");
+
+            var returnedValue = codeModel.NameFor(item);
+
+            Assert.Equal(item.Id, returnedValue);
+        }
+
+        [Fact]
+        public void CodeModel_NameFor_Identity_Item()
+        {
+            ICodeModel codeModel = new CodeModel();
+            IItemIdentity item = new OnMessageActivity();
+
+            var returnedValue = codeModel.NameFor(item);
+
+            Assert.Equal("OnMessageActivity[]", returnedValue);
+        }
+
+        [Fact]
+        public void CodeModel_PointsFor()
+        {
+            ICodeModel codeModel = new CodeModel();
+            var item = new WaterfallDialog("dialog-id");
+
+            var activity = MessageFactory.Text("hi");
+            var context = new TurnContext(new TestAdapter(), activity);
+
+            var dialogs = new DialogSet();
+            dialogs.Add(item);
+
+            var dc = new DialogContext(dialogs, context, new DialogState());
+
+            var instance = new DialogInstance { Id = "dialog-id" };
+
+            dc.Stack.Add(instance);
+
+            var codePoints = codeModel.PointsFor(dc, item, "more");
+
+            Assert.Equal(item, codePoints[0].Item);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/CodeModels/CodePointTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/CodeModels/CodePointTests.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Builder.Dialogs.Debugging.CodeModels;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests.CodeModels
+{
+    public sealed class CodePointTests
+    {
+        [Fact]
+        public void CodePoint_Constructor()
+        {
+            ICodeModel codeModel = new CodeModel();
+            var activity = MessageFactory.Text("hi");
+            var context = new TurnContext(new TestAdapter(), activity);
+            var dc = new DialogContext(new DialogSet(), context, new DialogState());
+            ICodePoint codePoint = new CodePoint(codeModel, dc, "test-item", "more");
+
+            Assert.Equal("test-item", codePoint.Item);
+            Assert.Equal("more", codePoint.More);
+            Assert.NotNull(codePoint.Data);
+        }
+
+        [Fact]
+        public void CodePoint_ToString()
+        {
+            ICodeModel codeModel = new CodeModel();
+            var activity = MessageFactory.Text("hi");
+            var context = new TurnContext(new TestAdapter(), activity);
+            var dc = new DialogContext(new DialogSet(), context, new DialogState());
+            ICodePoint codePoint = new CodePoint(codeModel, dc, "test-item", "more");
+
+            Assert.Equal(codePoint.ToString(), codePoint.Name);
+        }
+
+        [Fact]
+        public void CodePoint_Evaluate_Invalid_Expression_Throws()
+        {
+            ICodeModel codeModel = new CodeModel();
+            var activity = MessageFactory.Text("hi");
+            var context = new TurnContext(new TestAdapter(), activity);
+            var dc = new DialogContext(new DialogSet(), context, new DialogState());
+            ICodePoint codePoint = new CodePoint(codeModel, dc, "test-item", "more");
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                codePoint.Evaluate("test-expression");
+            });
+        }
+
+        [Fact]
+        public void CodePoint_Evaluate()
+        {
+            ICodeModel codeModel = new CodeModel();
+            var activity = MessageFactory.Text("hi");
+            var context = new TurnContext(new TestAdapter(), activity);
+            var dc = new DialogContext(new DialogSet(), context, new DialogState());
+            ICodePoint codePoint = new CodePoint(codeModel, dc, "test-item", "more");
+
+            var result = codePoint.Evaluate("123");
+            
+            Assert.Equal(123, result);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/DataModels/CoercionTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/DataModels/CoercionTests.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Builder.Dialogs.Debugging.DataModels;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests.DataModels
+{
+    public sealed class CoercionTests
+    {
+        [Fact]
+        public void Coercion_Coerce()
+        {
+            ICoercion coercion = new Coercion();
+
+            var result = coercion.Coerce("source", typeof(string));
+
+            Assert.Equal("source", result);
+        }
+
+        [Fact]
+        public void Coercion_Coerce_JToken()
+        {
+            ICoercion coercion = new Coercion();
+            var writer = new JTokenWriter();
+            writer.WriteStartObject();
+            writer.WritePropertyName("type");
+            writer.WriteValue("request");
+            writer.WritePropertyName("command");
+            writer.WriteValue("launch");
+            writer.WriteEndObject();
+
+            var result = coercion.Coerce(writer.Token, typeof(JToken));
+
+            Assert.Equal(writer.Token, result);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/DataModels/DataModelsTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/DataModels/DataModelsTests.cs
@@ -1,0 +1,353 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Bot.Builder.Dialogs.Debugging.DataModels;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests.DataModels
+{
+    public sealed class DataModelsTests
+    {
+        [Fact]
+        public void DataModel_Properties()
+        {
+            ICoercion coercion = new Coercion();
+            IDataModel dataModel = new DataModel(coercion);
+
+            Assert.Equal(2147483647, dataModel.Rank);
+
+            var scalar = dataModel.IsScalar("context");
+            Assert.True(scalar);
+
+            scalar = dataModel.IsScalar(null);
+            Assert.True(scalar);
+
+            var names = dataModel.Names("context");
+            Assert.Empty(names);
+        }
+
+        [Fact]
+        public void DataModel_ToString()
+        {
+            ICoercion coercion = new Coercion();
+            IDataModel dataModel = new DataModel(coercion);
+
+            var model = dataModel.ToString("context");
+            Assert.Equal("context", model);
+
+            var jTokenResult = dataModel.ToString(new JValue(true));
+            Assert.Equal("True", jTokenResult);
+
+            var classResult = dataModel.ToString(new Coercion());
+            Assert.Equal("Microsoft.Bot.Builder.Dialogs.Debugging.DataModels.Coercion", classResult);
+
+            var enumerableTypeResult = dataModel.ToString(new TestEnumerableDataModel());
+            Assert.Equal(
+                "Microsoft.Bot.Builder.Dialogs.Debugging.Tests.DataModels.DataModelsTests+TestEnumerableDataModel",
+                enumerableTypeResult);
+
+            var readOnlyDictionaryTypeResult = dataModel.ToString(new TestReadOnlyDictionaryDataModel());
+            Assert.Equal(
+                "Microsoft.Bot.Builder.Dialogs.Debugging.Tests.DataModels.DataModelsTests+TestReadOnlyDictionaryDataModel",
+                readOnlyDictionaryTypeResult);
+
+            var dictionaryTypeResult = dataModel.ToString(new TestDictionaryDataModel());
+            Assert.Equal(
+                "Microsoft.Bot.Builder.Dialogs.Debugging.Tests.DataModels.DataModelsTests+TestDictionaryDataModel",
+                dictionaryTypeResult);
+
+            var listTypeResult = dataModel.ToString(new TestListDataModel());
+            Assert.Equal("Microsoft.Bot.Builder.Dialogs.Debugging.Tests.DataModels.DataModelsTests+TestListDataModel", listTypeResult);
+        }
+
+        [Fact]
+        public void DictionaryDataModel_Properties()
+        {
+            ICoercion coercion = new Coercion();
+            var dictionaryDataModel = new DictionaryDataModel<string, string>(coercion);
+
+            Assert.Equal(6, dictionaryDataModel.Rank);
+
+            var context = new Dictionary<string, string> { { "key", "value" } };
+            var names = dictionaryDataModel.Names(context);
+            Assert.Single(names);
+            Assert.Equal("key", names.First());
+        }
+
+        [Fact]
+        public void EnumerableDataModel_Properties()
+        {
+            ICoercion coercion = new Coercion();
+            var dictionaryDataModel = new EnumerableDataModel<string>(coercion);
+
+            Assert.Equal(3, dictionaryDataModel.Rank);
+
+            var names = dictionaryDataModel.Names(new List<string> { "context" });
+            Assert.Single(names);
+            Assert.Equal(0, names.First());
+        }
+
+        [Fact]
+        public void JValueDataModel_Properties()
+        {
+            var jValueDataModel = JValueDataModel.Instance;
+
+            Assert.Equal(1, jValueDataModel.Rank);
+
+            Assert.True(jValueDataModel.IsScalar("context"));
+
+            Assert.Empty(jValueDataModel.Names("context"));
+
+            Assert.Equal("context", jValueDataModel.ToString("context"));
+        }
+
+        [Fact]
+        public void ListDataModel_Properties()
+        {
+            ICoercion coercion = new Coercion();
+            IDataModel listDataModel = new ListDataModel<string>(coercion);
+
+            Assert.Equal(4, listDataModel.Rank);
+
+            var names = listDataModel.Names(new List<string> { "context" });
+            Assert.Single(names);
+        }
+
+        [Fact]
+        public void NullDataModel_Properties()
+        {
+            var nullDataModel = NullDataModel.Instance;
+
+            Assert.Equal(0, nullDataModel.Rank);
+
+            Assert.True(nullDataModel.IsScalar("context"));
+
+            Assert.Empty(nullDataModel.Names("context"));
+
+            Assert.Equal("null", nullDataModel.ToString("context"));
+        }
+
+        [Fact]
+        public void ReadOnlyDictionaryDataModel_Properties()
+        {
+            ICoercion coercion = new Coercion();
+            var readOnlyDictDataModel = new ReadOnlyDictionaryDataModel<string, string>(coercion);
+
+            Assert.Equal(5, readOnlyDictDataModel.Rank);
+
+            var context = new Dictionary<string, string> { { "key", "value" } };
+            var names = readOnlyDictDataModel.Names(context);
+            Assert.Single(names);
+            Assert.Equal("key", names.First());
+        }
+
+        [Fact]
+        public void ReflectionDataModel_Properties()
+        {
+            ICoercion coercion = new Coercion();
+            IDataModel reflectionDataModel = new ReflectionDataModel<string>(coercion);
+
+            Assert.Equal(2, reflectionDataModel.Rank);
+
+            var names = reflectionDataModel.Names(new List<string> { "context" });
+            Assert.Equal(2, names.Count());
+        }
+
+        [Fact]
+        public void ScalarDataModel_Properties()
+        {
+            var scalarDataModel = ScalarDataModel.Instance;
+
+            Assert.Equal(1, scalarDataModel.Rank);
+
+            Assert.True(scalarDataModel.IsScalar("context"));
+
+            Assert.Empty(scalarDataModel.Names("context"));
+
+            Assert.Equal("context", scalarDataModel.ToString("context"));
+        }
+
+        internal class TestEnumerableDataModel : IEnumerable<string>
+        {
+            public IEnumerator<string> GetEnumerator()
+            {
+                throw new System.NotImplementedException();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                throw new System.NotImplementedException();
+            }
+        }
+
+        internal class TestReadOnlyDictionaryDataModel : IReadOnlyDictionary<string, string>
+        {
+            public IEnumerable<string> Keys => throw new System.NotImplementedException();
+
+            public IEnumerable<string> Values => throw new System.NotImplementedException();
+
+            public int Count => throw new System.NotImplementedException();
+
+            public string this[string key] => throw new System.NotImplementedException();
+
+            public bool ContainsKey(string key)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public IEnumerator<KeyValuePair<string, string>> GetEnumerator()
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public bool TryGetValue(string key, out string value)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                throw new System.NotImplementedException();
+            }
+        }
+
+        internal class TestDictionaryDataModel : IDictionary<string, string>
+        {
+            public int Count => throw new System.NotImplementedException();
+
+            public bool IsReadOnly => throw new System.NotImplementedException();
+
+            public ICollection<string> Values => throw new System.NotImplementedException();
+
+            public ICollection<string> Keys => throw new System.NotImplementedException();
+
+            public string this[string key]
+            {
+                get => throw new System.NotImplementedException();
+                set => throw new System.NotImplementedException();
+            }
+
+            public void Add(string key, string value)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public void Add(KeyValuePair<string, string> item)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public void Clear()
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public bool Contains(KeyValuePair<string, string> item)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public bool ContainsKey(string key)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public void CopyTo(KeyValuePair<string, string>[] array, int arrayIndex)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public IEnumerator<KeyValuePair<string, string>> GetEnumerator()
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public bool Remove(string key)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public bool Remove(KeyValuePair<string, string> item)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public bool TryGetValue(string key, out string value)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                throw new System.NotImplementedException();
+            }
+        }
+
+        internal class TestListDataModel : IList<string>
+        {
+            public int Count => throw new System.NotImplementedException();
+
+            public bool IsReadOnly => throw new System.NotImplementedException();
+
+            public string this[int index]
+            {
+                get => throw new System.NotImplementedException();
+                set => throw new System.NotImplementedException();
+            }
+
+            public void Add(string item)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public void Clear()
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public bool Contains(string item)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public void CopyTo(string[] array, int arrayIndex)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public IEnumerator<string> GetEnumerator()
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public int IndexOf(string item)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public void Insert(int index, string item)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public bool Remove(string item)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public void RemoveAt(int index)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                throw new System.NotImplementedException();
+            }
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/DebuggerSourceMapTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/DebuggerSourceMapTests.cs
@@ -1,0 +1,259 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Bot.Builder.Dialogs.Debugging.CodeModels;
+using Microsoft.Bot.Builder.Dialogs.Debugging.Protocol;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests
+{
+    public sealed class DebuggerSourceMapTests
+    {
+        [Fact]
+        public void DebuggerSourceMap_Constructor_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                new DebuggerSourceMap(null);
+            });
+        }
+
+        [Fact]
+        public void DebuggerSourceMap_Constructor_Works()
+        {
+            var codeModel = new CodeModel();
+            Assert.NotNull(new DebuggerSourceMap(codeModel));
+        }
+
+        [Fact]
+        public void DebuggerSourceMap_Assign_Item()
+        {
+            var stackFrame = new StackFrame
+            {
+                Id = 1,
+                Name = "TestFrame"
+            };
+
+            DebuggerSourceMap.Assign(stackFrame, "item", "more");
+
+            Assert.Equal("item", stackFrame.Item);
+            Assert.Equal("more", stackFrame.More);
+        }
+
+        [Fact]
+        public void DebuggerSourceMap_Assign_Null_SourceRange()
+        {
+            var stackFrame = new StackFrame
+            {
+                Id = 1,
+                Name = "TestFrame"
+            };
+
+            DebuggerSourceMap.Assign(stackFrame, null);
+
+            Assert.Null(stackFrame.Designer);
+            Assert.Null(stackFrame.Source);
+            Assert.Null(stackFrame.Line);
+            Assert.Null(stackFrame.EndLine);
+            Assert.Null(stackFrame.Column);
+            Assert.Null(stackFrame.EndColumn);
+        }
+
+        [Fact]
+        public void DebuggerSourceMap_Assign_SourceRange()
+        {
+            var stackFrame = new StackFrame
+            {
+                Id = 1,
+                Name = "TestFrame"
+            };
+            var sourceRange = new SourceRange
+            {
+                Designer = "testDesigner",
+                Path = "test.path",
+                StartPoint = new SourcePoint(0, 0),
+                EndPoint = new SourcePoint(10, 10)
+            };
+
+            DebuggerSourceMap.Assign(stackFrame, sourceRange);
+
+            Assert.Equal(sourceRange.Designer, stackFrame.Designer);
+            Assert.Equal(sourceRange.Path, stackFrame.Source.Path);
+            Assert.Equal(sourceRange.StartPoint.LineIndex, stackFrame.Line);
+            Assert.Equal(sourceRange.EndPoint.LineIndex, stackFrame.EndLine);
+            Assert.Equal(sourceRange.StartPoint.CharIndex, stackFrame.Column);
+            Assert.Equal(sourceRange.EndPoint.CharIndex, stackFrame.EndColumn);
+        }
+
+        [Fact]
+        public void DebuggerSourceMap_Equals_Null_Source()
+        {
+            var stackFrame = new StackFrame
+            {
+                Id = 1,
+                Name = "TestFrame",
+                Source = null
+            };
+
+            Assert.True(DebuggerSourceMap.Equals(stackFrame, null));
+        }
+
+        [Fact]
+        public void DebuggerSourceMap_Equals_False()
+        {
+            var stackFrame = new StackFrame
+            {
+                Id = 1,
+                Name = "TestFrame",
+                Source = new Source("test.source.path")
+            };
+            var sourceRange = new SourceRange
+            {
+                Designer = "testDesigner",
+                Path = "test.path",
+                StartPoint = new SourcePoint(0, 0),
+                EndPoint = new SourcePoint(10, 10)
+            };
+
+            Assert.False(DebuggerSourceMap.Equals(stackFrame, sourceRange));
+        }
+
+        [Fact]
+        public void DebuggerSourceMap_Equals_True()
+        {
+            var stackFrame = new StackFrame
+            {
+                Id = 1,
+                Name = "TestFrame"
+            };
+            var sourceRange = new SourceRange
+            {
+                Designer = "testDesigner",
+                Path = "path/test",
+                StartPoint = new SourcePoint(0, 0),
+                EndPoint = new SourcePoint(10, 10)
+            };
+
+            DebuggerSourceMap.Assign(stackFrame, sourceRange);
+
+            Assert.True(DebuggerSourceMap.Equals(stackFrame, sourceRange));
+        }
+
+        [Fact]
+        public void DebuggerSourceMap_Equals_True_With_Resources()
+        {
+            var stackFrame = new StackFrame
+            {
+                Id = 1,
+                Name = "TestFrame"
+            };
+            var sourceRange = new SourceRange
+            {
+                Designer = "testDesigner",
+                Path = "path/test.dialog",
+                StartPoint = new SourcePoint(0, 0),
+                EndPoint = new SourcePoint(10, 10)
+            };
+
+            DebuggerSourceMap.Assign(stackFrame, sourceRange);
+
+            Assert.True(DebuggerSourceMap.Equals(stackFrame, sourceRange));
+        }
+
+        [Fact]
+        public void DebuggerSourceMap_Add_InvalidPath_Throws()
+        {
+            var codeModel = new CodeModel();
+            ISourceMap sourceMap = new DebuggerSourceMap(codeModel);
+
+            var sourceRange = new SourceRange
+            {
+                Path = "test.path"
+            };
+
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                sourceMap.Add("test-item", sourceRange);
+            });
+        }
+
+        [Fact]
+        public void DebuggerSourceMap_Add()
+        {
+            var codeModel = new CodeModel();
+            ISourceMap sourceMap = new DebuggerSourceMap(codeModel);
+            const string item = "test-item";
+
+            var sourceRange = new SourceRange
+            {
+                Designer = "testDesigner",
+                Path = "c:/test/path",
+                StartPoint = new SourcePoint(0, 0),
+                EndPoint = new SourcePoint(10, 10)
+            };
+
+            sourceMap.Add(item, sourceRange);
+
+            Assert.True(sourceMap.TryGetValue(item, out _));
+        }
+
+        [Fact]
+        public void DebuggerSourceMap_Add_With_Remove()
+        {
+            var codeModel = new CodeModel();
+            ISourceMap sourceMap = new DebuggerSourceMap(codeModel);
+            const string item = "test-item";
+
+            var sourceRange = new SourceRange
+            {
+                Designer = "testDesigner",
+                Path = "c:/test/path",
+                StartPoint = new SourcePoint(0, 0),
+                EndPoint = new SourcePoint(10, 10)
+            };
+
+            // Add the item to the map.
+            sourceMap.Add(item, sourceRange);
+            Assert.True(sourceMap.TryGetValue(item, out _));
+
+            // Add the same item so it removes it from the map before adding it again.
+            sourceMap.Add(item, sourceRange);
+            Assert.True(sourceMap.TryGetValue(item, out _));
+        }
+
+        [Fact]
+        public void DebuggerSourceMap_SetBreakpoints_Source()
+        {
+            var codeModel = new CodeModel();
+            IBreakpoints sourceMap = new DebuggerSourceMap(codeModel);
+            var breakpointList = new List<SourceBreakpoint>
+            {
+                new SourceBreakpoint { Line = 1 }
+            };
+
+            var source = new Source("/test-path")
+            {
+                Name = "testSource"
+            };
+
+            var breakpoints = sourceMap.SetBreakpoints(source, breakpointList);
+            Assert.Single(breakpoints);
+        }
+
+        [Fact]
+        public void DebuggerSourceMap_SetBreakpoints_Function()
+        {
+            var codeModel = new CodeModel();
+            IBreakpoints sourceMap = new DebuggerSourceMap(codeModel);
+            var breakpointList = new List<FunctionBreakpoint>
+            {
+                new FunctionBreakpoint { Name = "test-breakpoint" }
+            };
+
+            var breakpoints = sourceMap.SetBreakpoints(breakpointList);
+            Assert.Equal(1, breakpoints.Count);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/DebuggingBotAdapterExtensionsTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/DebuggingBotAdapterExtensionsTests.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Linq;
+using Microsoft.Bot.Builder.Dialogs.Debugging.CodeModels;
+using Microsoft.Bot.Connector.Authentication;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests
+{
+    public sealed class DebuggingBotAdapterExtensionsTests
+    {
+        [Fact]
+        public void DebuggingBotAdapterExtensions_UseDebugger()
+        {
+            var codeModel = new CodeModel();
+            ISourceMap sourceMap = new DebuggerSourceMap(codeModel);
+
+            var adapter = new BotFrameworkAdapter(new SimpleCredentialProvider());
+
+            Assert.Single(adapter.MiddlewareSet);
+            
+            adapter.UseDebugger(3982, sourceMap);
+
+            Assert.Equal(2, adapter.MiddlewareSet.Count());
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/DialogDebugAdapterTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/DialogDebugAdapterTests.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Bot.Builder.Dialogs.Debugging.CodeModels;
+using Microsoft.Bot.Builder.Dialogs.Debugging.Transport;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests
+{
+    public sealed class DialogDebugAdapterTests
+    {
+        [Fact]
+        public void DialogDebugAdapter_Constructor_Default_Values()
+        {
+            var codeModel = new CodeModel();
+            IBreakpoints breakpoints = new DebuggerSourceMap(codeModel);
+
+            var adapter = new DialogDebugAdapter(
+                new DebugTransport(3983, null),
+                DebugSupport.SourceMap,
+                breakpoints,
+                null,
+                null,
+                null,
+                null,
+                null);
+            
+            Assert.NotNull(adapter);
+        }
+
+        [Fact]
+        public void DialogDebugAdapter_Constructor_Null_Transport_Throws()
+        {
+            var codeModel = new CodeModel();
+            IBreakpoints breakpoints = new DebuggerSourceMap(codeModel);
+
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var adapter = new DialogDebugAdapter(
+                null,
+                DebugSupport.SourceMap,
+                breakpoints,
+                null,
+                null,
+                null,
+                null,
+                null);
+            });
+        }
+
+        [Fact]
+        public void DialogDebugAdapter_Constructor_Null_sourceMap_Throws()
+        {
+            var codeModel = new CodeModel();
+            IBreakpoints breakpoints = new DebuggerSourceMap(codeModel);
+
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var adapter = new DialogDebugAdapter(
+                    new DebugTransport(3984, null),
+                    null,
+                    breakpoints,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null);
+            });
+        }
+
+        [Fact]
+        public void DialogDebugAdapter_Constructor_Null_BreakPoints_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var adapter = new DialogDebugAdapter(
+                    new DebugTransport(3985, null),
+                    DebugSupport.SourceMap,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null);
+            });
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/Events/EventsTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/Events/EventsTests.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.Bot.Builder.Dialogs.Debugging.Events;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests.Events
+{
+    public sealed class EventsTests
+    {
+        [Fact]
+        public void Events_Reset()
+        {
+            IEvents events = new Events<DialogEvents>();
+
+            Assert.True(events["activityReceived"]);
+            Assert.True(events["error"]);
+
+            events["testFilter"] = true;
+
+            var filters = new List<string>
+            {
+                "error", "testFilter"
+            };
+
+            events.Reset(filters);
+
+            Assert.False(events["activityReceived"]);
+            Assert.True(events["error"]);
+            Assert.True(events["testFilter"]);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/Identifiers/IdentifierCacheTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/Identifiers/IdentifierCacheTests.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Builder.Dialogs.Debugging.Identifiers;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests.Identifiers
+{
+    public sealed class IdentifierCacheTests
+    {
+        [Fact]
+        public void IdentifierCache_Items()
+        {
+            IIdentifier<string> identCache = new IdentifierCache<string>(new Identifier<string>(), 1);
+
+            var items = identCache.Items;
+
+            Assert.NotNull(items);
+        }
+
+        [Fact]
+        public void IdentifierCache_Add()
+        {
+            IIdentifier<string> identCache = new IdentifierCache<string>(new Identifier<string>(), 1);
+
+            var code = identCache.Add("item");
+
+            Assert.Equal(1ul, code);
+        }
+
+        [Fact]
+        public void IdentifierCache_TryGetValue()
+        {
+            IIdentifier<string> identCache = new IdentifierCache<string>(new Identifier<string>(), 1);
+
+            var code = identCache.Add("item");
+            identCache.TryGetValue("item", out var result);
+
+            Assert.Equal(code, result);
+
+            identCache.TryGetValue(code, out var item);
+            
+            Assert.Equal("item", item);
+        }
+
+        [Fact]
+        public void IdentifierCache_Remove()
+        {
+            IIdentifier<string> identCache = new IdentifierCache<string>(new Identifier<string>(), 1);
+
+            var code = identCache.Add("item");
+            Assert.True(identCache.TryGetValue(code, out var item));
+
+            identCache.Remove(item);
+            Assert.False(identCache.TryGetValue(code, out _));
+        }
+
+        [Fact]
+        public void IdentifierCache_Clear()
+        {
+            IIdentifier<string> identCache = new IdentifierCache<string>(new Identifier<string>(), 1);
+
+            var code = identCache.Add("item");
+            Assert.True(identCache.TryGetValue(code, out var item));
+
+            identCache.Clear();
+            Assert.False(identCache.TryGetValue(code, out _));
+        }
+
+        [Fact]
+        public void IdentifierCache_GetEnumerator()
+        {
+            IIdentifier<string> identCache = new IdentifierCache<string>(new Identifier<string>(), 1);
+
+            var code1 = identCache.Add("item");
+            Assert.True(identCache.TryGetValue(code1, out _));
+
+            Assert.NotNull(identCache.GetEnumerator());
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/Identifiers/IdentifierMutexTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/Identifiers/IdentifierMutexTests.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Builder.Dialogs.Debugging.Identifiers;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests.Identifiers
+{
+    public sealed class IdentifierMutexTests
+    {
+        [Fact]
+        public void IdentifierMutex_Items()
+        {
+            IIdentifier<string> mutexIdent = new IdentifierMutex<string>(new Identifier<string>());
+
+            var items = mutexIdent.Items;
+
+            Assert.NotNull(items);
+        }
+
+        [Fact]
+        public void IdentifierMutex_Add()
+        {
+            IIdentifier<string> mutexIdent = new IdentifierMutex<string>(new Identifier<string>());
+
+            var code = mutexIdent.Add("item");
+
+            Assert.Equal(1ul, code);
+        }
+
+        [Fact]
+        public void IdentifierMutex_TryGetValue()
+        {
+            IIdentifier<string> mutexIdent = new IdentifierMutex<string>(new Identifier<string>());
+
+            var code = mutexIdent.Add("item");
+            mutexIdent.TryGetValue("item", out var result);
+
+            Assert.Equal(code, result);
+
+            mutexIdent.TryGetValue(code, out var item);
+            
+            Assert.Equal("item", item);
+        }
+
+        [Fact]
+        public void IdentifierMutex_Remove()
+        {
+            IIdentifier<string> mutexIdent = new IdentifierMutex<string>(new Identifier<string>());
+
+            var code = mutexIdent.Add("item");
+            Assert.True(mutexIdent.TryGetValue(code, out var item));
+
+            mutexIdent.Remove(item);
+            Assert.False(mutexIdent.TryGetValue(code, out _));
+        }
+
+        [Fact]
+        public void IdentifierMutex_Clear()
+        {
+            IIdentifier<string> mutexIdent = new IdentifierMutex<string>(new Identifier<string>());
+
+            var code = mutexIdent.Add("item");
+            Assert.True(mutexIdent.TryGetValue(code, out var item));
+
+            mutexIdent.Clear();
+            Assert.False(mutexIdent.TryGetValue(code, out _));
+        }
+
+        [Fact]
+        public void IdentifierMutex_GetEnumerator()
+        {
+            IIdentifier<string> mutexIdent = new IdentifierMutex<string>(new Identifier<string>());
+
+            var code1 = mutexIdent.Add("item");
+
+            Assert.True(mutexIdent.TryGetValue(code1, out _));
+
+            Assert.NotNull(mutexIdent.GetEnumerator());
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/Identifiers/identifierTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/Identifiers/identifierTests.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using Microsoft.Bot.Builder.Dialogs.Debugging.Identifiers;
 using Xunit;
 
-namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests
+namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests.Identifiers
 {
     public sealed class IdentifierTests
     {

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/Protocol/ProtocolTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/Protocol/ProtocolTests.cs
@@ -1,0 +1,266 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Bot.Builder.Dialogs.Debugging.Protocol;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests.Protocol
+{
+    public sealed class ProtocolTests
+    {
+        [Fact]
+        public void BreakPoint_Get_Set()
+        {
+            var breakPoint = new Breakpoint
+            {
+                Message = "test message",
+                Verified = true
+            };
+
+            Assert.Equal("test message", breakPoint.Message);
+            Assert.True(breakPoint.Verified);
+        }
+
+        [Fact]
+        public void Disconnect_Get_Set()
+        {
+            var disconnect = new Disconnect
+            {
+                Restart = true,
+                TerminateDebuggee = false
+            };
+
+            Assert.True(disconnect.Restart);
+            Assert.False(disconnect.TerminateDebuggee);
+        }
+
+        [Fact]
+        public void Evaluate_Get_Set()
+        {
+            var evaluate = new Evaluate
+            {
+                FrameId = 0ul,
+                Expression = "test expression"
+            };
+
+            Assert.Equal(0ul, evaluate.FrameId);
+            Assert.Equal("test expression", evaluate.Expression);
+        }
+
+        [Fact]
+        public void ProtocolMessage_SwitchCase()
+        {
+            var writer = new JTokenWriter();
+            writer.WriteStartObject();
+            writer.WritePropertyName("type");
+            writer.WriteValue("request");
+            writer.WritePropertyName("command");
+            writer.WriteValue("launch");
+            writer.WriteEndObject();
+
+            var token = writer.Token;
+            var request = ProtocolMessage.Parse(token);
+            Assert.Equal("launch", request.Command);
+
+            token["command"] = "setBreakpoints";
+            request = ProtocolMessage.Parse(token);
+            Assert.Equal("setBreakpoints", request.Command);
+
+            token["command"] = "setFunctionBreakpoints";
+            request = ProtocolMessage.Parse(token);
+            Assert.Equal("setFunctionBreakpoints", request.Command);
+
+            token["command"] = "setExceptionBreakpoints";
+            request = ProtocolMessage.Parse(token);
+            Assert.Equal("setExceptionBreakpoints", request.Command);
+
+            token["command"] = "configurationDone";
+            request = Debugging.Protocol.ProtocolMessage.Parse(token);
+            Assert.Equal("configurationDone", request.Command);
+
+            token["command"] = "stackTrace";
+            request = ProtocolMessage.Parse(token);
+            Assert.Equal("stackTrace", request.Command);
+
+            token["command"] = "scopes";
+            request = ProtocolMessage.Parse(token);
+            Assert.Equal("scopes", request.Command);
+
+            token["command"] = "variables";
+            request = ProtocolMessage.Parse(token);
+            Assert.Equal("variables", request.Command);
+
+            token["command"] = "setVariable";
+            request = ProtocolMessage.Parse(token);
+            Assert.Equal("setVariable", request.Command);
+
+            token["command"] = "evaluate";
+            request = ProtocolMessage.Parse(token);
+            Assert.Equal("evaluate", request.Command);
+
+            token["command"] = "continue";
+            request = ProtocolMessage.Parse(token);
+            Assert.Equal("continue", request.Command);
+
+            token["command"] = "pause";
+            request = ProtocolMessage.Parse(token);
+            Assert.Equal("pause", request.Command);
+
+            token["command"] = "stepIn";
+            request = ProtocolMessage.Parse(token);
+            Assert.Equal("stepIn", request.Command);
+
+            token["command"] = "stepOut";
+            request = ProtocolMessage.Parse(token);
+            Assert.Equal("stepOut", request.Command);
+
+            token["command"] = "terminate";
+            request = ProtocolMessage.Parse(token);
+            Assert.Equal("terminate", request.Command);
+
+            token["command"] = "disconnect";
+            request = ProtocolMessage.Parse(token);
+            Assert.Equal("disconnect", request.Command);
+
+            token["type"] = "other";
+            Assert.Throws<NotImplementedException>(() =>
+                ProtocolMessage.Parse(token));
+        }
+
+        [Fact]
+        public void Request_ToString()
+        {
+            var request = new Request { Command = "test-command" };
+
+            Assert.Equal("test-command", request.Command);
+            Assert.Equal("test-command", request.ToString());
+        }
+
+        [Fact]
+        public void Response_Get_Set()
+        {
+            var response = new Response(2, new Request())
+            {
+                Message = "test-message"
+            };
+
+            Assert.Equal("test-message", response.Message);
+        }
+
+        [Fact]
+        public void Response_Fail()
+        {
+            var result = Response.Fail(3, new Request(), "fail message");
+            Assert.Equal("fail message", result.Message);
+            Assert.Equal("fail message", result.Body);
+            Assert.False(result.Success);
+        }
+
+        [Fact]
+        public void Scopes_Get_Set()
+        {
+            var scopes = new Scopes { FrameId = 0ul };
+
+            Assert.Equal(0ul, scopes.FrameId);
+        }
+
+        [Fact]
+        public void SetBreakpoints_Get_Set()
+        {
+            var setBreakpoints = new SetBreakpoints
+            {
+                Source = new Source("/test/path"),
+                Breakpoints = new[] { new SourceBreakpoint() },
+                SourceModified = false
+            };
+
+            Assert.Equal("/test/path", setBreakpoints.Source.Path);
+            Assert.Single(setBreakpoints.Breakpoints);
+            Assert.False(setBreakpoints.SourceModified);
+        }
+
+        [Fact]
+        public void SetExceptionBreakpoints_Get_Set()
+        {
+            var setBreakpoints = new SetExceptionBreakpoints { Filters = new[] { "testFilter" } };
+
+            Assert.Single(setBreakpoints.Filters);
+            Assert.Equal("testFilter", setBreakpoints.Filters[0]);
+        }
+
+        [Fact]
+        public void SetFunctionBreakpoints_Get_Set()
+        {
+            var setBreakpoints = new SetFunctionBreakpoints { Breakpoints = new[] { new FunctionBreakpoint { Name = "test-breakpoint" } } };
+
+            Assert.Single(setBreakpoints.Breakpoints);
+            Assert.Equal("test-breakpoint", setBreakpoints.Breakpoints[0].Name);
+        }
+
+        [Fact]
+        public void SetVariable_Get_Set()
+        {
+            var variable = new SetVariable
+            {
+                VariablesReference = 0ul,
+                Name = "test-variable",
+                Value = "value"
+            };
+
+            Assert.Equal(0ul, variable.VariablesReference);
+            Assert.Equal("test-variable", variable.Name);
+            Assert.Equal("value", variable.Value);
+        }
+
+        [Fact]
+        public void Source_Get_Set()
+        {
+            var source = new Source("/test/path")
+            {
+                Name = "test-source"
+            };
+
+            Assert.Equal("/test/path", source.Path);
+            Assert.Equal("test-source", source.Name);
+        }
+
+        [Fact]
+        public void StackTrace_Get_Set()
+        {
+            var stackTrace = new StackTrace
+            {
+                StartFrame = 1,
+                Levels = 2
+            };
+
+            Assert.Equal(1, stackTrace.StartFrame);
+            Assert.Equal(2, stackTrace.Levels);
+        }
+
+        [Fact]
+        public void Terminate_Get_Set()
+        {
+            var terminate = new Terminate { Restart = true };
+
+            Assert.True(terminate.Restart);
+        }
+
+        [Fact]
+        public void Thread_Get_Set()
+        {
+            var thread = new Thread { Name = "test-thread" };
+
+            Assert.Equal("test-thread", thread.Name);
+        }
+
+        [Fact]
+        public void Variables_Get_Set()
+        {
+            var variables = new Variables { VariablesReference = 0ul };
+
+            Assert.Equal(0ul, variables.VariablesReference);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/Transport/DebugTransportTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/Transport/DebugTransportTests.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Dialogs.Debugging.Transport;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests.Transport
+{
+    public sealed class DebugTransportTests
+    {
+        [Fact]
+        public void DebugTransport_Constructor()
+        {
+            var transport = new DebugTransport(3980, null);
+
+            Assert.NotNull(transport);
+
+            transport.Dispose();
+        }
+
+        [Fact]
+        public void DebugTransport_Dispose()
+        {
+            var transport = new DebugTransport(3981, null);
+
+            transport.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                transport.Dispose();
+            });
+        }
+
+        [Fact]
+        public void DebugTransport_Accept()
+        {
+            IDebugTransport transport = new DebugTransport(3982, null);
+
+            transport.Accept = AcceptAsync;
+
+            Assert.NotNull(transport.Accept);
+        }
+
+        [Fact]
+        public async Task DebugTransport_ReadAsync_Throws()
+        {
+            IDebugTransport transport = new DebugTransport(3983, null);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await transport.ReadAsync(default);
+            });
+        }
+
+        private static async Task AcceptAsync(CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask.ConfigureAwait(false);
+        }
+    }
+}


### PR DESCRIPTION
Fixes # XXXX

## Description
This PR increases the code coverage for the `Microsoft.Bot.Builder.Dialogs.Debugging` library from **39%** to **75%**.

## Specific Changes
Added unit tests for the following classes:
- Base/ActiveObject
- Base/ReaderWriterLock
- Base/Releaser
- CodeModels/CodeModel
- CodeModels/CodePoint
- DataModels/Coercion
- DataModels/DataModels
- DebuggerSourceMap
- DebuggingBotAdapterExtensions
- DialogDebugAdapter
- Events/Events
- Identifiers/IdentifierCache
- Identifiers/IdentifierMutex
- All classes in Protocol folder
- Transport/DebugTransport

Also, moved the _identifierTests_ class under the `Identifiers` folder.

## Testing
The following images show the tests passing and the new code coverage.
![image](https://user-images.githubusercontent.com/44245136/134557656-0ba14c50-1a8e-43e2-93af-7b12bfaec52f.png)
