### PR TITLE
[#6099] Remove low impact FxCop exclusions - Sample cases (2/2)

### DIFF
--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/DirectLineSpeechTests.cs
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/DirectLineSpeechTests.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Bot.Builder.FunctionalTests
                     }
                 });
 
-                var channelData = activity.GetChannelData<SpeechChannelData>();
+                var channelData = activity.GetChannelDataObject<SpeechChannelData>();
                 var id = channelData?.ConversationalAiData?.RequestInfo?.InteractionId;
                 if (!string.IsNullOrEmpty(id))
                 {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             Dialogs = dialogs ?? throw new ArgumentNullException(nameof(dialogs));
             Context = turnContext ?? throw new ArgumentNullException(nameof(turnContext));
             Stack = state.DialogStack;
-            State = new DialogStateManager(this);
+            State = new DialogStateManagerDictionary(this);
             Services = new TurnContextStateCollection();
 
             ObjectPath.SetPathValue(turnContext.TurnState, TurnPath.Activity, Context.Activity);
@@ -139,13 +139,13 @@ namespace Microsoft.Bot.Builder.Dialogs
         }
 
         /// <summary>
-        /// Gets or sets the DialogStateManager which manages view of all memory scopes.
+        /// Gets or sets the DialogStateManagerDictionary which manages view of all memory scopes.
         /// </summary>
         /// <value>
-        /// DialogStateManager with unified memory view of all memory scopes.
+        /// DialogStateManagerDictionary with unified memory view of all memory scopes.
         /// </value>
 #pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
-        public DialogStateManager State { get; set; }
+        public DialogStateManagerDictionary State { get; set; }
 #pragma warning restore CA2227 // Collection properties should be read only
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogExtensions.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                 dialogContext.Services[service.Key] = service.Value;
             }
 
