### PR TITLE
[#6099] Remove low impact FxCop exclusions - Rule CA1819 (Part 1/2)

### DIFF
--- a/libraries/Microsoft.Bot.Builder/FileTranscriptLogger.cs
+++ b/libraries/Microsoft.Bot.Builder/FileTranscriptLogger.cs
@@ -137,9 +137,9 @@ namespace Microsoft.Bot.Builder
             var transcriptFile = GetTranscriptFile(channelId, conversationId);
 
             var transcript = await LoadTranscriptAsync(transcriptFile).ConfigureAwait(false);
-            var result = new PagedResult<IActivity>();
+            var items = transcript.Where(activity => activity.Timestamp >= startDate).Cast<IActivity>().ToArray();
+            var result = new PagedResult<IActivity>(items);
             result.ContinuationToken = null;
-            result.Items = transcript.Where(activity => activity.Timestamp >= startDate).Cast<IActivity>().ToArray();
             return result;
         }
 
@@ -165,9 +165,8 @@ namespace Microsoft.Bot.Builder
                 });
             }
 
-            return Task.FromResult(new PagedResult<TranscriptInfo>()
+            return Task.FromResult(new PagedResult<TranscriptInfo>(transcripts.ToArray())
             {
-                Items = transcripts.ToArray(),
                 ContinuationToken = null,
             });
         }

--- a/libraries/Microsoft.Bot.Builder/PagedResult.cs
+++ b/libraries/Microsoft.Bot.Builder/PagedResult.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.ObjectModel;
 
 namespace Microsoft.Bot.Builder
 {
@@ -12,14 +13,21 @@ namespace Microsoft.Bot.Builder
     public class PagedResult<T>
     {
         /// <summary>
-        /// Gets or sets the page of items.
+        /// Initializes a new instance of the <see cref="PagedResult{T}"/> class.
+        /// </summary>
+        /// <param name="items">The array of items.</param>
+        public PagedResult(T[] items)
+        {
+            Items = new Collection<T>(items);
+        }
+
+        /// <summary>
+        /// Gets the page of items.
         /// </summary>
         /// <value>
         /// The array of items.
         /// </value>
-#pragma warning disable CA1819 // Properties should not return arrays (can't change this without breaking binary compat)
-        public T[] Items { get; set; } = Array.Empty<T>();
-#pragma warning restore CA1819 // Properties should not return arrays
+        public Collection<T> Items { get; } = new Collection<T>();
 
         /// <summary>
         /// Gets or sets a token for retrieving the next page of results.

--- a/libraries/Microsoft.Bot.Connector/Authentication/AuthenticationConfiguration.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AuthenticationConfiguration.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace Microsoft.Bot.Connector.Authentication
 {
@@ -16,14 +16,12 @@ namespace Microsoft.Bot.Connector.Authentication
     public class AuthenticationConfiguration
     {
         /// <summary>
-        /// Gets or sets an array of JWT endorsements.
+        /// Gets an array of JWT endorsements.
         /// </summary>
         /// <value>
         /// An array of JWT endorsements.
         /// </value>
-#pragma warning disable CA1819 // Properties should not return arrays (we can't change this without breaking binary compat)
-        public string[] RequiredEndorsements { get; set; } = Array.Empty<string>();
-#pragma warning restore CA1819 // Properties should not return arrays
+        public Collection<string> RequiredEndorsements { get; } = new Collection<string>();
 
         /// <summary>
         /// Gets or sets an <see cref="ClaimsValidator"/> instance used to validate the identity claims.

--- a/libraries/Microsoft.Bot.Connector/Authentication/ParameterizedBotFrameworkAuthentication.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ParameterizedBotFrameworkAuthentication.cs
@@ -282,7 +282,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 _toBotFromEmulatorOpenIdMetadataUrl,
                 AuthenticationConstants.AllowedSigningAlgorithms);
 
-            var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId, _authConfiguration.RequiredEndorsements).ConfigureAwait(false);
+            var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId, _authConfiguration.RequiredEndorsements.ToArray()).ConfigureAwait(false);
 
             await ValidateSkillIdentityAsync(identity, cancellationToken).ConfigureAwait(false);
 
@@ -369,7 +369,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 _toBotFromEmulatorOpenIdMetadataUrl,
                 AuthenticationConstants.AllowedSigningAlgorithms);
 
