### PR TITLE
[#390] Increase Microsoft.Bot.Builder.AI.Orchestrator code coverage

### DIFF
--- a/tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests/OrchestratorBotComponentTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests/OrchestratorBotComponentTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;

--- a/tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests/OrchestratorBotComponentTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests/OrchestratorBotComponentTests.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.AI.Orchestrator.Tests
+{
+    public class OrchestratorBotComponentTests
+    {
+        [Fact]
+        public void TestConfigureServices()
+        {
+            var service = new ServiceCollection();
+            new OrchestratorBotComponent().ConfigureServices(service, new ConfigurationBuilder().Build());
+            Assert.Equal(ServiceLifetime.Singleton, service[0].Lifetime);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests/OrchestratorRecognizerTest.cs
+++ b/tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests/OrchestratorRecognizerTest.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Schema;
+using Moq;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.AI.Orchestrator.Tests
+{
+    public class OrchestratorRecognizerTest
+    {
+        [Fact]
+        public async Task LogsTelemetryThrowsArgumentNullExcetionOnNullDialogContext()
+        {
+            var telemetryClient = new Mock<IBotTelemetryClient>();
+
+            var recognizer = new MyRecognizerSubclass { TelemetryClient = telemetryClient.Object };
+            var activity = MessageFactory.Text("hi");
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => recognizer.RecognizeAsync(null, activity));
+        }
+
+        /// <summary>
+        /// Subclass to test <see cref="OrchestratorRecognizer.FillRecognizerResultTelemetryProperties(RecognizerResult, Dictionary{string,string}, DialogContext)"/> functionality.
+        /// </summary>
+        private class MyRecognizerSubclass : OrchestratorRecognizer
+        {
+            public override async Task<RecognizerResult> RecognizeAsync(DialogContext dialogContext, Activity activity, CancellationToken cancellationToken = default, Dictionary<string, string> telemetryProperties = null, Dictionary<string, double> telemetryMetrics = null)
+            {
+                var text = activity.Text ?? string.Empty;
+
+                var recognizerResult = await Task.FromResult(new RecognizerResult
+                {
+                    Text = text,
+                    AlteredText = null,
+                    Intents = new Dictionary<string, IntentScore>
+                    {
+                        {
+                            "myTestIntent", new IntentScore
+                            {
+                                Score = 1.0,
+                                Properties = new Dictionary<string, object>()
+                            }
+                        }
+                    },
+                    Entities = new JObject(),
+                    Properties = new Dictionary<string, object>()
+                });
+
+                TrackRecognizerResult(dialogContext, $"{nameof(MyRecognizerSubclass)}Result", FillRecognizerResultTelemetryProperties(recognizerResult, telemetryProperties, dialogContext), telemetryMetrics);
+
+                return recognizerResult;
+            }
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests/OrchestratorRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests/OrchestratorRecognizerTests.cs
@@ -13,10 +13,10 @@ using Xunit;
 
 namespace Microsoft.Bot.Builder.AI.Orchestrator.Tests
 {
-    public class OrchestratorRecognizerTest
+    public class OrchestratorRecognizerTests
     {
         [Fact]
-        public async Task LogsTelemetryThrowsArgumentNullExcetionOnNullDialogContext()
+        public async Task LogsTelemetryThrowsArgumentNullExceptionOnNullDialogContext()
         {
             var telemetryClient = new Mock<IBotTelemetryClient>();
 


### PR DESCRIPTION
Fixes # XXXX

## Description
This PR increases the code coverage for the `Microsoft.Bot.Builder.AI.Orchestrator` library from **62%** to **88%**.

## Specific Changes
Added unit tests for the following classes:
- OrchestratorRecognizer
- OrchestratorBotComponent

## Testing
The following image shows the new code coverage.
![image](https://user-images.githubusercontent.com/18757147/134564894-fd2ed176-7085-4f3f-8b74-d8bbe9591bc2.png)

