### PR TITLE
[#5620] Upgrade Microsoft.Recognizers to 1.7.0

### DIFF
--- a/libraries/AdaptiveExpressions/AdaptiveExpressions.csproj
+++ b/libraries/AdaptiveExpressions/AdaptiveExpressions.csproj
@@ -32,7 +32,7 @@
   <ItemGroup>
     <PackageReference Include="Antlr4.Runtime.Standard" Version="4.8.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
-    <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.3.2" />
+    <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.22" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.0" />
   </ItemGroup>
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Microsoft.Bot.Builder.Dialogs.Adaptive.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Microsoft.Bot.Builder.Dialogs.Adaptive.csproj
@@ -47,11 +47,11 @@
     <PackageReference Include="AdaptiveExpressions" Condition=" '$(ReleasePackageVersion)' != '' " Version="$(ReleasePackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Recognizers.Text" Version="1.3.2" />
-    <PackageReference Include="Microsoft.Recognizers.Text.Choice" Version="1.3.2" />
-    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.3.2" />
-    <PackageReference Include="Microsoft.Recognizers.Text.Number" Version="1.3.2" />
-    <PackageReference Include="Microsoft.Recognizers.Text.Sequence" Version="1.3.2" />
+    <PackageReference Include="Microsoft.Recognizers.Text" Version="1.7.0" />
+    <PackageReference Include="Microsoft.Recognizers.Text.Choice" Version="1.7.0" />
+    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.7.0" />
+    <PackageReference Include="Microsoft.Recognizers.Text.Number" Version="1.7.0" />
+    <PackageReference Include="Microsoft.Recognizers.Text.Sequence" Version="1.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Microsoft.Bot.Builder.Dialogs.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Microsoft.Bot.Builder.Dialogs.csproj
@@ -26,8 +26,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(ReleasePackageVersion)' != '' " Version="$(ReleasePackageVersion)" />
-    <PackageReference Include="Microsoft.Recognizers.Text.Choice" Version="1.3.2" />
-    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.3.2" />
+    <PackageReference Include="Microsoft.Recognizers.Text.Choice" Version="1.7.0" />
+    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Bot.Builder.TestBot.Shared/Microsoft.Bot.Builder.TestBot.Shared.csproj
+++ b/tests/Microsoft.Bot.Builder.TestBot.Shared/Microsoft.Bot.Builder.TestBot.Shared.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.3.2" />
+    <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Bot.Builder.TestBot.WebApi/Microsoft.Bot.Builder.TestBot.WebApi.csproj
+++ b/tests/Microsoft.Bot.Builder.TestBot.WebApi/Microsoft.Bot.Builder.TestBot.WebApi.csproj
@@ -113,7 +113,7 @@
       <Version>2.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression">
-      <Version>1.2.3</Version>
+      <Version>1.7.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>10.0.3</Version>

--- a/tests/Microsoft.Bot.Builder.TestBot/Microsoft.Bot.Builder.TestBot.csproj
+++ b/tests/Microsoft.Bot.Builder.TestBot/Microsoft.Bot.Builder.TestBot.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.3.2" />
+    <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.7.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes # 5620

## Description
This PR updates the Recognizers packages to the 1.7.0 version.
It also updates `Microsoft.Extensions.Options` to the 2.2.0 version to solve the _package downgrade_ issue in the `Dialogs.Adaptive.Runtime` library.

## Specific Changes
Updated the Microsoft.Recognizers dependency in the following libraries:
  - AdaptiveExpressions
  - Microsoft.Bot.Builder.Dialogs.Adaptive
  - Microsoft.Bot.Builder.Dialogs
  - Microsoft.Bot.Builder.TestBot.Shared
  - Microsoft.Bot.Builder.TestBot.WebApi
  - Microsoft.Bot.Builder.TestBot

Updated `Microsoft.Extensions.Options` to the 2.2.0 version to solve the _package downgrade_ issue in the `Dialogs.Adaptive.Runtime` library.

## Testing
These images show one of the projects updated with its tests and the CI pipeline executing successfully.
![image](https://user-images.githubusercontent.com/44245136/142662816-c7add0cf-cb9d-4b0c-bbd2-20cf19ebb79f.png)
![image](https://user-images.githubusercontent.com/44245136/142662886-99729654-4513-407e-90bd-5063df598dcf.png)