-            var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId, _authConfiguration.RequiredEndorsements).ConfigureAwait(false);
+            var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId, _authConfiguration.RequiredEndorsements.ToArray()).ConfigureAwait(false);
             if (identity == null)
             {
                 // No valid identity. Not Authorized.
@@ -520,7 +520,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 _toBotFromChannelOpenIdMetadataUrl,
                 AuthenticationConstants.AllowedSigningAlgorithms);
 
-            var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId, _authConfiguration.RequiredEndorsements).ConfigureAwait(false);
+            var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId, _authConfiguration.RequiredEndorsements.ToArray()).ConfigureAwait(false);
 
             await ValidateChannelIdentityAsync(identity, serviceUrl, cancellationToken).ConfigureAwait(false);
 

--- a/libraries/Microsoft.Bot.Schema/AttachmentData.cs
+++ b/libraries/Microsoft.Bot.Schema/AttachmentData.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.Bot.Schema
 {
+    using System.Collections.ObjectModel;
     using Newtonsoft.Json;
 
     /// <summary> Attachment data. </summary>
@@ -23,8 +24,8 @@ namespace Microsoft.Bot.Schema
         {
             Type = type;
             Name = name;
-            OriginalBase64 = originalBase64;
-            ThumbnailBase64 = thumbnailBase64;
+            OriginalBase64 = new Collection<byte>(originalBase64);
+            ThumbnailBase64 = new Collection<byte>(thumbnailBase64);
             CustomInit();
         }
 
@@ -38,19 +39,15 @@ namespace Microsoft.Bot.Schema
         [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }
 
-        /// <summary>Gets or sets attachment content.</summary>
+        /// <summary>Gets attachment content.</summary>
         /// <value>The attachment content.</value>
         [JsonProperty(PropertyName = "originalBase64")]
-#pragma warning disable CA1819 // Properties should not return arrays (we can't change this without breaking backwards compat)
-        public byte[] OriginalBase64 { get; set; }
-#pragma warning restore CA1819 // Properties should not return arrays
+        public Collection<byte> OriginalBase64 { get; private set; }
 
-        /// <summary>Gets or sets attachment thumbnail.</summary>
+        /// <summary>Gets attachment thumbnail.</summary>
         /// <value>The attachment thumbnail.</value>
         [JsonProperty(PropertyName = "thumbnailBase64")]
-#pragma warning disable CA1819 // Properties should not return arrays
-        public byte[] ThumbnailBase64 { get; set; }
-#pragma warning restore CA1819 // Properties should not return arrays
+        public Collection<byte> ThumbnailBase64 { get; private set; }
 
         /// <summary>An initialization method that performs custom operations like setting defaults.</summary>
         partial void CustomInit();

--- a/libraries/Storage/Microsoft.Bot.Builder.Azure.Blobs/BlobsTranscriptStore.cs
+++ b/libraries/Storage/Microsoft.Bot.Builder.Azure.Blobs/BlobsTranscriptStore.cs
@@ -186,8 +186,6 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
                 throw new ArgumentNullException(nameof(conversationId));
             }
 
-            var pagedResult = new PagedResult<IActivity>();
-
             string token = null;
             List<BlobItem> blobs = new List<BlobItem>();
             do
@@ -227,7 +225,7 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
             }
             while (!string.IsNullOrEmpty(token) && blobs.Count < PageSize);
 
