### PR TITLE
[#6099] Remove low impact FxCop exclusions - Rule CA1819 (Part 2/2)

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
@@ -435,16 +435,19 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
         /// <remarks>If the task is successful, the result contains the QnA Maker options to use.</remarks>
         protected virtual Task<QnAMakerOptions> GetQnAMakerOptionsAsync(DialogContext dc)
         {
-            return Task.FromResult(new QnAMakerOptions
+            var qnaMakerOptions = new QnAMakerOptions
             {
                 ScoreThreshold = Threshold,
-                StrictFilters = StrictFilters?.ToArray(),
                 Top = Top,
                 Context = new QnARequestContext(),
                 QnAId = 0,
                 RankerType = RankerType,
                 IsTest = IsTest
-            });
+            };
+
+            qnaMakerOptions.SetStrictFilters(StrictFilters?.ToArray());
+
+            return Task.FromResult(qnaMakerOptions);
         }
 
         /// <summary>
@@ -581,9 +584,9 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
             if (response.Answers.Any() && response.Answers.First().Score <= (ActiveLearningUtils.MaximumScoreForLowScoreVariation / 100))
             {
                 // Get filtered list of the response that support low score variation criteria.
-                response.Answers = qnaClient.GetLowScoreVariation(response.Answers);
+                response.SetAnswers(qnaClient.GetLowScoreVariation(response.Answers.ToArray()));
 
-                if (response.Answers.Length > 1 && isActiveLearningEnabled)
+                if (response.Answers.Count > 1 && isActiveLearningEnabled)
                 {
                     var suggestedQuestions = new List<string>();
                     foreach (var qna in response.Answers)
@@ -686,7 +689,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
 
                 var answer = response.First();
 
-                if (answer.Context != null && answer.Context.Prompts.Length > 0)
+                if (answer.Context != null && answer.Context.Prompts.Count > 0)
                 {
                     var previousContextData = ObjectPath.GetPathValue(stepContext.ActiveDialog.State, QnAContextData, new Dictionary<string, int>());
                     var previousQnAId = ObjectPath.GetPathValue<int>(stepContext.ActiveDialog.State, PreviousQnAId, 0);

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/IQnAMakerClient.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/IQnAMakerClient.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Builder.AI.QnA
@@ -19,7 +20,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
         /// <param name="telemetryProperties">Additional properties to be logged to telemetry with the QnaMessage event.</param>
         /// <param name="telemetryMetrics">Additional metrics to be logged to telemetry with the QnaMessage event.</param>
         /// <returns>A list of answers for the user query, sorted in decreasing order of ranking score.</returns>
-        Task<QueryResult[]> GetAnswersAsync(
+        Task<Collection<QueryResult>> GetAnswersAsync(
                                         ITurnContext turnContext,
                                         QnAMakerOptions options,
                                         Dictionary<string, string> telemetryProperties,

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/ITelemetryQnAMaker.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/ITelemetryQnAMaker.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Builder.AI.QnA
@@ -31,6 +32,6 @@ namespace Microsoft.Bot.Builder.AI.QnA
         /// <param name="telemetryProperties">Additional properties to be logged to telemetry with the QnaMessage event.</param>
         /// <param name="telemetryMetrics">Additional metrics to be logged to telemetry with the QnaMessage event.</param>
         /// <returns>A list of answers for the user query, sorted in decreasing order of ranking score.</returns>
-        Task<QueryResult[]> GetAnswersAsync(ITurnContext turnContext, QnAMakerOptions options, Dictionary<string, string> telemetryProperties, Dictionary<string, double> telemetryMetrics = null);
+        Task<Collection<QueryResult>> GetAnswersAsync(ITurnContext turnContext, QnAMakerOptions options, Dictionary<string, string> telemetryProperties, Dictionary<string, double> telemetryMetrics = null);
     }
 }

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Models/QnAMakerTraceInfo.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Models/QnAMakerTraceInfo.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.ObjectModel;
 using Microsoft.Bot.Schema;
 using Newtonsoft.Json;
 
@@ -22,15 +23,13 @@ namespace Microsoft.Bot.Builder.AI.QnA
         public Activity Message { get; set; }
 
         /// <summary>
-        /// Gets or sets results that QnAMaker returned.
+        /// Gets results that QnAMaker returned.
         /// </summary>
         /// <value>
         /// Results that QnAMaker returned.
         /// </value>
         [JsonProperty("queryResults")]
-#pragma warning disable CA1819 // Properties should not return arrays (we can't change this without breaking binary compat)
-        public QueryResult[] QueryResults { get; set; }
-#pragma warning restore CA1819 // Properties should not return arrays
+        public Collection<QueryResult> QueryResults { get; private set; }
 
         /// <summary>
         /// Gets or sets iD of the Knowledgebase that is being used.
@@ -62,15 +61,13 @@ namespace Microsoft.Bot.Builder.AI.QnA
         public int Top { get; set; }
 
         /// <summary>
-        /// Gets or sets the filters used to return answers that have the specified metadata.       
+        /// Gets the filters used to return answers that have the specified metadata.       
         /// </summary>
         /// <value>
         /// The filters used to return answers that have the specified metadata.
         /// </value>        
         [JsonProperty("strictFilters")]
-#pragma warning disable CA1819 // Properties should not return arrays (we can't change this without breaking binary compat)
-        public Metadata[] StrictFilters { get; set; }
-#pragma warning restore CA1819 // Properties should not return arrays
+        public Collection<Metadata> StrictFilters { get; private set; }
 
         /// <summary>
         /// Gets or sets context for multi-turn responses.
@@ -109,15 +106,31 @@ namespace Microsoft.Bot.Builder.AI.QnA
         public string RankerType { get; set; }
 
         /// <summary>
-        /// Gets or sets the <see cref="Metadata"/> collection to be sent when calling QnA Maker to boost results.
+        /// Gets the <see cref="Metadata"/> collection to be sent when calling QnA Maker to boost results.
         /// </summary>
         /// <value>
         /// An array of <see cref="Metadata"/>.
         /// </value>
         [Obsolete("This property is no longer used and will be ignored")]
         [JsonIgnore]
-#pragma warning disable CA1819 // Properties should not return arrays (this property is obsolete and we won't change it)
-        public Metadata[] MetadataBoost { get; set; }
-#pragma warning restore CA1819 // Properties should not return arrays
+        public Collection<Metadata> MetadataBoost { get; private set; }
+
+        /// <summary>
+        /// Sets the results that QnAMaker returned.
+        /// </summary>
+        /// <param name="queryResults">The results that QnAMaker returned.</param>
+        public void SetQueryResults(QueryResult[] queryResults)
+        {
+            QueryResults = new Collection<QueryResult>(queryResults);
+        }
+
+        /// <summary>
+        /// Sets the filters used to return answers that have the specified metadata.
+        /// </summary>
+        /// <param name="filters">The filters used to return answers that have the specified metadata.</param>
+        public void SetStrictFilters(Metadata[] filters)
+        {
+            StrictFilters = new Collection<Metadata>(filters);
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Models/QnAResponseContext.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Models/QnAResponseContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.ObjectModel;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.AI.QnA
@@ -12,14 +13,12 @@ namespace Microsoft.Bot.Builder.AI.QnA
     public class QnAResponseContext
     {
         /// <summary>
-        /// Gets or sets the prompts collection of related prompts.
+        /// Gets the prompts collection of related prompts.
         /// </summary>
         /// <value>
         /// The QnA prompts array.
         /// </value>
         [JsonProperty(PropertyName = "prompts")]
-#pragma warning disable CA1819 // Properties should not return arrays (we can't change this without breaking binary compat)
-        public QnaMakerPrompt[] Prompts { get; set; }
-#pragma warning restore CA1819 // Properties should not return arrays
+        public Collection<QnaMakerPrompt> Prompts { get; private set; }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Models/QueryResult.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Models/QueryResult.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.ObjectModel;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.AI.QnA
@@ -11,15 +12,22 @@ namespace Microsoft.Bot.Builder.AI.QnA
     public class QueryResult
     {
         /// <summary>
-        /// Gets or sets the list of questions indexed in the QnA Service for the given answer.
+        /// Initializes a new instance of the <see cref="QueryResult"/> class.
+        /// </summary>
+        /// <param name="questions">The list of questions indexed in the QnA Service for the given answer.</param>
+        public QueryResult(string[] questions)
+        {
+            Questions = new Collection<string>(questions);
+        }
+
+        /// <summary>
+        /// Gets the list of questions indexed in the QnA Service for the given answer.
         /// </summary>
         /// <value>
         /// The list of questions indexed in the QnA Service for the given answer.
         /// </value>
         [JsonProperty("questions")]
-#pragma warning disable CA1819 // Properties should not return arrays (we can't change this without breaking binary compat)
-        public string[] Questions { get; set; }
-#pragma warning restore CA1819 // Properties should not return arrays
+        public Collection<string> Questions { get; private set; }
 
         /// <summary>
         /// Gets or sets the answer text.
@@ -42,15 +50,13 @@ namespace Microsoft.Bot.Builder.AI.QnA
         public float Score { get; set; }
 
         /// <summary>
-        /// Gets or sets metadata that is associated with the answer.
+        /// Gets metadata that is associated with the answer.
         /// </summary>
         /// <value>
         /// Metadata that is associated with the answer.
         /// </value>
         [JsonProperty(PropertyName = "metadata")]
-#pragma warning disable CA1819 // Properties should not return arrays (we can't change this without breaking binary compat)
-        public Metadata[] Metadata { get; set; }
-#pragma warning restore CA1819 // Properties should not return arrays
+        public Collection<Metadata> Metadata { get; private set; }
 
         /// <summary>
         /// Gets or sets the source from which the QnA was extracted.

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Models/QueryResults.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Models/QueryResults.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.ObjectModel;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.AI.QnA
@@ -11,7 +12,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
     public class QueryResults
     {
         /// <summary>
-        /// Gets or sets the answers for a user query,
+        /// Gets the answers for a user query,
         /// sorted in decreasing order of ranking score.
         /// </summary>
         /// <value>
@@ -19,9 +20,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
         /// sorted in decreasing order of ranking score.
         /// </value>
         [JsonProperty("answers")]
-#pragma warning disable CA1819 // Properties should not return arrays (we can't change this without breaking binary compat)
-        public QueryResult[] Answers { get; set; }
-#pragma warning restore CA1819 // Properties should not return arrays
+        public Collection<QueryResult> Answers { get; private set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether gets or set for the active learning enable flag.
@@ -31,5 +30,14 @@ namespace Microsoft.Bot.Builder.AI.QnA
         /// </value>
         [JsonProperty("activeLearningEnabled")]
         public bool ActiveLearningEnabled { get; set; }
+
+        /// <summary>
+        /// Sets the answers for a user query.
+        /// </summary>
+        /// <param name="answers">The answers for a user query.</param>
+        public void SetAnswers(QueryResult[] answers)
+        {
+            Answers = new Collection<QueryResult>(answers);
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMaker.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMaker.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
 using System.Net.Http;
@@ -127,7 +128,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
         /// <param name="turnContext">The Turn Context that contains the user question to be queried against your knowledge base.</param>
         /// <param name="options">The options for the QnA Maker knowledge base. If null, constructor option is used for this instance.</param>
         /// <returns>A list of answers for the user query, sorted in decreasing order of ranking score.</returns>
-        public Task<QueryResult[]> GetAnswersAsync(ITurnContext turnContext, QnAMakerOptions options = null)
+        public Task<Collection<QueryResult>> GetAnswersAsync(ITurnContext turnContext, QnAMakerOptions options = null)
         {
             return GetAnswersAsync(turnContext, options, null);
         }
@@ -140,7 +141,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
         /// <param name="telemetryProperties">Additional properties to be logged to telemetry with the QnaMessage event.</param>
         /// <param name="telemetryMetrics">Additional metrics to be logged to telemetry with the QnaMessage event.</param>
         /// <returns>A list of answers for the user query, sorted in decreasing order of ranking score.</returns>
-        public async Task<QueryResult[]> GetAnswersAsync(
+        public async Task<Collection<QueryResult>> GetAnswersAsync(
                                         ITurnContext turnContext,
                                         QnAMakerOptions options,
                                         Dictionary<string, string> telemetryProperties,
@@ -188,7 +189,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
 
             var result = await this._generateAnswerHelper.GetAnswersRawAsync(turnContext, messageActivity, options).ConfigureAwait(false);
 
-            await OnQnaResultsAsync(result.Answers, turnContext, telemetryProperties, telemetryMetrics, CancellationToken.None).ConfigureAwait(false);
+            await OnQnaResultsAsync(result.Answers.ToArray(), turnContext, telemetryProperties, telemetryMetrics, CancellationToken.None).ConfigureAwait(false);
 
             return result;
         }

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMakerOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMakerOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.ObjectModel;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.AI.QnA
@@ -71,27 +72,23 @@ namespace Microsoft.Bot.Builder.AI.QnA
         public int QnAId { get; set; }
 
         /// <summary>
-        /// Gets or sets the <see cref="Metadata"/> collection to be sent when calling QnA Maker to filter results.
+        /// Gets the <see cref="Metadata"/> collection to be sent when calling QnA Maker to filter results.
         /// </summary>
         /// <value>
         /// An array of <see cref="Metadata"/>.
         /// </value>
         [JsonProperty("strictFilters")]
-#pragma warning disable CA1819 // Properties should not return arrays (we can't change this without breaking binary compat)
-        public Metadata[] StrictFilters { get; set; }
-#pragma warning restore CA1819 // Properties should not return arrays
+        public Collection<Metadata> StrictFilters { get; private set; }
 
         /// <summary>
-        /// Gets or sets the <see cref="Metadata"/> collection to be sent when calling QnA Maker to boost results.
+        /// Gets the <see cref="Metadata"/> collection to be sent when calling QnA Maker to boost results.
         /// </summary>
         /// <value>
         /// An array of <see cref="Metadata"/>.
         /// </value>
         [Obsolete("This property is no longer used and will be ignored")]
         [JsonIgnore]
-#pragma warning disable CA1819 // Properties should not return arrays (property is obsolete, we won't change it)
-        public Metadata[] MetadataBoost { get; set; }
-#pragma warning restore CA1819 // Properties should not return arrays
+        public Collection<Metadata> MetadataBoost { get; private set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to call test or prod environment of knowledge base to be called. 
@@ -120,5 +117,14 @@ namespace Microsoft.Bot.Builder.AI.QnA
         /// </value>
         [JsonProperty("strictFiltersJoinOperator")]
         public JoinOperator StrictFiltersJoinOperator { get; set; }
+
+        /// <summary>
+        /// Sets the <see cref="Metadata"/> collection to be sent when calling QnA Maker to filter results. 
+        /// </summary>
+        /// <param name="filters">The <see cref="Metadata"/> collection to filter results.</param>
+        public void SetStrictFilters(Metadata[] filters)
+        {
+            StrictFilters = new Collection<Metadata>(filters);
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMakerRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMakerRecognizer.cs
@@ -207,19 +207,22 @@ namespace Microsoft.Bot.Builder.AI.QnA.Recognizers
 
             // Calling QnAMaker to get response.
             var qnaClient = await GetQnAMakerClientAsync(dialogContext).ConfigureAwait(false);
+            var qnaMakerOptions = new QnAMakerOptions
+            {
+                Context = Context,
+                ScoreThreshold = (float)Threshold,
+                Top = Top,
+                QnAId = QnAId,
+                RankerType = RankerType,
+                IsTest = IsTest,
+                StrictFiltersJoinOperator = StrictFiltersJoinOperator
+            };
+            
+            qnaMakerOptions.SetStrictFilters(filters.ToArray());
+
             var answers = await qnaClient.GetAnswersAsync(
                 dialogContext.Context,
-                new QnAMakerOptions
-                {
-                    Context = Context,
-                    ScoreThreshold = (float)Threshold,
-                    StrictFilters = filters.ToArray(),
-                    Top = Top,
-                    QnAId = QnAId,
-                    RankerType = RankerType,
-                    IsTest = IsTest,
-                    StrictFiltersJoinOperator = StrictFiltersJoinOperator
-                },
+                qnaMakerOptions,
                 null).ConfigureAwait(false);
 
             if (answers.Any())

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/GenerateAnswerUtils.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/GenerateAnswerUtils.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -50,7 +51,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
         /// <param name="options">The options for the QnA Maker knowledge base. If null, constructor option is used for this instance.</param>
         /// <returns>A list of answers for the user query, sorted in decreasing order of ranking score.</returns>
         [Obsolete]
-        public async Task<QueryResult[]> GetAnswersAsync(ITurnContext turnContext, IMessageActivity messageActivity, QnAMakerOptions options)
+        public async Task<Collection<QueryResult>> GetAnswersAsync(ITurnContext turnContext, IMessageActivity messageActivity, QnAMakerOptions options)
         {
             var result = await GetAnswersRawAsync(turnContext, messageActivity, options).ConfigureAwait(false);
 
@@ -86,7 +87,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
 
             var result = await QueryQnaServiceAsync((Activity)messageActivity, hydratedOptions).ConfigureAwait(false);
 
-            await EmitTraceInfoAsync(turnContext, (Activity)messageActivity, result.Answers, hydratedOptions).ConfigureAwait(false);
+            await EmitTraceInfoAsync(turnContext, (Activity)messageActivity, result.Answers.ToArray(), hydratedOptions).ConfigureAwait(false);
 
             return result;
         }
@@ -102,7 +103,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
                 answer.Score = answer.Score / 100;
             }
 
-            results.Answers = results.Answers.Where(answer => answer.Score > options.ScoreThreshold).ToArray();
+            results.SetAnswers(results.Answers.Where(answer => answer.Score > options.ScoreThreshold).ToArray());
 
             return results;
         }
@@ -136,7 +137,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
 
             if (options.StrictFilters == null)
             {
-                options.StrictFilters = Array.Empty<Metadata>();
+                options.SetStrictFilters(Array.Empty<Metadata>());
             }
 
             if (options.RankerType == null)
@@ -166,9 +167,9 @@ namespace Microsoft.Bot.Builder.AI.QnA
                     hydratedOptions.Top = queryOptions.Top;
                 }
 
-                if (queryOptions.StrictFilters?.Length > 0)
+                if (queryOptions.StrictFilters?.Count > 0)
                 {
-                    hydratedOptions.StrictFilters = queryOptions.StrictFilters;
+                    hydratedOptions.SetStrictFilters(queryOptions.StrictFilters.ToArray());
                 }
 
                 hydratedOptions.Context = queryOptions.Context;
@@ -211,16 +212,18 @@ namespace Microsoft.Bot.Builder.AI.QnA
             var traceInfo = new QnAMakerTraceInfo
             {
                 Message = messageActivity,
-                QueryResults = result,
                 KnowledgeBaseId = _endpoint.KnowledgeBaseId,
                 ScoreThreshold = options.ScoreThreshold,
                 Top = options.Top,
-                StrictFilters = options.StrictFilters,
                 Context = options.Context,
                 QnAId = options.QnAId,
                 IsTest = options.IsTest,
                 RankerType = options.RankerType
             };
+
+            traceInfo.SetQueryResults(result);
+            traceInfo.SetStrictFilters(options.StrictFilters.ToArray());
+
             var traceActivity = Activity.CreateTraceActivity(QnAMaker.QnAMakerName, QnAMaker.QnAMakerTraceType, traceInfo, QnAMaker.QnAMakerTraceLabel);
             await turnContext.SendActivityAsync(traceActivity).ConfigureAwait(false);
         }

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/Models/QnAMakerTraceInfoTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/Models/QnAMakerTraceInfoTests.cs
@@ -16,19 +16,19 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests.Models
         {
             var qnaMakerTraceInfo = new QnAMakerTraceInfo
             {
-                QueryResults = new[]
-                {
-                    new QueryResult
-                    {
-                        Questions = new[] { "What's your name?" },
-                        Answer = "My name is Mike",
-                        Score = 0.9F,
-                    },
-                },
                 KnowledgeBaseId = Guid.NewGuid().ToString(),
                 ScoreThreshold = 0.5F,
                 Top = 1,
             };
+
+            qnaMakerTraceInfo.SetQueryResults(new[]
+            {
+                new QueryResult(new[] { "What's your name?" })
+                {
+                    Answer = "My name is Mike",
+                    Score = 0.9F,
+                },
+            });
 
             var serializerSettings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto };
             var serialized = JsonConvert.SerializeObject(qnaMakerTraceInfo, serializerSettings);

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
@@ -282,9 +283,9 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
 
             var results = await qna.GetAnswersAsync(GetContext("Q11"));
             Assert.NotNull(results);
-            Assert.Equal(4, results.Length);
+            Assert.Equal(4, results.Count);
 
-            var filteredResults = qna.GetLowScoreVariation(results);
+            var filteredResults = qna.GetLowScoreVariation(results.ToArray());
             Assert.NotNull(filteredResults);
             Assert.Equal(3, filteredResults.Length);
 
@@ -294,9 +295,9 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
            
             results = await qna.GetAnswersAsync(GetContext("Q11"));
             Assert.NotNull(results);
-            Assert.Equal(4, results.Length);
+            Assert.Equal(4, results.Count);
 
-            filteredResults = qna.GetLowScoreVariation(results);
+            filteredResults = qna.GetLowScoreVariation(results.ToArray());
             Assert.NotNull(filteredResults);
             Assert.Equal(3, filteredResults.Length);
         }
@@ -363,12 +364,13 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
 
             var options = new QnAMakerOptions
             {
-                StrictFilters = new Metadata[]
-                {
-                    new Metadata() { Name = "topic", Value = "value" },
-                },
                 Top = 1,
             };
+
+            options.SetStrictFilters(new Metadata[]
+            {
+                new Metadata() { Name = "topic", Value = "value" },
+            });
 
             var results = await qna.GetAnswersAsync(GetContext("how do I clean the stove?"), options);
             Assert.NotNull(results);
@@ -543,7 +545,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
 
             var results = await qna.GetAnswersAsync(GetContext("Where can I buy?"), options);
             Assert.NotNull(results);
-            Assert.Equal(2, results.Length);
+            Assert.Equal(2, results.Count);
             Assert.NotEqual(1, results[0].Score);
         }
 
@@ -851,7 +853,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
 
             var results = await qna.GetAnswersAsync(GetContext("Q11"), qnaMakerOptions);
             Assert.NotNull(results);
-            Assert.Equal(2, results.Length);
+            Assert.Equal(2, results.Count);
         }
 
         [Fact]
@@ -883,46 +885,50 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
             var oneFilteredOption = new QnAMakerOptions
             {
                 Top = 30,
-                StrictFilters = new Metadata[]
-                {
-                    new Metadata
-                    {
-                        Name = "movie",
-                        Value = "disney",
-                    },
-                },
             };
+
+            oneFilteredOption.SetStrictFilters(new Metadata[]
+            {
+                new Metadata
+                {
+                    Name = "movie",
+                    Value = "disney",
+                },
+            });
 
             var twoStrictFiltersOptions = new QnAMakerOptions
             {
                 Top = 30,
-                StrictFilters = new Metadata[]
-                {
-                    new Metadata()
-                    {
-                        Name = "movie",
-                        Value = "disney",
-                    },
-                    new Metadata()
-                    {
-                        Name = "home",
-                        Value = "floating",
-                    },
-                },
             };
+
+            twoStrictFiltersOptions.SetStrictFilters(new Metadata[]
+            {
+                new Metadata()
+                {
+                    Name = "movie",
+                    Value = "disney",
+                },
+                new Metadata()
+                {
+                    Name = "home",
+                    Value = "floating",
+                },
+            });
+
             var allChangedRequestOptions = new QnAMakerOptions
             {
                 Top = 2000,
                 ScoreThreshold = 0.42F,
-                StrictFilters = new Metadata[]
-                {
-                    new Metadata()
-                    {
-                        Name = "dog",
-                        Value = "samoyed",
-                    },
-                },
             };
+
+            allChangedRequestOptions.SetStrictFilters(new Metadata[]
+            {
+                new Metadata()
+                {
+                    Name = "dog",
+                    Value = "samoyed",
+                },
+            });
 
             var context = GetContext("up");
 
@@ -973,21 +979,23 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
             var oneFilteredOption = new QnAMakerOptions()
             {
                 Top = 30,
-                StrictFilters = new Metadata[]
-                {
-                    new Metadata()
-                    {
-                        Name = "movie",
-                        Value = "disney",
-                    },
-                    new Metadata()
-                    {
-                        Name = "production",
-                        Value = "Walden",
-                    },
-                },
                 StrictFiltersJoinOperator = JoinOperator.OR
             };
+
+            oneFilteredOption.SetStrictFilters(new Metadata[]
+            {
+                new Metadata()
+                {
+                    Name = "movie",
+                    Value = "disney",
+                },
+                new Metadata()
+                {
+                    Name = "production",
+                    Value = "Walden",
+                },
+            });
+
             var qna = GetQnAMaker(
                             interceptHttp,
                             new QnAMakerEndpoint
@@ -1001,7 +1009,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
             var context = GetContext("up");
             var noFilterResults1 = await qna.GetAnswersAsync(context, oneFilteredOption);
             var requestContent1 = JsonConvert.DeserializeObject<CapturedRequest>(interceptHttp.Content);
-            Assert.Equal(2, oneFilteredOption.StrictFilters.Length);
+            Assert.Equal(2, oneFilteredOption.StrictFilters.Count);
             Assert.Equal(JoinOperator.OR, oneFilteredOption.StrictFiltersJoinOperator);
         }
 


### PR DESCRIPTION
Addresses # 6099
#minor

## Description
This PR removes the exclusions of the FxCop rule [CA1819](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1819) (Properties should not return arrays).

### Detailed Changes
- Removed the rule exclusion and changed the property type from array to collection in the following classes:
   - `Microsoft.Bot.Builder.AI.QnA/Models/QnAMakerTraceInfo`: _QueryResults, StrictFilters_, and _MetadataBoost_ properties.
   - `Microsoft.Bot.Builder.AI.QnA/Models/QnAResponseContext`: _Prompts_ property.
   - `Microsoft.Bot.Builder.AI.QnA/Models/QueryResult`: _Questions_ and _Metadata_ properies.
   - `Microsoft.Bot.Builder.AI.QnA/Models/QueryResults`: _Answers_ property.
   - `Microsoft.Bot.Builder.AI.QnA/QnAMakerOptions`: _StrictFilters_ and _MetadataBoost_ properties.
- Added ` Setxxx()` methods to set the properties that are accessed after the class is instantiated.
- Replaced `Length` with `Count` for the updated properties.
- Added `ToArray()` to the properties when needed.

## Testing
This image shows the test passing after the changes.
![image](https://user-images.githubusercontent.com/44245136/153253175-f8057180-6217-4c85-8387-29a84382d9fc.png)