### PR TITLE
[#5713] Dialogs.Declarative.Tests hang and give no message.

### DIFF
--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/SchemaTestsFixture.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/SchemaTestsFixture.cs
@@ -28,6 +28,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
             // Only generate schemas on Windows.
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
+                BotFrameworkCLIPrerequisite();
+
                 // Save an in memory copy of the current schema file.
                 var oldSchema = File.Exists(schemaPath) ? File.ReadAllText(schemaPath) : string.Empty;
                 File.Delete(schemaPath);
@@ -108,6 +110,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
             process.WaitForExit();
 
             return process.ExitCode != 0 ? process.StandardError.ReadToEnd() : string.Empty;
+        }
+
+        /// <summary>
+        /// Validates if BotFramework-CLI is installed in the Operative System (OS).
+        /// If there isn't installed, an error will be thrown, requiring the prerequisite to be installed to be able to execute the test.
+        /// </summary>
+        private static void BotFrameworkCLIPrerequisite()
+        {
+            var error = RunCommand("/C bf");
+            if (error.Length != 0)
+            {
+                throw new InvalidOperationException("This test requires BotFramework-CLI! go to https://github.com/microsoft/botframework-cli#installation to install it.");
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes # 5713

## Description
This PR fixes an issue when BotFramework-CLI is not installed in the Operative System (OS), the tests hang while installing the library. Instead, when it isn't installed, the tests will fail, warning the user to install the library.

## Specific Changes
- Added `BotFrameworkCLIPrerequisite` method in `Microsoft.Bot.Builder.Dialogs.Declarative.Tests/SchemaTestsFixture.cs`.
  - Will execute the `bf` command to corroborate that's installed.
  - If the `bf` command execution failed, it will throw an error warning to install the library.

## Testing
The following images show when there is no `bf-cli` install, and when there is.
![image](https://user-images.githubusercontent.com/62260472/142653411-a7b2e88a-f794-4562-bc84-c404aeddf631.png)