-            pagedResult.Items = blobs
+            var items = blobs
                 .Select(async bl =>
                 {
                     var blobClient = _containerClient.Value.GetBlobClient(bl.Name);
@@ -236,7 +234,9 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
                 .Select(t => t.Result)
                 .ToArray();
 
-            if (pagedResult.Items.Length == PageSize)
+            var pagedResult = new PagedResult<IActivity>(items);
+            
+            if (pagedResult.Items.Count == PageSize)
             {
                 pagedResult.ContinuationToken = blobs.Last().Name;
             }
@@ -296,9 +296,9 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
             }
             while (!string.IsNullOrEmpty(token) && conversations.Count < PageSize);
 
-            var pagedResult = new PagedResult<TranscriptInfo>() { Items = conversations.ToArray() };
+            var pagedResult = new PagedResult<TranscriptInfo>(conversations.ToArray());
 
-            if (pagedResult.Items.Length == PageSize)
+            if (pagedResult.Items.Count == PageSize)
             {
                 pagedResult.ContinuationToken = pagedResult.Items.Last().Id;
             }

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
 
             // Validate Trace Activity created
             var pagedResult = await transcriptStore.GetTranscriptActivitiesAsync("test", conversationId);
-            Assert.Equal(7, pagedResult.Items.Length);
+            Assert.Equal(7, pagedResult.Items.Count);
             Assert.Equal("how do I clean the stove?", pagedResult.Items[0].AsMessageActivity().Text);
             Assert.Equal(0, pagedResult.Items[1].Type.CompareTo(ActivityTypes.Trace));
             var traceInfo = ((JObject)((ITraceActivity)pagedResult.Items[1]).Value).ToObject<QnAMakerTraceInfo>();

--- a/tests/Microsoft.Bot.Builder.Tests/TranscriptBaseTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/TranscriptBaseTests.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Bot.Builder.Tests
 
             pagedResult = await Store.GetTranscriptActivitiesAsync("test", conversationId);
             Assert.Null(pagedResult.ContinuationToken);
-            Assert.Equal(activities.Count, pagedResult.Items.Length);
+            Assert.Equal(activities.Count, pagedResult.Items.Count);
 
             int indexActivity = 0;
             foreach (var result in pagedResult.Items.OrderBy(result => result.Timestamp))
@@ -138,7 +138,7 @@ namespace Microsoft.Bot.Builder.Tests
             }
 
             pagedResult = await Store.GetTranscriptActivitiesAsync("test", conversationId, startDate: start + TimeSpan.FromMinutes(5));
-            Assert.Equal(activities.Count / 2, pagedResult.Items.Length);
+            Assert.Equal(activities.Count / 2, pagedResult.Items.Count);
 
             indexActivity = 5;
             foreach (var result in pagedResult.Items.OrderBy(result => result.Timestamp))
@@ -170,8 +170,8 @@ namespace Microsoft.Bot.Builder.Tests
             var pagedResult = await Store.GetTranscriptActivitiesAsync("test", conversationId);
             var pagedResult2 = await Store.GetTranscriptActivitiesAsync("test", conversationId2);
 
-            Assert.Equal(activities.Count, pagedResult.Items.Length);
-            Assert.Equal(activities.Count, pagedResult2.Items.Length);
+            Assert.Equal(activities.Count, pagedResult.Items.Count);
+            Assert.Equal(activities.Count, pagedResult2.Items.Count);
 
             await Store.DeleteTranscriptAsync("test", conversationId);
 
@@ -179,7 +179,7 @@ namespace Microsoft.Bot.Builder.Tests
             pagedResult2 = await Store.GetTranscriptActivitiesAsync("test", conversationId2);
 
             Assert.Empty(pagedResult.Items);
-            Assert.Equal(activities.Count, pagedResult2.Items.Length);
+            Assert.Equal(activities.Count, pagedResult2.Items.Count);
         }
 
         public async Task GetTranscriptActivities()

--- a/tests/Microsoft.Bot.Builder.Tests/TranscriptLoggerMiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/TranscriptLoggerMiddlewareTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Bot.Builder.Tests
                 {
                     Assert.Equal("bar", ((Activity)activity).Text);
                     var activities = await transcriptStore.GetTranscriptActivitiesAsync(activity.ChannelId, conversationId);
-                    Assert.Equal(2, activities.Items.Length);
+                    Assert.Equal(2, activities.Items.Count);
                 })
                 .Send(new Activity(ActivityTypes.Event) { Name = ActivityEventNames.ContinueConversation })
                 .AssertReply(async activity =>
@@ -38,7 +38,7 @@ namespace Microsoft.Bot.Builder.Tests
                     // Ensure the event hasn't been added to the transcript.
                     var activities = await transcriptStore.GetTranscriptActivitiesAsync(activity.ChannelId, conversationId);
                     Assert.DoesNotContain(activities.Items, a => ((Activity)a).Type == ActivityTypes.Event && ((Activity)a).Name == ActivityEventNames.ContinueConversation);
-                    Assert.Equal(3, activities.Items.Length);
+                    Assert.Equal(3, activities.Items.Count);
                 })
                 .StartTestAsync();
         }