-            var dialogStateManager = new DialogStateManager(dialogContext, stateConfiguration);
+            var dialogStateManager = new DialogStateManagerDictionary(dialogContext, stateConfiguration);
             await dialogStateManager.LoadAllScopesAsync(cancellationToken).ConfigureAwait(false);
             dialogContext.Context.TurnState.Add(dialogStateManager);
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogStateManagerDictionary.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogStateManagerDictionary.cs
@@ -15,13 +15,11 @@ using Newtonsoft.Json.Linq;
 namespace Microsoft.Bot.Builder.Dialogs.Memory
 {
     /// <summary>
-    /// The DialogStateManager manages memory scopes and pathresolvers
+    /// The DialogStateManagerDictionary manages memory scopes and pathresolvers
     /// MemoryScopes are named root level objects, which can exist either in the dialogcontext or off of turn state
     /// PathResolvers allow for shortcut behavior for mapping things like $foo -> dialog.foo.
     /// </summary>
-#pragma warning disable CA1710 // Identifiers should have correct suffix (We can't rename this class without breaking binary compat)
-    public class DialogStateManager : IDictionary<string, object>
-#pragma warning restore CA1710 // Identifiers should have correct suffix
+    public class DialogStateManagerDictionary : IDictionary<string, object>
     {
         /// <summary>
         /// Information for tracking when path was last modified.
@@ -34,11 +32,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
         private int _version;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DialogStateManager"/> class.
+        /// Initializes a new instance of the <see cref="DialogStateManagerDictionary"/> class.
         /// </summary>
         /// <param name="dc">The dialog context for the current turn of the conversation.</param>
         /// <param name="configuration">Configuration for the dialog state manager. Default is <c>null</c>.</param>
-        public DialogStateManager(DialogContext dc, DialogStateManagerConfiguration configuration = null)
+        public DialogStateManagerDictionary(DialogContext dc, DialogStateManagerConfiguration configuration = null)
         {
             _dialogContext = dc ?? throw new ArgumentNullException(nameof(dc));
             Configuration = configuration ?? dc.Context.TurnState.Get<DialogStateManagerConfiguration>();

--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityExtensions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Bot.Builder.Teams
         /// <returns>The current activity's team's meeting, or null.</returns>
         public static TeamsMeetingInfo TeamsGetMeetingInfo(this IActivity activity)
         {
-            var channelData = activity.GetChannelData<TeamsChannelData>();
+            var channelData = activity.GetChannelDataObject<TeamsChannelData>();
             return channelData?.Meeting;
         }
 
@@ -30,7 +30,7 @@ namespace Microsoft.Bot.Builder.Teams
         /// <returns>The current activity's team's channel, or empty string.</returns>
         public static string TeamsGetChannelId(this IActivity activity)
         {
-            var channelData = activity.GetChannelData<TeamsChannelData>();
+            var channelData = activity.GetChannelDataObject<TeamsChannelData>();
             return channelData?.Channel?.Id;
         }
 
@@ -41,7 +41,7 @@ namespace Microsoft.Bot.Builder.Teams
         /// <returns>The current activity's team's Id, or an empty string.</returns>
         public static TeamInfo TeamsGetTeamInfo(this IActivity activity)
         {
-            var channelData = activity.GetChannelData<TeamsChannelData>();
+            var channelData = activity.GetChannelDataObject<TeamsChannelData>();
             return channelData?.Team;
         }
 

--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityHandler.cs
@@ -431,7 +431,7 @@ namespace Microsoft.Bot.Builder.Teams
         {
             if (turnContext.Activity.ChannelId == Channels.Msteams)
             {
-                var channelData = turnContext.Activity.GetChannelData<TeamsChannelData>();
+                var channelData = turnContext.Activity.GetChannelDataObject<TeamsChannelData>();
 
                 if (turnContext.Activity.MembersAdded != null)
                 {

--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Bot.Builder.Teams
         {
             meetingId ??= turnContext.Activity.TeamsGetMeetingInfo()?.Id ?? throw new InvalidOperationException("This method is only valid within the scope of a MS Teams Meeting.");
             participantId ??= turnContext.Activity.From.AadObjectId ?? throw new InvalidOperationException($"{nameof(participantId)} is required.");
-            tenantId ??= turnContext.Activity.GetChannelData<TeamsChannelData>()?.Tenant?.Id ?? throw new InvalidOperationException($"{nameof(tenantId)} is required.");
+            tenantId ??= turnContext.Activity.GetChannelDataObject<TeamsChannelData>()?.Tenant?.Id ?? throw new InvalidOperationException($"{nameof(tenantId)} is required.");
 
             using (var teamsClient = GetTeamsConnectorClient(turnContext))
             {

--- a/libraries/Microsoft.Bot.Builder/TelemetryLoggerMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/TelemetryLoggerMiddleware.cs
@@ -342,9 +342,7 @@ namespace Microsoft.Bot.Builder
         /// <param name="activity">The Activity object deleted by bot.</param>
         /// <param name="additionalProperties">Additional properties to add to the event.</param>
         /// <returns>The properties and their values to log when the bot deletes a message it sent previously.</returns>
-#pragma warning disable CA1822 // Mark members as static (can't change this without breaking binary compat)
         protected Task<Dictionary<string, string>> FillDeleteEventPropertiesAsync(IMessageDeleteActivity activity, Dictionary<string, string> additionalProperties = null)
-#pragma warning restore CA1822 // Mark members as static
         {
             if (activity == null)
             {
@@ -374,7 +372,7 @@ namespace Microsoft.Bot.Builder
             switch (activity.ChannelId)
             {
                 case Channels.Msteams:
-                    var teamsChannelData = activity.GetChannelData<TeamsChannelData>();
+                    var teamsChannelData = activity.GetChannelDataObject<TeamsChannelData>();
                     
                     properties.Add("TeamsTenantId", teamsChannelData?.Tenant?.Id);
                     properties.Add("TeamsUserAadObjectId", activity.From?.AadObjectId);

--- a/libraries/Microsoft.Bot.Schema/Activity.cs
+++ b/libraries/Microsoft.Bot.Schema/Activity.cs
@@ -443,9 +443,7 @@ namespace Microsoft.Bot.Schema
         /// Channel-specific content.
         /// </value>
         [JsonProperty(PropertyName = "channelData")]
-#pragma warning disable CA1721 // Property names should not match get methods (we can't change this without changing binary compat).
         public object ChannelData { get; set; }
-#pragma warning restore CA1721 // Property names should not match get methods
 
         /// <summary>
         /// Gets or sets a string indicating whether the recipient of a

--- a/libraries/Microsoft.Bot.Schema/ActivityEx.cs
+++ b/libraries/Microsoft.Bot.Schema/ActivityEx.cs
@@ -407,42 +407,38 @@ namespace Microsoft.Bot.Schema
         /// <summary>
         /// Gets the channel data for this activity as a strongly-typed object.
         /// </summary>
-        /// <typeparam name="TypeT">The type of the object to return.</typeparam>
+        /// <typeparam name="TType">The type of the object to return.</typeparam>
         /// <returns>The strongly-typed object; or the type's default value, if the <see cref="ChannelData"/> is null.</returns>
         /// <seealso cref="ChannelData"/>
         /// <seealso cref="TryGetChannelData{TypeT}(out TypeT)"/>
-#pragma warning disable CA1715 // Identifiers should have correct prefix (we can't change it without breaking binary compatibility)
-        public TypeT GetChannelData<TypeT>()
-#pragma warning restore CA1715 // Identifiers should have correct prefix
+        public TType GetChannelDataObject<TType>()
         {
             if (ChannelData == null)
             {
                 return default;
             }
 
-            if (ChannelData.GetType() == typeof(TypeT))
+            if (ChannelData.GetType() == typeof(TType))
             {
-                return (TypeT)ChannelData;
+                return (TType)ChannelData;
             }
 
-            return ((JObject)ChannelData).ToObject<TypeT>();
+            return ((JObject)ChannelData).ToObject<TType>();
         }
 
         /// <summary>
         /// Gets the channel data for this activity as a strongly-typed object.
         /// A return value idicates whether the operation succeeded.
         /// </summary>
-        /// <typeparam name="TypeT">The type of the object to return.</typeparam>
+        /// <typeparam name="TType">The type of the object to return.</typeparam>
         /// <param name="instance">When this method returns, contains the strongly-typed object if the operation succeeded,
         /// or the type's default value if the operation failed.</param>
         /// <returns>
         /// <c>true</c> if the operation succeeded; otherwise, <c>false</c>.
         /// </returns>
         /// <seealso cref="ChannelData"/>
-        /// <seealso cref="GetChannelData{TypeT}"/>
-#pragma warning disable CA1715 // Identifiers should have correct prefix (we can't change it without breaking binary compatibility)
-        public bool TryGetChannelData<TypeT>(out TypeT instance)
-#pragma warning restore CA1715 // Identifiers should have correct prefix
+        /// <seealso cref="GetChannelDataObject{TType}"/>
+        public bool TryGetChannelData<TType>(out TType instance)
         {
             instance = default;
 
@@ -453,7 +449,7 @@ namespace Microsoft.Bot.Schema
                     return false;
                 }
 
-                instance = GetChannelData<TypeT>();
+                instance = GetChannelDataObject<TType>();
                 return true;
             }
 #pragma warning disable CA1031 // Do not catch general exception types (we just return false here if the conversion fails for any reason)

--- a/libraries/Microsoft.Bot.Schema/IActivity.cs
+++ b/libraries/Microsoft.Bot.Schema/IActivity.cs
@@ -125,9 +125,7 @@ namespace Microsoft.Bot.Schema
         /// <value>
         /// Channel-specific payload.
         /// </value>
-#pragma warning disable CA1721 // Property names should not match get methods (we can't change this without breaking binary compat)
         dynamic ChannelData { get; set; }
-#pragma warning restore CA1721 // Property names should not match get methods
 
         /// <summary>
         /// Gets the channel data as strongly typed object.
@@ -135,7 +133,7 @@ namespace Microsoft.Bot.Schema
         /// <typeparam name="TypeT">The expected type of the object.</typeparam>
         /// <returns>The strongly typed channel data.</returns>
 #pragma warning disable CA1715 // Identifiers should have correct prefix (we can't change this without breaking binary compat)
-        TypeT GetChannelData<TypeT>();
+        TypeT GetChannelDataObject<TypeT>();
 #pragma warning restore CA1715 // Identifiers should have correct prefix
 
         /// <summary>

--- a/tests/Microsoft.Bot.Schema.Tests/ActivityTest.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/ActivityTest.cs
@@ -375,7 +375,7 @@ namespace Microsoft.Bot.Schema.Tests
 
             try
             {
-                var result = activity.GetChannelData<MyChannelData>();
+                var result = activity.GetChannelDataObject<MyChannelData>();
                 if (channelData == null)
                 {
                     Assert.Null(result);

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TeamsChannelDataTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TeamsChannelDataTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Bot.Schema.Tests.Teams
             var activity = new Activity { ChannelData = new TeamsChannelData { Team = new TeamInfo { AadGroupId = AadGroupId } } };
 
             // Act
-            var channelData = activity.GetChannelData<TeamsChannelData>();
+            var channelData = activity.GetChannelDataObject<TeamsChannelData>();
 
             // Assert
             Assert.Equal(AadGroupId, channelData.Team.AadGroupId);


### PR DESCRIPTION
Addresses # 6099
#minor

## Description
This PR removes some of the FxCop rule exclusions with possible high impact.

### Detailed Changes
- **CA1710 - Identifiers should have correct suffix**
   - Renamed the `DialogStateManager` class as `DialogStateManagerDictionary`.
- **CA1822 - Mark members as static**
   - Removing this rule exclusion in `TelemetryLoggerMiddleware` class didn't require changes.
- **CA1715 // Identifiers should have correct prefix**
   - Renamed generic type _TypeT_ as _TType_ in `GetChannelData` method in the `ActivityEx` class.
- **CA1721 - Property names should not match get methods**
   - Renamed the `GetChannelData` method from `IActivity` interface as `GetChannelDataObject`.

## Testing
This image shows the tests passing after the changes.
[image]