### PR TITLE
[#5924] Fix Adaptive Dialogs ISO Date String parsing to a JTokenType.Date Object

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
@@ -518,7 +518,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
             }
 
             using (var readerText = new StreamReader(await resource.OpenStreamAsync().ConfigureAwait(false)))
-            using (var readerJson = new JsonTextReader(readerText))
+            using (var readerJson = new JsonTextReader(readerText) { DateParseHandling = DateParseHandling.None })
             {
                 if (advanceJsonReader)
                 {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/ObjectPath.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/ObjectPath.cs
@@ -722,7 +722,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             {
                 if (value is JToken || value is JObject || value is JArray)
                 {
-                    val = Clone((JToken)value);
+                    val = ((JToken)value).DeepClone();
                 }
                 else if (value == null)
                 {

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/Fallback/datetime.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/Fallback/datetime.dialog
@@ -23,6 +23,14 @@
         },
         {
           "$kind": "Microsoft.SendActivity",
+          "activity": "${user.date}"
+        },
+        {
+          "$kind": "Microsoft.SendActivity",
+          "activity": "${trim(user.date)}"
+        },
+        {
+          "$kind": "Microsoft.SendActivity",
           "activity": "${addToTime(user.date, 120, 'Second')}"
         },
         {

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/LGGeneratorTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/LGGeneratorTests.cs
@@ -524,6 +524,8 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
                 await dm.OnTurnAsync(turnContext, cancellationToken: cancellationToken).ConfigureAwait(false);
             })
             .Send("hello")
+                .AssertReply("2018-01-01T08:00:00.000Z")
+                .AssertReply("2018-01-01T08:00:00.000Z")
                 .AssertReply("2018-01-01T08:02:00.000Z")
                 .AssertReply("2018-01-01T08:03:00.000Z")
                 .AssertReply("2018-01-06T08:00:00.000Z")

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ObjectPathTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ObjectPathTests.cs
@@ -478,7 +478,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         [Fact]
         public void SetPathValue()
         {
+            const string dateISO = "2021-11-30T23:59:59:000Z";
             var test = new Dictionary<string, object>();
+
             ObjectPath.SetPathValue(test, "x.y.z", 15);
             ObjectPath.SetPathValue(test, "x.p", "hello");
             ObjectPath.SetPathValue(test, "foo", new { Bar = 15, Blat = "yo" });
@@ -486,6 +488,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             ObjectPath.SetPathValue(test, "x.a[0]", "dabba");
             ObjectPath.SetPathValue(test, "null", null);
             ObjectPath.SetPathValue(test, "enum", TypeCode.Empty);
+            ObjectPath.SetPathValue(test, "date.string.iso", dateISO);
+            ObjectPath.SetPathValue(test, "date.string.jtoken.iso", new JValue(dateISO));
+            ObjectPath.SetPathValue(test, "date.object", new { iso = dateISO });
+            ObjectPath.SetPathValue(test, "date.object.jtoken", JToken.FromObject(new { iso = dateISO }));
 
             Assert.Equal(15, ObjectPath.GetPathValue<int>(test, "x.y.z"));
             Assert.Equal("hello", ObjectPath.GetPathValue<string>(test, "x.p"));
@@ -498,6 +504,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.Equal("dabba", value2);
             Assert.False(ObjectPath.TryGetPathValue<object>(test, "null", out var nullValue));
             Assert.Equal(TypeCode.Empty, ObjectPath.GetPathValue<TypeCode>(test, "enum"));
+            Assert.Equal(dateISO, ObjectPath.GetPathValue<string>(test, "date.string.iso"));
+            Assert.Equal(dateISO, ObjectPath.GetPathValue<string>(test, "date.string.jtoken.iso"));
+            Assert.Equal(dateISO, ObjectPath.GetPathValue<string>(test, "date.object.iso"));
+            Assert.Equal(dateISO, ObjectPath.GetPathValue<string>(test, "date.object.jtoken.iso"));
 
             // value type tests
 #pragma warning disable SA1121 // Use built-in type alias


### PR DESCRIPTION
Fixes # 5924

**Original Issue:** microsoft/BotFramework-Composer# 2731

## Description
This PR fixes an issue when using Adaptive Dialogs' `Microsoft.SetProperty` with a String Date expressed as [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) (`e.g. 2021-11-30T23:59:59:000Z`), the Dialogs' internal code that uses [NewtonsoftJSON](https://www.newtonsoft.com/json) to read and process the `Properties` will recognize and transform the String Date to a `JTokenType.Date` object causing an error when subsequent BuiltIn Functionalities (`e.g. trim(stringDateISO)`) receive a string as an input value.
This PR provides a solution to disable the `DataPaseHandling` when the JSON file is read, and when the `Property` object is cloned instead of Serializing/Deserializing the object.

## Specific Changes
- Added `DateParseHandling` option in `Dialogs.Declarative/ResourceExplorer` when the Adaptive Dialog JSON file is read to prevent recognition and transformation for String Date values.
- Updated `Dialogs/ObjectPath` to use `JToken.DeepClone` instead of `Deserialize(Serialize)` functionality to clone the object.
- Added unit tests for `Dialogs Adaptive Language Generation` and `Dialogs/ObjectPath`.

## Testing
The following images show the comparison between DotNet and JavaScript implementations before and after the changes, and the CI Pipeline passing successfully.
![image](https://user-images.githubusercontent.com/62260472/144292694-ab95ae0c-0290-4dee-a624-301a2c643ca1.png)
![image](https://user-images.githubusercontent.com/62260472/144292703-f236146b-ac80-438f-961f-fa9252fd2f21.png)