--- a/tests/Microsoft.Bot.Builder.Tests/Transcript_MiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Transcript_MiddlewareTests.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Bot.Builder.Tests
             await Task.Delay(100);
 
             var pagedResult = await transcriptStore.GetTranscriptActivitiesAsync(conversation.ChannelId, conversation.Conversation.Id);
-            Assert.Equal(3, pagedResult.Items.Length);
+            Assert.Equal(3, pagedResult.Items.Count);
             Assert.Equal("foo", pagedResult.Items[0].AsMessageActivity().Text);
             Assert.NotNull(pagedResult.Items[1].AsMessageDeleteActivity());
             Assert.Equal(ActivityTypes.MessageDelete, pagedResult.Items[1].Type);
@@ -138,7 +138,7 @@ namespace Microsoft.Bot.Builder.Tests
             await Task.Delay(100);
 
             var pagedResult = await transcriptStore.GetTranscriptActivitiesAsync(conversation.ChannelId, conversation.Conversation.Id);
-            Assert.Equal(6, pagedResult.Items.Length);
+            Assert.Equal(6, pagedResult.Items.Count);
             Assert.Equal("foo", pagedResult.Items[0].AsMessageActivity().Text);
             Assert.NotNull(pagedResult.Items[1].AsTypingActivity());
             Assert.Equal("echo:foo", pagedResult.Items[2].AsMessageActivity().Text);
@@ -202,7 +202,7 @@ namespace Microsoft.Bot.Builder.Tests
             await Task.Delay(100);
 
             var pagedResult = await transcriptStore.GetTranscriptActivitiesAsync(conversation.ChannelId, conversation.Conversation.Id);
-            Assert.Equal(20, pagedResult.Items.Length);
+            Assert.Equal(20, pagedResult.Items.Count);
             Assert.Equal("inbound message to TestFlow", pagedResult.Items[0].AsMessageActivity().Text);
             Assert.NotNull(pagedResult.Items[1].AsMessageActivity());
             Assert.Equal("I am an activity with an Id.", pagedResult.Items[1].AsMessageActivity().Text);
@@ -249,7 +249,7 @@ namespace Microsoft.Bot.Builder.Tests
             await Task.Delay(100);
 
             var pagedResult = await transcriptStore.GetTranscriptActivitiesAsync(conversation.ChannelId, conversation.Conversation.Id);
-            Assert.Equal(3, pagedResult.Items.Length);
+            Assert.Equal(3, pagedResult.Items.Count);
             Assert.Equal("foo", pagedResult.Items[0].AsMessageActivity().Text);
             Assert.Equal("new response", pagedResult.Items[1].AsMessageActivity().Text);
             Assert.Equal("update", pagedResult.Items[2].AsMessageActivity().Text);
@@ -291,14 +291,14 @@ namespace Microsoft.Bot.Builder.Tests
 
             // Perform some queries
             var pagedResult = await transcriptStore.GetTranscriptActivitiesAsync(conversation.ChannelId, conversation.Conversation.Id, null, dateTimeStartOffset1.DateTime);
-            Assert.Equal(3, pagedResult.Items.Length);
+            Assert.Equal(3, pagedResult.Items.Count);
             Assert.Equal("foo", pagedResult.Items[0].AsMessageActivity().Text);
             Assert.Equal("new response", pagedResult.Items[1].AsMessageActivity().Text);
             Assert.Equal("update", pagedResult.Items[2].AsMessageActivity().Text);
 
             // Perform some queries
             pagedResult = await transcriptStore.GetTranscriptActivitiesAsync(conversation.ChannelId, conversation.Conversation.Id, null, DateTimeOffset.MinValue);
-            Assert.Equal(3, pagedResult.Items.Length);
+            Assert.Equal(3, pagedResult.Items.Count);
             Assert.Equal("foo", pagedResult.Items[0].AsMessageActivity().Text);
             Assert.Equal("new response", pagedResult.Items[1].AsMessageActivity().Text);
             Assert.Equal("update", pagedResult.Items[2].AsMessageActivity().Text);

--- a/tests/Microsoft.Bot.Connector.Tests/AttachmentsTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/AttachmentsTests.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Bot.Connector.Tests
                 var attachmentId = response.Id;
                 var stream = await client.Attachments.GetAttachmentAsync(attachmentId, "original");
 
