### PR TITLE
[#6099] Remove low impact FxCop exclusions - Rule CA2227 (Part 3/8)

### DIFF
--- a/libraries/Microsoft.Bot.Schema/Teams/ConversationList.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/ConversationList.cs
@@ -27,18 +27,16 @@ namespace Microsoft.Bot.Schema.Teams
         /// <param name="conversations">The IList of conversations.</param>
         public ConversationList(IList<ChannelInfo> conversations = default)
         {
-            Conversations = conversations;
+            Conversations = conversations ?? new List<ChannelInfo>();
             CustomInit();
         }
 
         /// <summary>
-        /// Gets or sets the conversations.
+        /// Gets the conversations.
         /// </summary>
         /// <value>The conversations.</value>
         [JsonProperty(PropertyName = "conversations")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat)
-        public IList<ChannelInfo> Conversations { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<ChannelInfo> Conversations { get; private set; } = new List<ChannelInfo>();
 
         /// <summary>
         /// An initialization method that performs custom operations like setting defaults.

--- a/libraries/Microsoft.Bot.Schema/Teams/MessageActionsPayload.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MessageActionsPayload.cs
@@ -69,9 +69,9 @@ namespace Microsoft.Bot.Schema.Teams
             From = from;
             Body = body;
             AttachmentLayout = attachmentLayout;
-            Attachments = attachments;
-            Mentions = mentions;
-            Reactions = reactions;
+            Attachments = attachments ?? new List<MessageActionsPayloadAttachment>();
+            Mentions = mentions ?? new List<MessageActionsPayloadMention>();
+            Reactions = reactions ?? new List<MessageActionsPayloadReaction>();
             CustomInit();
         }
 
@@ -171,31 +171,25 @@ namespace Microsoft.Bot.Schema.Teams
         public string AttachmentLayout { get; set; }
 
         /// <summary>
-        /// Gets or sets attachments in the message - card, image, file, etc.
+        /// Gets attachments in the message - card, image, file, etc.
         /// </summary>
         /// <value>The attachments in the message.</value>
         [JsonProperty(PropertyName = "attachments")]
-#pragma warning disable CA2227 // Collection properties should be read only  (we can't change this without breaking compat)
-        public IList<MessageActionsPayloadAttachment> Attachments { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<MessageActionsPayloadAttachment> Attachments { get; private set; } = new List<MessageActionsPayloadAttachment>();
 
         /// <summary>
-        /// Gets or sets list of entities mentioned in the message.
+        /// Gets list of entities mentioned in the message.
         /// </summary>
         /// <value>The entities mentioned in the message.</value>
         [JsonProperty(PropertyName = "mentions")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat)
-        public IList<MessageActionsPayloadMention> Mentions { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<MessageActionsPayloadMention> Mentions { get; private set; } = new List<MessageActionsPayloadMention>();
 
         /// <summary>
-        /// Gets or sets reactions for the message.
+        /// Gets reactions for the message.
         /// </summary>
         /// <value>The reactions for the message.</value>
         [JsonProperty(PropertyName = "reactions")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat)
-        public IList<MessageActionsPayloadReaction> Reactions { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<MessageActionsPayloadReaction> Reactions { get; private set; } = new List<MessageActionsPayloadReaction>();
 
         /// <summary>
         /// Gets or sets the link back to the message.

--- a/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionAction.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionAction.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Bot.Schema.Teams
             CommandId = commandId;
             CommandContext = commandContext;
             BotMessagePreviewAction = botMessagePreviewAction;
-            BotActivityPreview = botActivityPreview;
+            BotActivityPreview = botActivityPreview ?? new List<Activity>();
             MessagePayload = messagePayload;
             CustomInit();
         }
@@ -70,13 +70,11 @@ namespace Microsoft.Bot.Schema.Teams
         public string BotMessagePreviewAction { get; set; }
 
         /// <summary>
-        /// Gets or sets the bot activity preview.
+        /// Gets the bot activity preview.
         /// </summary>
         /// <value>The bot activity preview.</value>
         [JsonProperty(PropertyName = "botActivityPreview")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<Activity> BotActivityPreview { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<Activity> BotActivityPreview { get; private set; } = new List<Activity>();
 
         /// <summary>
         /// Gets or sets message content sent as part of the command request.

--- a/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionQuery.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionQuery.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Bot.Schema.Teams
         public MessagingExtensionQuery(string commandId = default, IList<MessagingExtensionParameter> parameters = default, MessagingExtensionQueryOptions queryOptions = default, string state = default)
         {
             CommandId = commandId;
-            Parameters = parameters;
+            Parameters = parameters ?? new List<MessagingExtensionParameter>();
             QueryOptions = queryOptions;
             State = state;
             CustomInit();
@@ -45,13 +45,11 @@ namespace Microsoft.Bot.Schema.Teams
         public string CommandId { get; set; }
 
         /// <summary>
-        /// Gets or sets parameters for the query.
+        /// Gets parameters for the query.
         /// </summary>
         /// <value>The parameters for the query.</value>
         [JsonProperty(PropertyName = "parameters")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<MessagingExtensionParameter> Parameters { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<MessagingExtensionParameter> Parameters { get; private set; } = new List<MessagingExtensionParameter>();
 
         /// <summary>
         /// Gets or sets the query options.

--- a/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionResult.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionResult.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Bot.Schema.Teams
         {
             AttachmentLayout = attachmentLayout;
             Type = type;
-            Attachments = attachments;
+            Attachments = attachments ?? new List<MessagingExtensionAttachment>();
             SuggestedActions = suggestedActions;
             Text = text;
             ActivityPreview = activityPreview;
@@ -61,13 +61,11 @@ namespace Microsoft.Bot.Schema.Teams
         public string Type { get; set; }
 
         /// <summary>
-        /// Gets or sets (Only when type is result) Attachments.
+        /// Gets (Only when type is result) Attachments.
         /// </summary>
         /// <value>The attachments.</value>
         [JsonProperty(PropertyName = "attachments")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<MessagingExtensionAttachment> Attachments { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<MessagingExtensionAttachment> Attachments { get; private set; } = new List<MessagingExtensionAttachment>();
 
         /// <summary>
         /// Gets or sets the suggested actions.

--- a/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionSuggestedAction.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionSuggestedAction.cs
@@ -23,20 +23,18 @@ namespace Microsoft.Bot.Schema.Teams
         /// Initializes a new instance of the <see cref="MessagingExtensionSuggestedAction"/> class.
         /// </summary>
         /// <param name="actions">Actions.</param>
-        public MessagingExtensionSuggestedAction(IList<CardAction> actions = default(IList<CardAction>))
+        public MessagingExtensionSuggestedAction(IList<CardAction> actions = default)
         {
-            Actions = actions;
+            Actions = actions ?? new List<CardAction>();
             CustomInit();
         }
 
         /// <summary>
-        /// Gets or sets actions.
+        /// Gets actions.
         /// </summary>
         /// <value>The actions.</value>
         [JsonProperty(PropertyName = "actions")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<CardAction> Actions { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<CardAction> Actions { get; private set; } = new List<CardAction>();
 
         /// <summary>
         /// An initialization method that performs custom operations like setting defaults.

--- a/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCard.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCard.cs
@@ -37,8 +37,8 @@ namespace Microsoft.Bot.Schema.Teams
             Text = text;
             Summary = summary;
             ThemeColor = themeColor;
-            Sections = sections;
-            PotentialAction = potentialAction;
+            Sections = sections ?? new List<O365ConnectorCardSection>();
+            PotentialAction = potentialAction ?? new List<O365ConnectorCardActionBase>();
             CustomInit();
         }
 
@@ -71,22 +71,18 @@ namespace Microsoft.Bot.Schema.Teams
         public string ThemeColor { get; set; }
 
         /// <summary>
-        /// Gets or sets set of sections for the current card.
+        /// Gets set of sections for the current card.
         /// </summary>
         /// <value>The sections for the current card.</value>
         [JsonProperty(PropertyName = "sections")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<O365ConnectorCardSection> Sections { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<O365ConnectorCardSection> Sections { get; private set; } = new List<O365ConnectorCardSection>();
 
         /// <summary>
-        /// Gets or sets set of actions for the current card.
+        /// Gets set of actions for the current card.
         /// </summary>
         /// <value>The actions for the current card.</value>
         [JsonProperty(PropertyName = "potentialAction")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<O365ConnectorCardActionBase> PotentialAction { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<O365ConnectorCardActionBase> PotentialAction { get; private set; } = new List<O365ConnectorCardActionBase>();
 
         /// <summary>
         /// An initialization method that performs custom operations like setting defaults.

--- a/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardActionCard.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardActionCard.cs
@@ -39,31 +39,27 @@ namespace Microsoft.Bot.Schema.Teams
         public O365ConnectorCardActionCard(string type = default, string name = default, string id = default, IList<O365ConnectorCardInputBase> inputs = default, IList<O365ConnectorCardActionBase> actions = default)
             : base(type, name, id)
         {
-            Inputs = inputs;
-            Actions = actions;
+            Inputs = inputs ?? new List<O365ConnectorCardInputBase>();
+            Actions = actions ?? new List<O365ConnectorCardActionBase>();
             CustomInit();
         }
 
         /// <summary>
-        /// Gets or sets set of inputs contained in this ActionCard whose each
+        /// Gets set of inputs contained in this ActionCard whose each
         /// item can be in any subtype of O365ConnectorCardInputBase.
         /// </summary>
         /// <value>The inputs contained in the ActionCard.</value>
         [JsonProperty(PropertyName = "inputs")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<O365ConnectorCardInputBase> Inputs { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<O365ConnectorCardInputBase> Inputs { get; private set; } = new List<O365ConnectorCardInputBase>();
 
         /// <summary>
-        /// Gets or sets set of actions contained in this ActionCard whose each
+        /// Gets set of actions contained in this ActionCard whose each
         /// item can be in any subtype of O365ConnectorCardActionBase except
         /// O365ConnectorCardActionCard, as nested ActionCard is forbidden.
         /// </summary>
         /// <value>The actions contained in this ActionCard.</value>
         [JsonProperty(PropertyName = "actions")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<O365ConnectorCardActionBase> Actions { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<O365ConnectorCardActionBase> Actions { get; private set; } = new List<O365ConnectorCardActionBase>();
 
         /// <summary>
         /// An initialization method that performs custom operations like setting defaults.

--- a/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardMultichoiceInput.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardMultichoiceInput.cs
@@ -34,21 +34,19 @@ namespace Microsoft.Bot.Schema.Teams
         public O365ConnectorCardMultichoiceInput(string type = default, string id = default, bool? isRequired = default, string title = default, string value = default, IList<O365ConnectorCardMultichoiceInputChoice> choices = default, string style = default, bool? isMultiSelect = default)
             : base(type, id, isRequired, title, value)
         {
-            Choices = choices;
+            Choices = choices ?? new List<O365ConnectorCardMultichoiceInputChoice>();
             Style = style;
             IsMultiSelect = isMultiSelect;
             CustomInit();
         }
 
         /// <summary>
-        /// Gets or sets set of choices whose each item can be in any subtype
+        /// Gets set of choices whose each item can be in any subtype
         /// of O365ConnectorCardMultichoiceInputChoice.
         /// </summary>
         /// <value>The choices.</value>
         [JsonProperty(PropertyName = "choices")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<O365ConnectorCardMultichoiceInputChoice> Choices { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<O365ConnectorCardMultichoiceInputChoice> Choices { get; private set; } = new List<O365ConnectorCardMultichoiceInputChoice>();
 
         /// <summary>
         /// Gets or sets choice item rendering style. Default value is

--- a/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardOpenUri.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardOpenUri.cs
@@ -31,18 +31,16 @@ namespace Microsoft.Bot.Schema.Teams
         public O365ConnectorCardOpenUri(string type = default, string name = default, string id = default, IList<O365ConnectorCardOpenUriTarget> targets = default)
             : base(type, name, id)
         {
-            Targets = targets;
+            Targets = targets ?? new List<O365ConnectorCardOpenUriTarget>();
             CustomInit();
         }
 
         /// <summary>
-        /// Gets or sets target OS/URLs.
+        /// Gets target OS/URLs.
         /// </summary>
         /// <value>The target OS/URLs.</value>
         [JsonProperty(PropertyName = "targets")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<O365ConnectorCardOpenUriTarget> Targets { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<O365ConnectorCardOpenUriTarget> Targets { get; private set; } = new List<O365ConnectorCardOpenUriTarget>();
 
         /// <summary>
         /// An initialization method that performs custom operations like setting defaults.

--- a/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardSection.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardSection.cs
@@ -43,9 +43,9 @@ namespace Microsoft.Bot.Schema.Teams
             ActivityImage = activityImage;
             ActivityImageType = activityImageType;
             Markdown = markdown;
-            Facts = facts;
-            Images = images;
-            PotentialAction = potentialAction;
+            Facts = facts ?? new List<O365ConnectorCardFact>();
+            Images = images ?? new List<O365ConnectorCardImage>();
+            PotentialAction = potentialAction ?? new List<O365ConnectorCardActionBase>();
             CustomInit();
         }
 
@@ -108,31 +108,25 @@ namespace Microsoft.Bot.Schema.Teams
         public bool? Markdown { get; set; }
 
         /// <summary>
-        /// Gets or sets set of facts for the current section.
+        /// Gets set of facts for the current section.
         /// </summary>
         /// <value>The facts for the current section.</value>
         [JsonProperty(PropertyName = "facts")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<O365ConnectorCardFact> Facts { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<O365ConnectorCardFact> Facts { get; private set; } = new List<O365ConnectorCardFact>();
 
         /// <summary>
-        /// Gets or sets set of images for the current section.
+        /// Gets set of images for the current section.
         /// </summary>
         /// <value>The images for the current section.</value>
         [JsonProperty(PropertyName = "images")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<O365ConnectorCardImage> Images { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<O365ConnectorCardImage> Images { get; private set; } = new List<O365ConnectorCardImage>();
 
         /// <summary>
-        /// Gets or sets set of actions for the current section.
+        /// Gets set of actions for the current section.
         /// </summary>
         /// <value>The actions for the current section.</value>
         [JsonProperty(PropertyName = "potentialAction")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<O365ConnectorCardActionBase> PotentialAction { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<O365ConnectorCardActionBase> PotentialAction { get; private set; } = new List<O365ConnectorCardActionBase>();
 
         /// <summary>
         /// An initialization method that performs custom operations like setting defaults.

--- a/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardViewAction.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardViewAction.cs
@@ -30,18 +30,16 @@ namespace Microsoft.Bot.Schema.Teams
         public O365ConnectorCardViewAction(string type = default, string name = default, string id = default, IList<string> target = default)
             : base(type, name, id)
         {
-            Target = target;
+            Target = target ?? new List<string>();
             CustomInit();
         }
 
         /// <summary>
-        /// Gets or sets target urls, only the first url effective for card button.
+        /// Gets target urls, only the first url effective for card button.
         /// </summary>
         /// <value>The target URLs.</value>
         [JsonProperty(PropertyName = "target")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<string> Target { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<string> Target { get; private set; } = new List<string>();
 
         /// <summary>
         /// An initialization method that performs custom operations like setting defaults.

--- a/libraries/Microsoft.Bot.Schema/Teams/TabResponseCards.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TabResponseCards.cs
@@ -20,15 +20,13 @@ namespace Microsoft.Bot.Schema.Teams
         }
 
         /// <summary>
-        /// Gets or sets adaptive cards for this card tab response.
+        /// Gets adaptive cards for this card tab response.
         /// </summary>
         /// <value>
         /// Cards for this <see cref="TabResponse"/>.
         /// </value>
         [JsonProperty(PropertyName = "cards")]
-#pragma warning disable CA2227 // Collection properties should be read only
-        public IList<TabResponseCard> Cards { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<TabResponseCard> Cards { get; private set; } = new List<TabResponseCard>();
 
         /// <summary>
         /// An initialization method that performs custom operations like setting defaults.

--- a/libraries/Microsoft.Bot.Schema/Teams/TabSubmitData.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TabSubmitData.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Bot.Schema.Teams
         public string Type { get; set; }
 
         /// <summary>
-        /// Gets or sets properties that are not otherwise defined by the <see cref="TabSubmit"/> type but that
+        /// Gets properties that are not otherwise defined by the <see cref="TabSubmit"/> type but that
         /// might appear in the serialized REST JSON object.
         /// </summary>
         /// <value>The extended properties for the object.</value>
@@ -37,9 +37,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// the JSON object is deserialized, but are instead stored in this property. Such properties
         /// will be written to a JSON object when the instance is serialized.</remarks>
         [JsonExtensionData(ReadData = true, WriteData = true)]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
-        public JObject Properties { get; set; } = new JObject();
-#pragma warning restore CA2227 // Collection properties should be read only
+        public JObject Properties { get; private set; } = new JObject();
 
         /// <summary>
         /// An initialization method that performs custom operations like setting defaults.

--- a/libraries/Microsoft.Bot.Schema/Teams/TabSuggestedActions.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TabSuggestedActions.cs
@@ -20,15 +20,13 @@ namespace Microsoft.Bot.Schema.Teams
         }
 
         /// <summary>
-        /// Gets or sets actions for a card tab response.
+        /// Gets actions for a card tab response.
         /// </summary>
         /// <value>
         /// Actions for this <see cref="TabSuggestedActions"/>.
         /// </value>
         [JsonProperty(PropertyName = "actions")]
-#pragma warning disable CA2227 // Collection properties should be read only
-        public IList<CardAction> Actions { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<CardAction> Actions { get; private set; } = new List<CardAction>();
 
         /// <summary>
         /// An initialization method that performs custom operations like setting defaults.

--- a/libraries/Microsoft.Bot.Schema/Teams/TeamsPagedMembersResult.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TeamsPagedMembersResult.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Bot.Schema.Teams
         {
             ContinuationToken = continuationToken;
             var teamsChannelAccounts = members.Select(channelAccount => JObject.FromObject(channelAccount).ToObject<TeamsChannelAccount>());
-            Members = teamsChannelAccounts.ToList() ?? new List<TeamsChannelAccount>();
+            Members = teamsChannelAccounts?.ToList() ?? new List<TeamsChannelAccount>();
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Schema/Teams/TeamsPagedMembersResult.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TeamsPagedMembersResult.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Bot.Schema.Teams
         {
             ContinuationToken = continuationToken;
             var teamsChannelAccounts = members.Select(channelAccount => JObject.FromObject(channelAccount).ToObject<TeamsChannelAccount>());
-            Members = teamsChannelAccounts.ToList();
+            Members = teamsChannelAccounts.ToList() ?? new List<TeamsChannelAccount>();
         }
 
         /// <summary>
@@ -43,14 +43,12 @@ namespace Microsoft.Bot.Schema.Teams
         public string ContinuationToken { get; set; }
 
         /// <summary>
-        /// Gets or sets the list of channel accounts.
+        /// Gets the list of channel accounts.
         /// </summary>
         /// <value>
         /// The channel accounts.
         /// </value>
         [JsonProperty(PropertyName = "members")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
-        public IList<TeamsChannelAccount> Members { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<TeamsChannelAccount> Members { get; private set; } = new List<TeamsChannelAccount>();
     }
 }

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/MessageActionsPayloadTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/MessageActionsPayloadTests.cs
@@ -52,9 +52,9 @@ namespace Microsoft.Bot.Schema.Tests.Teams
             Assert.Equal(default, messageActionPayload.From);
             Assert.Equal(default, messageActionPayload.Body);
             Assert.Equal(default, messageActionPayload.AttachmentLayout);
-            Assert.Equal(default, messageActionPayload.Attachments);
-            Assert.Equal(default, messageActionPayload.Mentions);
-            Assert.Equal(default, messageActionPayload.Reactions);
+            Assert.Equal(new List<MessageActionsPayloadAttachment>(), messageActionPayload.Attachments);
+            Assert.Equal(new List<MessageActionsPayloadMention>(), messageActionPayload.Mentions);
+            Assert.Equal(new List<MessageActionsPayloadReaction>(), messageActionPayload.Reactions);
         }
 
         /// <summary>
@@ -118,7 +118,7 @@ namespace Microsoft.Bot.Schema.Tests.Teams
         /// <returns>A MessageActionsPayload set with testing values.</returns>
         private MessageActionsPayload CreateActionPayload()
         {
-            return new MessageActionsPayload
+            return new MessageActionsPayload(attachments: _attachments, mentions: _mentions, reactions: _reactions)
             {
                 Id = _id,
                 ReplyToId = _replyId,
@@ -133,9 +133,6 @@ namespace Microsoft.Bot.Schema.Tests.Teams
                 From = _from,
                 Body = _body,
                 AttachmentLayout = _attachmentLayout,
-                Attachments = _attachments,
-                Mentions = _mentions,
-                Reactions = _reactions,
                 LinkToMessage = _linkToMessage
             };
         }

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TabResponseCardsTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TabResponseCardsTests.cs
@@ -14,10 +14,8 @@ namespace Microsoft.Bot.Schema.Tests.Teams
         [ClassData(typeof(TabResponseCardsTestData))]
         public void TabResponseCardsInits(IList<TabResponseCard> cards)
         {
-            var responseCards = new TabResponseCards()
-            {
-                Cards = cards
-            };
+            var responseCards = new TabResponseCards();
+            ((List<TabResponseCard>)responseCards.Cards).AddRange(cards);
 
             Assert.NotNull(responseCards);
             Assert.IsType<TabResponseCards>(responseCards);

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TabSubmitDataTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TabSubmitDataTests.cs
@@ -16,9 +16,9 @@ namespace Microsoft.Bot.Schema.Tests.Teams
         {
             var submitData = new TabSubmitData()
             {
-                Type = tabType,
-                Properties = properties
+                Type = tabType
             };
+            submitData.Properties.Merge(properties);
 
             Assert.NotNull(submitData);
             Assert.IsType<TabSubmitData>(submitData);

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TabSuggestedActionsTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TabSuggestedActionsTests.cs
@@ -14,10 +14,8 @@ namespace Microsoft.Bot.Schema.Tests.Teams
         [ClassData(typeof(TabSuggestedActionsTestData))]
         public void TabSuggestedActionsInits(IList<CardAction> actions)
         {
-            var suggestedActions = new TabSuggestedActions()
-            {
-                Actions = actions
-            };
+            var suggestedActions = new TabSuggestedActions();
+            ((List<CardAction>)suggestedActions.Actions).AddRange(actions);
 
             Assert.NotNull(suggestedActions);
             Assert.IsType<TabSuggestedActions>(suggestedActions);

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TabsTestData.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TabsTestData.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Bot.Schema.Tests.Teams
         {
             public IEnumerator<object[]> GetEnumerator()
             {
-                yield return new object[] { null };
+                yield return new object[] { new List<TabResponseCard>() };
                 yield return new object[]
                 {
                     new List<TabResponseCard>()
@@ -111,7 +111,7 @@ namespace Microsoft.Bot.Schema.Tests.Teams
             public IEnumerator<object[]> GetEnumerator()
             {
                 // string tabType, JObject properties
-                yield return new object[] { null, null };
+                yield return new object[] { null, new JObject() };
                 yield return new object[]
                 {
                     "pdf",
@@ -126,7 +126,7 @@ namespace Microsoft.Bot.Schema.Tests.Teams
         {
             public IEnumerator<object[]> GetEnumerator()
             {
-                yield return new object[] { null };
+                yield return new object[] { new List<CardAction>() };
                 yield return new object[]
                 { 
                     new List<CardAction>()


### PR DESCRIPTION
Addresses # 6099
#minor

## Description
This PR removes the exclusions of the FxCop rule [CA2227](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2227) (Collection properties must be read-only) in **Bot.Schema/Teams** classes.

### Detailed Changes
- Updated Collection properties (Dictionary, List, JObject)' accessor from `set` to `private set`.
- Initialized collection properties with empty collections.
- Replaced direct set of the properties with calls to the Collections' methods _Add(), AddRange(), Merge()_, and _Clear()_ depending on the case.
- The following properties were updated:
   - Microsoft.Bot.Schema/Teams/ConversationList: Conversations.
   - Microsoft.Bot.Schema/Teams/MessageActionsPayload: Attachments, Mentions, and Reactions.
   - Microsoft.Bot.Schema/Teams/MessagingExtensionAction: BotActivityPreview.
   - Microsoft.Bot.Schema/Teams/MessagingExtensionQuery: Parameters.
   - Microsoft.Bot.Schema/Teams/MessagingExtensionResult: Attachments.
   - Microsoft.Bot.Schema/Teams/MessagingExtensionSuggestedAction: Actions.
   - Microsoft.Bot.Schema/Teams/O365ConnectorCard: Sections, PotentialAction.
   - Microsoft.Bot.Schema/Teams/O365ConnectorCardActionCard: Inputs, Actions.
   - Microsoft.Bot.Schema/Teams/O365ConnectorCardMultichoiceInput: Choices.
   - Microsoft.Bot.Schema/Teams/O365ConnectorCardOpenUri: Targets.
   - Microsoft.Bot.Schema/Teams/O365ConnectorCardSection: Facts, Images, and PotentialAction.
   - Microsoft.Bot.Schema/Teams/O365ConnectorCardViewAction: Target.
   - Microsoft.Bot.Schema/Teams/TabResponseCards: Cards.
   - Microsoft.Bot.Schema/Teams/TabSubmitData: Properties.
   - Microsoft.Bot.Schema/Teams/TabSuggestedActions: Actions
   - Microsoft.Bot.Schema/Teams/TeamsPagedMembersResult: Members.

## Testing
This image shows the tests passing after the changes.
![image](https://user-images.githubusercontent.com/44245136/154278898-76dbcfed-be0e-4e1b-b7d2-7f01a2fc1dcc.png)