-                var expectedAsString = Convert.ToBase64String(attachment.OriginalBase64, Base64FormattingOptions.None);
+                var expectedAsString = Convert.ToBase64String(attachment.OriginalBase64.ToArray(), Base64FormattingOptions.None);
                 
                 stream.Position = 0;
                 var length = stream.Length > int.MaxValue ? int.MaxValue : Convert.ToInt32(stream.Length);

--- a/tests/Microsoft.Bot.Schema.Tests/AttachmentTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/AttachmentTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
@@ -48,8 +49,8 @@ namespace Microsoft.Bot.Schema.Tests
             Assert.IsType<AttachmentData>(attachmentData);
             Assert.Equal(type, attachmentData.Type);
             Assert.Equal(name, attachmentData.Name);
-            Assert.Equal(originalBase64, attachmentData.OriginalBase64);
-            Assert.Equal(thumbnailBase64, attachmentData.ThumbnailBase64);
+            Assert.Equal(originalBase64, attachmentData.OriginalBase64.ToArray());
+            Assert.Equal(thumbnailBase64, attachmentData.ThumbnailBase64.ToArray());
         }
 
         [Fact]

--- a/tests/Storage/Microsoft.Bot.Builder.Azure.Blobs.Tests/TranscriptStoreBaseTests.cs
+++ b/tests/Storage/Microsoft.Bot.Builder.Azure.Blobs.Tests/TranscriptStoreBaseTests.cs
@@ -173,7 +173,6 @@ namespace Microsoft.Bot.Builder.Azure.Blobs.Tests
             {
                 var cleanChanel = Guid.NewGuid().ToString();
 
-                var loggedPagedResult = new PagedResult<IActivity>();
                 var activities = new List<IActivity>();
 
                 for (var i = 0; i < ConversationIds.Length; i++)
@@ -185,14 +184,14 @@ namespace Microsoft.Bot.Builder.Azure.Blobs.Tests
                     activities.Add(a);
                 }
 
-                loggedPagedResult = TranscriptStore.GetTranscriptActivitiesAsync(cleanChanel, ConversationIds[0]).Result;
+                var loggedPagedResult = TranscriptStore.GetTranscriptActivitiesAsync(cleanChanel, ConversationIds[0]).Result;
                 var ct = loggedPagedResult.ContinuationToken;
-                Assert.Equal(20, loggedPagedResult.Items.Length);
+                Assert.Equal(20, loggedPagedResult.Items.Count);
                 Assert.NotNull(ct);
                 Assert.True(loggedPagedResult.ContinuationToken.Length > 0);
                 loggedPagedResult = TranscriptStore.GetTranscriptActivitiesAsync(cleanChanel, ConversationIds[0], ct).Result;
                 ct = loggedPagedResult.ContinuationToken;
-                Assert.Equal(10, loggedPagedResult.Items.Length);
+                Assert.Equal(10, loggedPagedResult.Items.Count);
                 Assert.Null(ct);
             }
         }
@@ -202,7 +201,6 @@ namespace Microsoft.Bot.Builder.Azure.Blobs.Tests
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {
-                var loggedActivities = new PagedResult<IActivity>();
                 int i;
                 for (i = 0; i < ConversationSpecialIds.Length; i++)
                 {
@@ -210,7 +208,7 @@ namespace Microsoft.Bot.Builder.Azure.Blobs.Tests
                     await TranscriptStore.DeleteTranscriptAsync(a.ChannelId, a.Conversation.Id);
                 }
 
-                loggedActivities =
+                var loggedActivities =
                     await TranscriptStore.GetTranscriptActivitiesAsync(ChannelId, ConversationIds[i]);
                 Assert.Empty(loggedActivities.Items);
             }
@@ -262,7 +260,7 @@ namespace Microsoft.Bot.Builder.Azure.Blobs.Tests
                     .StartTestAsync();
 
                 var pagedResult = await GetPagedResultAsync(conversation, 6);
-                Assert.Equal(6, pagedResult.Items.Length);
+                Assert.Equal(6, pagedResult.Items.Count);
                 Assert.Equal("foo", pagedResult.Items[0].AsMessageActivity().Text);
                 Assert.NotNull(pagedResult.Items[1].AsTypingActivity());
                 Assert.Equal("echo:foo", pagedResult.Items[2].AsMessageActivity().Text);
@@ -310,7 +308,7 @@ namespace Microsoft.Bot.Builder.Azure.Blobs.Tests
                     .StartTestAsync();
 
                 var pagedResult = await GetPagedResultAsync(conversation, 3);
-                Assert.Equal(3, pagedResult.Items.Length);
+                Assert.Equal(3, pagedResult.Items.Count);
                 Assert.Equal("foo", pagedResult.Items[0].AsMessageActivity().Text);
                 Assert.Equal("new response", pagedResult.Items[1].AsMessageActivity().Text);
                 Assert.Equal("update", pagedResult.Items[2].AsMessageActivity().Text);
@@ -340,7 +338,7 @@ namespace Microsoft.Bot.Builder.Azure.Blobs.Tests
                 await Task.Delay(3000);
 
                 var pagedResult = await GetPagedResultAsync(conversation, 2);
-                Assert.Equal(2, pagedResult.Items.Length);
+                Assert.Equal(2, pagedResult.Items.Count);
                 Assert.Equal(fooId, pagedResult.Items[0].AsMessageActivity().Id);
                 Assert.Equal("foo", pagedResult.Items[0].AsMessageActivity().Text);
                 Assert.StartsWith("g_", pagedResult.Items[1].AsMessageActivity().Id);
@@ -386,14 +384,14 @@ namespace Microsoft.Bot.Builder.Azure.Blobs.Tests
 
                 // Perform some queries
                 var pagedResult = await TranscriptStore.GetTranscriptActivitiesAsync(conversation.ChannelId, conversation.Conversation.Id, null, dateTimeStartOffset1.DateTime);
-                Assert.Equal(3, pagedResult.Items.Length);
+                Assert.Equal(3, pagedResult.Items.Count);
                 Assert.Equal("foo", pagedResult.Items[0].AsMessageActivity().Text);
                 Assert.Equal("new response", pagedResult.Items[1].AsMessageActivity().Text);
                 Assert.Equal("update", pagedResult.Items[2].AsMessageActivity().Text);
 
                 // Perform some queries
                 pagedResult = await TranscriptStore.GetTranscriptActivitiesAsync(conversation.ChannelId, conversation.Conversation.Id, null, DateTimeOffset.MinValue);
-                Assert.Equal(3, pagedResult.Items.Length);
+                Assert.Equal(3, pagedResult.Items.Count);
                 Assert.Equal("foo", pagedResult.Items[0].AsMessageActivity().Text);
                 Assert.Equal("new response", pagedResult.Items[1].AsMessageActivity().Text);
                 Assert.Equal("update", pagedResult.Items[2].AsMessageActivity().Text);
@@ -433,7 +431,7 @@ namespace Microsoft.Bot.Builder.Azure.Blobs.Tests
                     .StartTestAsync();
 
                 var pagedResult = await GetPagedResultAsync(conversation, 3);
-                Assert.Equal(3, pagedResult.Items.Length);
+                Assert.Equal(3, pagedResult.Items.Count);
                 Assert.Equal("foo", pagedResult.Items[0].AsMessageActivity().Text);
                 Assert.NotNull(pagedResult.Items[1].AsMessageDeleteActivity());
                 Assert.Equal(ActivityTypes.MessageDelete, pagedResult.Items[1].Type);
@@ -478,7 +476,7 @@ namespace Microsoft.Bot.Builder.Azure.Blobs.Tests
                 try
                 {
                     pagedResult = await TranscriptStore.GetTranscriptActivitiesAsync(conversation.ChannelId, conversation.Conversation.Id);
-                    if (pagedResult.Items.Length >= expectedLength)
+                    if (pagedResult.Items.Count >= expectedLength)
                     {
                         break;
                     }


### PR DESCRIPTION
Addresses # 6099
#minor

## Description
This PR removes the exclusions of the FxCop rule [CA1819](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1819) (Properties should not return arrays).

### Detailed Changes
- Removed the rule exclusion and changed the property type from array to collection in the following classes:
   - Microsoft.Bot.Builder/PagedResult: Items property.
   - Microsoft.Bot.Connector/Authentication/AuthenticationConfiguration: RequiredEndorsements property.
   - Microsoft.Bot.Schema/AttachmentData: OriginalBase64 and ThumbnailBase64 properties.
- Replaced `Lenght` method with `Count` for the updated properties.
- Added `ToArray()` to the properties when needed.

## Testing
This image shows the test passing after the changes.
![image](https://user-images.githubusercontent.com/44245136/153253175-f8057180-6217-4c85-8387-29a84382d9fc.png)