### PR TITLE
[#6099] Remove low impact FxCop exclusions - Rule CA2227 (Part 7/8)

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
@@ -105,11 +105,6 @@ namespace Microsoft.Bot.Builder.Dialogs
             // Ensure prompt initialized
             prompt ??= Activity.CreateMessageActivity();
 
-            if (prompt.Attachments == null)
-            {
-                prompt.Attachments = new List<Attachment>();
-            }
-
             // Append appropriate card if missing
             if (!ChannelSupportsOAuthCard(turnContext.Activity.ChannelId))
             {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
@@ -323,16 +323,9 @@ namespace Microsoft.Bot.Builder.Dialogs
                     prompt.SuggestedActions = msg.SuggestedActions;
                 }
 
-                if (msg.Attachments != null && msg.Attachments.Any())
+                if (msg.Attachments?.Count > 0)
                 {
-                    if (prompt.Attachments == null)
-                    {
-                        prompt.Attachments = msg.Attachments;
-                    }
-                    else
-                    {
-                        prompt.Attachments = prompt.Attachments.Concat(msg.Attachments).ToList();
-                    }
+                    ((List<Attachment>)prompt.Attachments).AddRange(msg.Attachments);
                 }
 
                 return prompt;

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
@@ -323,7 +323,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                     prompt.SuggestedActions = msg.SuggestedActions;
                 }
 
-                if (msg.Attachments?.Count > 0)
+                if (msg.Attachments.Any())
                 {
                     ((List<Attachment>)prompt.Attachments).AddRange(msg.Attachments);
                 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/SkillDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/SkillDialog.cs
@@ -177,7 +177,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                 // Apply conversation reference and common properties from incoming activity before sending.
                 activity.ApplyConversationReference(turnContext.Activity.GetConversationReference(), true);
                 activity.ChannelData = turnContext.Activity.ChannelData;
-                activity.Properties = turnContext.Activity.Properties;
+                activity.Properties.Merge(turnContext.Activity.Properties);
 
                 var skillConversationId = (string)instance.State[SkillConversationIdStateKey];
 
@@ -249,7 +249,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             }
 
             Activity eocActivity = null;
-            if (activity.DeliveryMode == DeliveryModes.ExpectReplies && response.Body.Activities != null && response.Body.Activities.Any())
+            if (activity.DeliveryMode == DeliveryModes.ExpectReplies && response.Body.Activities.Any())
             {
                 // Track sent invoke responses, so more than one is not sent.
                 bool sentInvokeResponse = false;

--- a/libraries/Microsoft.Bot.Builder/ActivityHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/ActivityHandler.cs
@@ -179,14 +179,14 @@ namespace Microsoft.Bot.Builder
         /// <seealso cref="OnMembersRemovedAsync(IList{ChannelAccount}, ITurnContext{IConversationUpdateActivity}, CancellationToken)"/>
         protected virtual Task OnConversationUpdateActivityAsync(ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
         {
-            if (turnContext.Activity.MembersAdded != null)
+            if (turnContext.Activity.MembersAdded?.Count > 0)
             {
                 if (turnContext.Activity.MembersAdded.Any(m => m.Id != turnContext.Activity.Recipient?.Id))
                 {
                     return OnMembersAddedAsync(turnContext.Activity.MembersAdded, turnContext, cancellationToken);
                 }
             }
-            else if (turnContext.Activity.MembersRemoved != null)
+            else if (turnContext.Activity.MembersRemoved?.Count > 0)
             {
                 if (turnContext.Activity.MembersRemoved.Any(m => m.Id != turnContext.Activity.Recipient?.Id))
                 {
@@ -273,18 +273,18 @@ namespace Microsoft.Bot.Builder
         /// <seealso cref="OnReactionsChangedAsync(IList{MessageReaction}, IList{MessageReaction}, ITurnContext{IMessageReactionActivity}, CancellationToken)"/>
         protected virtual async Task OnMessageReactionActivityAsync(ITurnContext<IMessageReactionActivity> turnContext, CancellationToken cancellationToken)
         {
-            if (turnContext.Activity.ReactionsRemoved != null && turnContext.Activity.ReactionsAdded != null)
+            if (turnContext.Activity.ReactionsRemoved?.Count > 0 && turnContext.Activity.ReactionsAdded?.Count > 0)
             {
                 await OnReactionsChangedAsync(turnContext.Activity.ReactionsAdded, turnContext.Activity.ReactionsRemoved, turnContext, cancellationToken).ConfigureAwait(false);
             }
             else
             {
-                if (turnContext.Activity.ReactionsAdded != null)
+                if (turnContext.Activity.ReactionsAdded?.Count > 0)
                 {
                     await OnReactionsAddedAsync(turnContext.Activity.ReactionsAdded, turnContext, cancellationToken).ConfigureAwait(false);
                 }
 
-                if (turnContext.Activity.ReactionsRemoved != null)
+                if (turnContext.Activity.ReactionsRemoved?.Count > 0)
                 {
                     await OnReactionsRemovedAsync(turnContext.Activity.ReactionsRemoved, turnContext, cancellationToken).ConfigureAwait(false);
                 }

--- a/libraries/Microsoft.Bot.Builder/ActivityHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/ActivityHandler.cs
@@ -179,14 +179,14 @@ namespace Microsoft.Bot.Builder
         /// <seealso cref="OnMembersRemovedAsync(IList{ChannelAccount}, ITurnContext{IConversationUpdateActivity}, CancellationToken)"/>
         protected virtual Task OnConversationUpdateActivityAsync(ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
         {
-            if (turnContext.Activity.MembersAdded?.Count > 0)
+            if (turnContext.Activity.MembersAdded.Any())
             {
                 if (turnContext.Activity.MembersAdded.Any(m => m.Id != turnContext.Activity.Recipient?.Id))
                 {
                     return OnMembersAddedAsync(turnContext.Activity.MembersAdded, turnContext, cancellationToken);
                 }
             }
-            else if (turnContext.Activity.MembersRemoved?.Count > 0)
+            else if (turnContext.Activity.MembersRemoved.Any())
             {
                 if (turnContext.Activity.MembersRemoved.Any(m => m.Id != turnContext.Activity.Recipient?.Id))
                 {
@@ -273,18 +273,18 @@ namespace Microsoft.Bot.Builder
         /// <seealso cref="OnReactionsChangedAsync(IList{MessageReaction}, IList{MessageReaction}, ITurnContext{IMessageReactionActivity}, CancellationToken)"/>
         protected virtual async Task OnMessageReactionActivityAsync(ITurnContext<IMessageReactionActivity> turnContext, CancellationToken cancellationToken)
         {
-            if (turnContext.Activity.ReactionsRemoved?.Count > 0 && turnContext.Activity.ReactionsAdded?.Count > 0)
+            if (turnContext.Activity.ReactionsRemoved.Any() && turnContext.Activity.ReactionsAdded.Any())
             {
                 await OnReactionsChangedAsync(turnContext.Activity.ReactionsAdded, turnContext.Activity.ReactionsRemoved, turnContext, cancellationToken).ConfigureAwait(false);
             }
             else
             {
-                if (turnContext.Activity.ReactionsAdded?.Count > 0)
+                if (turnContext.Activity.ReactionsAdded.Any())
                 {
                     await OnReactionsAddedAsync(turnContext.Activity.ReactionsAdded, turnContext, cancellationToken).ConfigureAwait(false);
                 }
 
-                if (turnContext.Activity.ReactionsRemoved?.Count > 0)
+                if (turnContext.Activity.ReactionsRemoved.Any())
                 {
                     await OnReactionsRemovedAsync(turnContext.Activity.ReactionsRemoved, turnContext, cancellationToken).ConfigureAwait(false);
                 }

--- a/libraries/Microsoft.Bot.Builder/EventFactory.cs
+++ b/libraries/Microsoft.Bot.Builder/EventFactory.cs
@@ -84,8 +84,6 @@ namespace Microsoft.Bot.Builder
             handoffEvent.Id = Guid.NewGuid().ToString();
             handoffEvent.Timestamp = DateTime.UtcNow;
             handoffEvent.Conversation = conversation;
-            handoffEvent.Attachments = new List<Attachment>();
-            handoffEvent.Entities = new List<Entity>();
             return handoffEvent;
         }
     }

--- a/libraries/Microsoft.Bot.Builder/MessageFactory.cs
+++ b/libraries/Microsoft.Bot.Builder/MessageFactory.cs
@@ -310,7 +310,7 @@ namespace Microsoft.Bot.Builder
         {
             var ma = Activity.CreateMessageActivity();
             ma.AttachmentLayout = attachmentLayout;
-            ma.Attachments = attachments.ToList();
+            ((List<Attachment>)ma.Attachments).AddRange(attachments.ToList());
             SetTextAndSpeak(ma, text, ssml, inputHint);
             return ma;
         }

--- a/libraries/Microsoft.Bot.Builder/NormalizeMentionsMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/NormalizeMentionsMiddleware.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -64,11 +65,14 @@ namespace Microsoft.Bot.Builder
                     // strip recipient mention tags and text.
                     activity.RemoveRecipientMention();
 
-                    if (activity.Entities != null)
+                    if (activity.Entities?.Count > 0)
                     {
                         // strip entity.mention records for recipient id.
-                        activity.Entities = activity.Entities.Where(entity => entity.Type == "mention" &&
+                        var filteredEntities = activity.Entities.Where(entity => entity.Type == "mention" &&
                            ((dynamic)entity.Properties["mentioned"]).id != activity.Recipient.Id).ToList();
+
+                        activity.Entities.Clear();
+                        ((List<Entity>)activity.Entities).AddRange(filteredEntities);
                     }
                 }
 

--- a/libraries/Microsoft.Bot.Builder/NormalizeMentionsMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/NormalizeMentionsMiddleware.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Bot.Builder
                     // strip recipient mention tags and text.
                     activity.RemoveRecipientMention();
 
-                    if (activity.Entities?.Count > 0)
+                    if (activity.Entities.Any())
                     {
                         // strip entity.mention records for recipient id.
                         var filteredEntities = activity.Entities.Where(entity => entity.Type == "mention" &&

--- a/libraries/Microsoft.Bot.Builder/Skills/CloudSkillHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/Skills/CloudSkillHandler.cs
@@ -106,11 +106,13 @@ namespace Microsoft.Bot.Builder.Skills
             // we need to swap the values back to the ones received from the skill so the bot gets the actual activity.
             turnContext.Activity.ChannelData = activity.ChannelData;
             turnContext.Activity.Code = activity.Code;
-            turnContext.Activity.Entities = activity.Entities;
+            turnContext.Activity.Entities.Clear();
+            ((List<Entity>)turnContext.Activity.Entities).AddRange(activity.Entities);
             turnContext.Activity.Locale = activity.Locale;
             turnContext.Activity.LocalTimestamp = activity.LocalTimestamp;
             turnContext.Activity.Name = activity.Name;
-            turnContext.Activity.Properties = activity.Properties;
+            turnContext.Activity.Properties.RemoveAll();
+            turnContext.Activity.Properties.Merge(activity.Properties);
             turnContext.Activity.RelatesTo = activity.RelatesTo;
             turnContext.Activity.ReplyToId = activity.ReplyToId;
             turnContext.Activity.Timestamp = activity.Timestamp;

--- a/libraries/Microsoft.Bot.Builder/Streaming/StreamingRequestHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/Streaming/StreamingRequestHandler.cs
@@ -220,14 +220,7 @@ namespace Microsoft.Bot.Builder.Streaming
                         streamAttachments.Add(new Attachment() { ContentType = request.Streams[i].ContentType, Content = request.Streams[i].Stream });
                     }
 
-                    if (activity.Attachments != null)
-                    {
-                        activity.Attachments = activity.Attachments.Concat(streamAttachments).ToArray();
-                    }
-                    else
-                    {
-                        activity.Attachments = streamAttachments.ToArray();
-                    }
+                    ((List<Attachment>)activity.Attachments).AddRange(streamAttachments.ToArray());
                 }
 
                 // Populate Activity.CallerId given the Audience value.
@@ -418,7 +411,10 @@ namespace Microsoft.Bot.Builder.Streaming
             var streamAttachments = activity.Attachments.Where(a => a.Content is Stream);
             if (streamAttachments.Any())
             {
-                activity.Attachments = activity.Attachments.Where(a => !(a.Content is Stream)).ToList();
+                var filteredAttachments = activity.Attachments.Where(a => !(a.Content is Stream)).ToList();
+                activity.Attachments.Clear();
+                ((List<Attachment>)activity.Attachments).AddRange(filteredAttachments);
+
                 return streamAttachments.Select(streamAttachment =>
                 {
                     var streamContent = new StreamContent(streamAttachment.Content as Stream);

--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityHandler.cs
@@ -433,12 +433,12 @@ namespace Microsoft.Bot.Builder.Teams
             {
                 var channelData = turnContext.Activity.GetChannelData<TeamsChannelData>();
 
-                if (turnContext.Activity.MembersAdded != null)
+                if (turnContext.Activity.MembersAdded?.Count > 0)
                 {
                     return OnTeamsMembersAddedDispatchAsync(turnContext.Activity.MembersAdded, channelData?.Team, turnContext, cancellationToken);
                 }
 
-                if (turnContext.Activity.MembersRemoved != null)
+                if (turnContext.Activity.MembersRemoved?.Count > 0)
                 {
                     return OnTeamsMembersRemovedDispatchAsync(turnContext.Activity.MembersRemoved, channelData?.Team, turnContext, cancellationToken);
                 }

--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityHandler.cs
@@ -433,12 +433,12 @@ namespace Microsoft.Bot.Builder.Teams
             {
                 var channelData = turnContext.Activity.GetChannelData<TeamsChannelData>();
 
-                if (turnContext.Activity.MembersAdded?.Count > 0)
+                if (turnContext.Activity.MembersAdded.Any())
                 {
                     return OnTeamsMembersAddedDispatchAsync(turnContext.Activity.MembersAdded, channelData?.Team, turnContext, cancellationToken);
                 }
 
-                if (turnContext.Activity.MembersRemoved?.Count > 0)
+                if (turnContext.Activity.MembersRemoved.Any())
                 {
                     return OnTeamsMembersRemovedDispatchAsync(turnContext.Activity.MembersRemoved, channelData?.Team, turnContext, cancellationToken);
                 }

--- a/libraries/Microsoft.Bot.Schema/Activity.cs
+++ b/libraries/Microsoft.Bot.Schema/Activity.cs
@@ -135,10 +135,10 @@ namespace Microsoft.Bot.Schema
             Recipient = recipient;
             TextFormat = textFormat;
             AttachmentLayout = attachmentLayout;
-            MembersAdded = membersAdded;
-            MembersRemoved = membersRemoved;
-            ReactionsAdded = reactionsAdded;
-            ReactionsRemoved = reactionsRemoved;
+            MembersAdded = membersAdded ?? new List<ChannelAccount>();
+            MembersRemoved = membersRemoved ?? new List<ChannelAccount>();
+            ReactionsAdded = reactionsAdded ?? new List<MessageReaction>();
+            ReactionsRemoved = reactionsRemoved ?? new List<MessageReaction>();
             TopicName = topicName;
             HistoryDisclosed = historyDisclosed;
             Locale = locale;
@@ -147,8 +147,8 @@ namespace Microsoft.Bot.Schema
             InputHint = inputHint;
             Summary = summary;
             SuggestedActions = suggestedActions;
-            Attachments = attachments;
-            Entities = entities;
+            Attachments = attachments ?? new List<Attachment>();
+            Entities = entities ?? new List<Entity>();
             ChannelData = channelData;
             Action = action;
             ReplyToId = replyToId;
@@ -161,8 +161,8 @@ namespace Microsoft.Bot.Schema
             Expiration = expiration;
             Importance = importance;
             DeliveryMode = deliveryMode;
-            ListenFor = listenFor;
-            TextHighlights = textHighlights;
+            ListenFor = listenFor ?? new List<string>();
+            TextHighlights = textHighlights ?? new List<TextHighlight>();
             SemanticAction = semanticAction;
             CustomInit();
         }
@@ -291,50 +291,42 @@ namespace Microsoft.Bot.Schema
         public string AttachmentLayout { get; set; }
 
         /// <summary>
-        /// Gets or sets the collection of members added to the conversation.
+        /// Gets the collection of members added to the conversation.
         /// </summary>
         /// <value>
         /// The collection of members added to the conversation.
         /// </value>
         [JsonProperty(PropertyName = "membersAdded")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
-        public IList<ChannelAccount> MembersAdded { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<ChannelAccount> MembersAdded { get; private set; } = new List<ChannelAccount>();
 
         /// <summary>
-        /// Gets or sets the collection of members removed from the
+        /// Gets the collection of members removed from the
         /// conversation.
         /// </summary>
         /// <value>
         /// The collection of members removed from the conversation.
         /// </value>
         [JsonProperty(PropertyName = "membersRemoved")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
-        public IList<ChannelAccount> MembersRemoved { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<ChannelAccount> MembersRemoved { get; private set; } = new List<ChannelAccount>();
 
         /// <summary>
-        /// Gets or sets the collection of reactions added to the conversation.
+        /// Gets the collection of reactions added to the conversation.
         /// </summary>
         /// <value>
         /// The collection of reactions added to the conversation.
         /// </value>
         [JsonProperty(PropertyName = "reactionsAdded")]
-#pragma warning disable CA2227 // Collection properties should be read only  (we can't change this without breaking binary compat)
-        public IList<MessageReaction> ReactionsAdded { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<MessageReaction> ReactionsAdded { get; private set; } = new List<MessageReaction>();
 
         /// <summary>
-        /// Gets or sets the collection of reactions removed from the
+        /// Gets the collection of reactions removed from the
         /// conversation.
         /// </summary>
         /// <value>
         /// The collection of reactions removed from the conversation.
         /// </value>
         [JsonProperty(PropertyName = "reactionsRemoved")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
-        public IList<MessageReaction> ReactionsRemoved { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<MessageReaction> ReactionsRemoved { get; private set; } = new List<MessageReaction>();
 
         /// <summary>
         /// Gets or sets the updated topic name of the conversation.
@@ -415,26 +407,22 @@ namespace Microsoft.Bot.Schema
         public SuggestedActions SuggestedActions { get; set; }
 
         /// <summary>
-        /// Gets or sets the attachments for the activity.
+        /// Gets the attachments for the activity.
         /// </summary>
         /// <value>
         /// The attachments for the activity.
         /// </value>
         [JsonProperty(PropertyName = "attachments")]
-#pragma warning disable CA2227 // Collection properties should be read only  (we can't change this without breaking binary compat)
-        public IList<Attachment> Attachments { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<Attachment> Attachments { get; private set; } = new List<Attachment>();
 
         /// <summary>
-        /// Gets or sets the entities that were mentioned in the message.
+        /// Gets the entities that were mentioned in the message.
         /// </summary>
         /// <value>
         /// The entities that were mentioned in the message.
         /// </value>
         [JsonProperty(PropertyName = "entities")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
-        public IList<Entity> Entities { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<Entity> Entities { get; private set; } = new List<Entity>();
 
         /// <summary>
         /// Gets or sets channel-specific content.
@@ -561,19 +549,17 @@ namespace Microsoft.Bot.Schema
         public string DeliveryMode { get; set; }
 
         /// <summary>
-        /// Gets or sets list of phrases and references that speech and
+        /// Gets list of phrases and references that speech and
         /// language-priming systems should listen for.
         /// </summary>
         /// <value>
         /// List of phrases and references that speech and language-priming systems should listen for.
         /// </value>
         [JsonProperty(PropertyName = "listenFor")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
-        public IList<string> ListenFor { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<string> ListenFor { get; private set; } = new List<string>();
 
         /// <summary>
-        /// Gets or sets the collection of text fragments to highlight when the
+        /// Gets the collection of text fragments to highlight when the
         /// activity contains a ReplyToId value.
         /// </summary>
         /// <value>
@@ -581,9 +567,7 @@ namespace Microsoft.Bot.Schema
         /// activity contains a ReplyToId value.
         /// </value>
         [JsonProperty(PropertyName = "textHighlights")]
-#pragma warning disable CA2227 // Collection properties should be read only  (we can't change this without breaking binary compat)
-        public IList<TextHighlight> TextHighlights { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<TextHighlight> TextHighlights { get; private set; } = new List<TextHighlight>();
 
         /// <summary>
         /// Gets or sets an optional programmatic action accompanying this

--- a/libraries/Microsoft.Bot.Schema/ActivityEx.cs
+++ b/libraries/Microsoft.Bot.Schema/ActivityEx.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Bot.Schema
         public const string ContentType = "application/vnd.microsoft.activity";
 
         /// <summary>
-        /// Gets or sets properties that are not otherwise defined by the <see cref="Activity"/> type but that
+        /// Gets properties that are not otherwise defined by the <see cref="Activity"/> type but that
         /// might appear in the serialized REST JSON object.
         /// </summary>
         /// <value>The extended properties for the object.</value>
@@ -53,9 +53,7 @@ namespace Microsoft.Bot.Schema
         /// the JSON object is deserialized, but are instead stored in this property. Such properties
         /// will be written to a JSON object when the instance is serialized.</remarks>
         [JsonExtensionData(ReadData = true, WriteData = true)]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
-        public JObject Properties { get; set; } = new JObject();
-#pragma warning restore CA2227 // Collection properties should be read only
+        public JObject Properties { get; private set; } = new JObject();
 
         /// <summary>
         /// Creates an instance of the <see cref="Activity"/> class as an <see cref="IMessageActivity"/> object.

--- a/libraries/Microsoft.Bot.Schema/Attachment.cs
+++ b/libraries/Microsoft.Bot.Schema/Attachment.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Bot.Schema
         public string Name { get; set; }
 
         /// <summary>
-        /// Gets or sets properties that are not otherwise defined by the <see cref="Attachment"/> type but that
+        /// Gets properties that are not otherwise defined by the <see cref="Attachment"/> type but that
         /// might appear in the REST JSON object.
         /// </summary>
         /// <value>The extended properties for the object.</value>
@@ -71,9 +71,7 @@ namespace Microsoft.Bot.Schema
         /// the JSON object is deserialized, but are instead stored in this property. Such properties
         /// will be written to a JSON object when the instance is serialized.</remarks>
         [JsonExtensionData(ReadData = true, WriteData = true)]
-#pragma warning disable CA2227 // Collection properties should be read only  (we can't change this without breaking binary compat)
-        public JObject Properties { get; set; } = new JObject();
-#pragma warning restore CA2227 // Collection properties should be read only
+        public JObject Properties { get; private set; } = new JObject();
 
         /// <summary>
         /// Gets or sets (OPTIONAL) Thumbnail associated with attachment.

--- a/libraries/Microsoft.Bot.Schema/AttachmentInfo.cs
+++ b/libraries/Microsoft.Bot.Schema/AttachmentInfo.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Bot.Schema
         {
             Name = name;
             Type = type;
-            Views = views;
+            Views = views ?? new List<AttachmentView>();
             CustomInit();
         }
 
@@ -37,12 +37,10 @@ namespace Microsoft.Bot.Schema
         [JsonProperty(PropertyName = "type")]
         public string Type { get; set; }
 
-        /// <summary>Gets or sets attachment views.</summary>
+        /// <summary>Gets attachment views.</summary>
         /// <value> The attachment views.</value>
         [JsonProperty(PropertyName = "views")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<AttachmentView> Views { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<AttachmentView> Views { get; private set; } = new List<AttachmentView>();
 
         /// <summary>An initialization method that performs custom operations like setting defaults.</summary>
         partial void CustomInit();

--- a/libraries/Microsoft.Bot.Schema/IActivity.cs
+++ b/libraries/Microsoft.Bot.Schema/IActivity.cs
@@ -97,14 +97,12 @@ namespace Microsoft.Bot.Schema
         string ReplyToId { get; set; }
 
         /// <summary>
-        /// Gets or sets collection of Entity objects, each of which contains metadata about this activity. Each Entity object is typed.
+        /// Gets collection of Entity objects, each of which contains metadata about this activity. Each Entity object is typed.
         /// </summary>
         /// <value>
         /// Collection of Entity objects, each of which contains metadata about this activity. Each Entity object is typed.
         /// </value>
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
-        IList<Entity> Entities { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        IList<Entity> Entities { get; }
 
         /// <summary>
         /// Gets or sets channel-specific payload.

--- a/libraries/Microsoft.Bot.Schema/IConversationUpdateActivity.cs
+++ b/libraries/Microsoft.Bot.Schema/IConversationUpdateActivity.cs
@@ -11,20 +11,16 @@ namespace Microsoft.Bot.Schema
     public interface IConversationUpdateActivity : IActivity
     {
         /// <summary>
-        /// Gets or Sets Members added to the conversation.
+        /// Gets Members added to the conversation.
         /// </summary>
         /// <value>List of ChannelAccount.</value>
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
-        IList<ChannelAccount> MembersAdded { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        IList<ChannelAccount> MembersAdded { get; }
 
         /// <summary>
-        /// Gets or Sets Members removed from the conversation.
+        /// Gets Members removed from the conversation.
         /// </summary>
         /// <value>List of ChannelAccount.</value>
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
-        IList<ChannelAccount> MembersRemoved { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        IList<ChannelAccount> MembersRemoved { get; }
 
         /// <summary>
         /// Gets or Sets The conversation's updated topic name.

--- a/libraries/Microsoft.Bot.Schema/IMessageActivity.cs
+++ b/libraries/Microsoft.Bot.Schema/IMessageActivity.cs
@@ -71,14 +71,12 @@ namespace Microsoft.Bot.Schema
         string AttachmentLayout { get; set; }
 
         /// <summary>
-        /// Gets or sets attachments.
+        /// Gets attachments.
         /// </summary>
         /// <value>
         /// Attachments.
         /// </value>
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
-        IList<Attachment> Attachments { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        IList<Attachment> Attachments { get; }
 
         /// <summary>
         /// Gets or sets suggestedActions are used to express actions for interacting with a card like keyboards/quickReplies.

--- a/libraries/Microsoft.Bot.Schema/IMessageReactionActivity.cs
+++ b/libraries/Microsoft.Bot.Schema/IMessageReactionActivity.cs
@@ -11,23 +11,19 @@ namespace Microsoft.Bot.Schema
     public interface IMessageReactionActivity : IActivity
     {
         /// <summary>
-        /// Gets or sets reactions added to the activity.
+        /// Gets reactions added to the activity.
         /// </summary>
         /// <value>
         /// Reactions added to the activity.
         /// </value>
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
-        IList<MessageReaction> ReactionsAdded { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        IList<MessageReaction> ReactionsAdded { get; }
 
         /// <summary>
-        /// Gets or sets reactions removed from the activity.
+        /// Gets reactions removed from the activity.
         /// </summary>
         /// <value>
         /// Reactions removed from the activity.
         /// </value>
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
-        IList<MessageReaction> ReactionsRemoved { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        IList<MessageReaction> ReactionsRemoved { get; }
     }
 }

--- a/libraries/Microsoft.Bot.Schema/ISuggestionActivity.cs
+++ b/libraries/Microsoft.Bot.Schema/ISuggestionActivity.cs
@@ -15,11 +15,9 @@ namespace Microsoft.Bot.Schema
     public interface ISuggestionActivity : IMessageActivity
     {
         /// <summary>
-        /// Gets or Sets Indicates the sections of text in the referenced message to highlight.
+        /// Gets Indicates the sections of text in the referenced message to highlight.
         /// </summary>
         /// <value>TextHighlights.</value>
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
-        IList<TextHighlight> TextHighlights { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        IList<TextHighlight> TextHighlights { get; }
     }
 }

--- a/testbots/Microsoft.Bot.Builder.TestBot.Shared/Bots/DialogAndWelcomeBot.cs
+++ b/testbots/Microsoft.Bot.Builder.TestBot.Shared/Bots/DialogAndWelcomeBot.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Bot.Builder.TestBot.Shared.Bots
         private Activity CreateResponse(IActivity activity, Attachment attachment)
         {
             var response = ((Activity)activity).CreateReply();
-            response.Attachments = new List<Attachment>() { attachment };
+            response.Attachments.Add(attachment);
             return response;
         }
     }

--- a/testbots/Skills/Parent/ParentBot.cs
+++ b/testbots/Skills/Parent/ParentBot.cs
@@ -89,7 +89,7 @@ namespace Microsoft.BotBuilderSamples
                             cloneActivity,
                             cancellationToken);
 
-                        if (response1.Status == (int)HttpStatusCode.OK && response1.Body?.Activities != null)
+                        if (response1.Status == (int)HttpStatusCode.OK && response1.Body?.Activities.Count() > 0)
                         {
                             var activities = response1.Body.Activities.ToArray();
                             if (!(await InterceptOAuthCards(activities, turnContext, cancellationToken)))
@@ -122,7 +122,7 @@ namespace Microsoft.BotBuilderSamples
 
                 if (response.Status == (int)HttpStatusCode.OK)
                 {
-                    await turnContext.SendActivitiesAsync(response.Body?.Activities?.ToArray(), cancellationToken);
+                    await turnContext.SendActivitiesAsync(response.Body?.Activities.ToArray(), cancellationToken);
                 }
             }
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/AttachmentPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/AttachmentPromptTests.cs
@@ -45,7 +45,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var attachment = new Attachment { Content = "some content", ContentType = "text/plain" };
 
             // Create incoming activity with attachment.
-            var activityWithAttachment = new Activity { Type = ActivityTypes.Message, Attachments = new List<Attachment> { attachment } };
+            var activityWithAttachment = new Activity { Type = ActivityTypes.Message };
+            activityWithAttachment.Attachments.Add(attachment);
 
             await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
@@ -90,7 +91,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var attachment = new Attachment { Content = "some content", ContentType = "text/plain" };
 
             // Create incoming activity with attachment.
-            var activityWithAttachment = new Activity { Type = ActivityTypes.Message, Attachments = new List<Attachment> { attachment } };
+            var activityWithAttachment = new Activity { Type = ActivityTypes.Message };
+            activityWithAttachment.Attachments.Add(attachment);
 
             await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicePromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicePromptTests.cs
@@ -347,12 +347,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                     {
                         // Create mock attachment for testing.
                         var attachment = new Attachment { Content = "some content", ContentType = "text/plain" };
+                        var prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" };
+                        prompt.Attachments.Add(attachment);
 
                         await dc.PromptAsync(
                             "ChoicePrompt",
                             new PromptOptions
                             {
-                                Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?", Attachments = new List<Attachment> { attachment } },
+                                Prompt = prompt,
                                 Choices = _colorChoices,
                             },
                             cancellationToken);

--- a/tests/Microsoft.Bot.Builder.TestBot.Tests/Bots/DialogAndWelcomeBotTests.cs
+++ b/tests/Microsoft.Bot.Builder.TestBot.Tests/Bots/DialogAndWelcomeBotTests.cs
@@ -27,12 +27,9 @@ namespace Microsoft.BotBuilderSamples.Tests.Bots
             var conversationUpdateActivity = new Activity
             {
                 Type = ActivityTypes.ConversationUpdate,
-                MembersAdded = new List<ChannelAccount>
-                {
-                    new ChannelAccount { Id = "theUser" },
-                },
                 Recipient = new ChannelAccount { Id = "theBot" },
             };
+            conversationUpdateActivity.MembersAdded.Add(new ChannelAccount { Id = "theUser" });
             var testAdapter = new TestAdapter(Channels.Test);
 
             // Act

--- a/tests/Microsoft.Bot.Builder.Tests/ActivityHandlerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/ActivityHandlerTests.cs
@@ -93,12 +93,9 @@ namespace Microsoft.Bot.Builder.Tests
             var activity = new Activity
             {
                 Type = ActivityTypes.ConversationUpdate,
-                MembersAdded = new List<ChannelAccount>
-                {
-                    new ChannelAccount { Id = "b" },
-                },
                 Recipient = new ChannelAccount { Id = "b" },
             };
+            activity.MembersAdded.Add(new ChannelAccount { Id = "b" });
             var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
 
             // Act
@@ -117,13 +114,11 @@ namespace Microsoft.Bot.Builder.Tests
             var activity = new Activity
             {
                 Type = ActivityTypes.ConversationUpdate,
-                MembersAdded = new List<ChannelAccount>
-                {
-                    new ChannelAccount { Id = "a" },
-                    new ChannelAccount { Id = "b" },
-                },
                 Recipient = new ChannelAccount { Id = "b" },
             };
+            activity.MembersAdded.Add(new ChannelAccount { Id = "a" });
+            activity.MembersAdded.Add(new ChannelAccount { Id = "b" });
+
             var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
 
             // Act
@@ -143,14 +138,14 @@ namespace Microsoft.Bot.Builder.Tests
             var activity = new Activity
             {
                 Type = ActivityTypes.ConversationUpdate,
-                MembersAdded = new List<ChannelAccount>
-                {
-                    new ChannelAccount { Id = "a" },
-                    new ChannelAccount { Id = "b" },
-                    new ChannelAccount { Id = "c" },
-                },
                 Recipient = new ChannelAccount { Id = "b" },
             };
+            ((List<ChannelAccount>)activity.MembersAdded).AddRange(new List<ChannelAccount>
+            {
+                new ChannelAccount { Id = "a" },
+                new ChannelAccount { Id = "b" },
+                new ChannelAccount { Id = "c" },
+            });
             var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
 
             // Act
@@ -170,12 +165,9 @@ namespace Microsoft.Bot.Builder.Tests
             var activity = new Activity
             {
                 Type = ActivityTypes.ConversationUpdate,
-                MembersRemoved = new List<ChannelAccount>
-                {
-                    new ChannelAccount { Id = "c" },
-                },
                 Recipient = new ChannelAccount { Id = "c" },
             };
+            activity.MembersRemoved.Add(new ChannelAccount { Id = "c" });
             var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
 
             // Act
@@ -194,13 +186,10 @@ namespace Microsoft.Bot.Builder.Tests
             var activity = new Activity
             {
                 Type = ActivityTypes.ConversationUpdate,
-                MembersRemoved = new List<ChannelAccount>
-                {
-                    new ChannelAccount { Id = "a" },
-                    new ChannelAccount { Id = "c" },
-                },
                 Recipient = new ChannelAccount { Id = "c" },
             };
+            activity.MembersRemoved.Add(new ChannelAccount { Id = "a" });
+            activity.MembersRemoved.Add(new ChannelAccount { Id = "c" });
             var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
 
             // Act
@@ -220,14 +209,14 @@ namespace Microsoft.Bot.Builder.Tests
             var activity = new Activity
             {
                 Type = ActivityTypes.ConversationUpdate,
-                MembersRemoved = new List<ChannelAccount>
-                {
-                    new ChannelAccount { Id = "a" },
-                    new ChannelAccount { Id = "b" },
-                    new ChannelAccount { Id = "c" },
-                },
                 Recipient = new ChannelAccount { Id = "c" },
             };
+            ((List<ChannelAccount>)activity.MembersRemoved).AddRange(new List<ChannelAccount>
+            {
+                new ChannelAccount { Id = "a" },
+                new ChannelAccount { Id = "b" },
+                new ChannelAccount { Id = "c" },
+            });
             var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
 
             // Act
@@ -247,12 +236,9 @@ namespace Microsoft.Bot.Builder.Tests
             var activity = new Activity
             {
                 Type = ActivityTypes.ConversationUpdate,
-                MembersAdded = new List<ChannelAccount>
-                {
-                    new ChannelAccount { Id = "b" },
-                },
                 Recipient = new ChannelAccount { Id = "b" },
             };
+            activity.MembersAdded.Add(new ChannelAccount { Id = "b" });
             var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
 
             // Act
@@ -271,12 +257,9 @@ namespace Microsoft.Bot.Builder.Tests
             var activity = new Activity
             {
                 Type = ActivityTypes.ConversationUpdate,
-                MembersRemoved = new List<ChannelAccount>
-                {
-                    new ChannelAccount { Id = "c" },
-                },
                 Recipient = new ChannelAccount { Id = "c" },
             };
+            activity.MembersRemoved.Add(new ChannelAccount { Id = "c" });
             var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
 
             // Act
@@ -298,15 +281,10 @@ namespace Microsoft.Bot.Builder.Tests
             var activity = new Activity
             {
                 Type = ActivityTypes.MessageReaction,
-                ReactionsAdded = new List<MessageReaction>
-                {
-                    new MessageReaction("sad"),
-                },
-                ReactionsRemoved = new List<MessageReaction>
-                {
-                    new MessageReaction("angry"),
-                },
             };
+            activity.ReactionsAdded.Add(new MessageReaction("sad"));
+            activity.ReactionsRemoved.Add(new MessageReaction("angry"));
+
             var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
 
             // Act
@@ -329,11 +307,8 @@ namespace Microsoft.Bot.Builder.Tests
             var activity = new Activity
             {
                 Type = ActivityTypes.MessageReaction,
-                ReactionsAdded = new List<MessageReaction>
-                {
-                    new MessageReaction("sad"),
-                },
             };
+            activity.ReactionsAdded.Add(new MessageReaction("sad"));
             var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
 
             // Act
@@ -356,11 +331,8 @@ namespace Microsoft.Bot.Builder.Tests
             var activity = new Activity
             {
                 Type = ActivityTypes.MessageReaction,
-                ReactionsRemoved = new List<MessageReaction>
-                {
-                    new MessageReaction("angry"),
-                },
             };
+            activity.ReactionsRemoved.Add(new MessageReaction("angry"));
             var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
 
             // Act

--- a/tests/Microsoft.Bot.Builder.Tests/NormalizeMentionsMiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/NormalizeMentionsMiddlewareTests.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Bot.Builder.Tests
         {
             Activity activity = new Activity();
             activity.Text = text;
-            activity.Entities = entities.ToList();
+            ((List<Entity>)activity.Entities).AddRange(entities);
             return activity;
         }
 

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerHidingTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerHidingTests.cs
@@ -75,12 +75,9 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             var activity = new Activity
             {
                 Type = ActivityTypes.ConversationUpdate,
-                MembersAdded = new List<ChannelAccount>
-                {
-                    new ChannelAccount { Id = "b" },
-                },
                 Recipient = new ChannelAccount { Id = "b" },
             };
+            activity.MembersAdded.Add(new ChannelAccount { Id = "b" });
             var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
 
             // Act
@@ -99,13 +96,10 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             var activity = new Activity
             {
                 Type = ActivityTypes.ConversationUpdate,
-                MembersAdded = new List<ChannelAccount>
-                {
-                    new ChannelAccount { Id = "a" },
-                    new ChannelAccount { Id = "b" },
-                },
                 Recipient = new ChannelAccount { Id = "b" },
             };
+            activity.MembersAdded.Add(new ChannelAccount { Id = "a" });
+            activity.MembersAdded.Add(new ChannelAccount { Id = "b" });
             var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
 
             // Act
@@ -125,14 +119,15 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             var activity = new Activity
             {
                 Type = ActivityTypes.ConversationUpdate,
-                MembersAdded = new List<ChannelAccount>
-                {
-                    new ChannelAccount { Id = "a" },
-                    new ChannelAccount { Id = "b" },
-                    new ChannelAccount { Id = "c" },
-                },
+
                 Recipient = new ChannelAccount { Id = "b" },
             };
+            ((List<ChannelAccount>)activity.MembersAdded).AddRange(new List<ChannelAccount>
+            {
+                new ChannelAccount { Id = "a" },
+                new ChannelAccount { Id = "b" },
+                new ChannelAccount { Id = "c" },
+            });
             var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
 
             // Act
@@ -152,12 +147,9 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             var activity = new Activity
             {
                 Type = ActivityTypes.ConversationUpdate,
-                MembersAdded = new List<ChannelAccount>
-                {
-                    new ChannelAccount { Id = "c" },
-                },
                 Recipient = new ChannelAccount { Id = "c" },
             };
+            activity.MembersAdded.Add(new ChannelAccount { Id = "c" });
             var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
 
             // Act
@@ -176,13 +168,10 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             var activity = new Activity
             {
                 Type = ActivityTypes.ConversationUpdate,
-                MembersAdded = new List<ChannelAccount>
-                {
-                    new ChannelAccount { Id = "a" },
-                    new ChannelAccount { Id = "c" },
-                },
                 Recipient = new ChannelAccount { Id = "c" },
             };
+            activity.MembersAdded.Add(new ChannelAccount { Id = "a" });
+            activity.MembersAdded.Add(new ChannelAccount { Id = "c" });
             var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
 
             // Act
@@ -202,14 +191,14 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             var activity = new Activity
             {
                 Type = ActivityTypes.ConversationUpdate,
-                MembersAdded = new List<ChannelAccount>
-                {
-                    new ChannelAccount { Id = "a" },
-                    new ChannelAccount { Id = "b" },
-                    new ChannelAccount { Id = "c" },
-                },
                 Recipient = new ChannelAccount { Id = "c" },
             };
+            ((List<ChannelAccount>)activity.MembersAdded).AddRange(new List<ChannelAccount>
+            {
+                new ChannelAccount { Id = "a" },
+                new ChannelAccount { Id = "b" },
+                new ChannelAccount { Id = "c" },
+            });
             var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
 
             // Act
@@ -229,12 +218,9 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             var activity = new Activity
             {
                 Type = ActivityTypes.ConversationUpdate,
-                MembersAdded = new List<ChannelAccount>
-                {
-                    new ChannelAccount { Id = "b" },
-                },
                 Recipient = new ChannelAccount { Id = "b" },
             };
+            activity.MembersAdded.Add(new ChannelAccount { Id = "b" });
             var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
 
             // Act
@@ -253,12 +239,9 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             var activity = new Activity
             {
                 Type = ActivityTypes.ConversationUpdate,
-                MembersAdded = new List<ChannelAccount>
-                {
-                    new ChannelAccount { Id = "c" },
-                },
                 Recipient = new ChannelAccount { Id = "c" },
             };
+            activity.MembersAdded.Add(new ChannelAccount { Id = "c" });
             var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
 
             // Act
@@ -280,15 +263,9 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             var activity = new Activity
             {
                 Type = ActivityTypes.MessageReaction,
-                ReactionsAdded = new List<MessageReaction>
-                {
-                    new MessageReaction("sad"),
-                },
-                ReactionsRemoved = new List<MessageReaction>
-                {
-                    new MessageReaction("angry"),
-                },
             };
+            activity.ReactionsAdded.Add(new MessageReaction("sad"));
+            activity.ReactionsRemoved.Add(new MessageReaction("angry"));
             var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
 
             // Act
@@ -311,11 +288,8 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             var activity = new Activity
             {
                 Type = ActivityTypes.MessageReaction,
-                ReactionsAdded = new List<MessageReaction>
-                {
-                    new MessageReaction("sad"),
-                },
             };
+            activity.ReactionsAdded.Add(new MessageReaction("sad"));
             var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
 
             // Act
@@ -338,11 +312,8 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             var activity = new Activity
             {
                 Type = ActivityTypes.MessageReaction,
-                ReactionsRemoved = new List<MessageReaction>
-                {
-                    new MessageReaction("angry"),
-                },
             };
+            activity.ReactionsRemoved.Add(new MessageReaction("angry"));
             var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
 
             // Act

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerTests.cs
@@ -33,10 +33,6 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             var activity = new Activity
             {
                 Type = ActivityTypes.ConversationUpdate,
-                MembersAdded = new List<ChannelAccount>
-                {
-                    new ChannelAccount { Id = "bot" },
-                },
                 Recipient = new ChannelAccount { Id = "bot" },
                 ChannelData = new TeamsChannelData
                 {
@@ -48,6 +44,7 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                 },
                 ChannelId = Channels.Msteams,
             };
+            activity.MembersAdded.Add(new ChannelAccount { Id = "bot" });
 
             var turnContext = new TurnContext(new SimpleAdapter(), activity);
             turnContext.TurnState.Add<IConnectorClient>(connectorClient);
@@ -76,10 +73,6 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             var activity = new Activity
             {
                 Type = ActivityTypes.ConversationUpdate,
-                MembersAdded = new List<ChannelAccount>
-                {
-                    new ChannelAccount { Id = "id-1" },
-                },
                 Recipient = new ChannelAccount { Id = "b" },
                 ChannelData = new TeamsChannelData
                 {
@@ -91,6 +84,7 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                 },
                 ChannelId = Channels.Msteams,
             };
+            activity.MembersAdded.Add(new ChannelAccount { Id = "id-1" });
 
             var turnContext = new TurnContext(new SimpleAdapter(), activity);
             turnContext.TurnState.Add<IConnectorClient>(connectorClient);
@@ -119,14 +113,11 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             var activity = new Activity
             {
                 Type = ActivityTypes.ConversationUpdate,
-                MembersAdded = new List<ChannelAccount>
-                {
-                    new ChannelAccount { Id = "id-1" },
-                },
                 Recipient = new ChannelAccount { Id = "b" },
                 Conversation = new ConversationAccount { Id = "conversation-id" },
                 ChannelId = Channels.Msteams,
             };
+            activity.MembersAdded.Add(new ChannelAccount { Id = "id-1" });
 
             var turnContext = new TurnContext(new SimpleAdapter(), activity);
             turnContext.TurnState.Add<IConnectorClient>(connectorClient);
@@ -152,22 +143,20 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             customHttpClient.BaseAddress = baseUri;
             var connectorClient = new ConnectorClient(new Uri("http://localhost/"), new MicrosoftAppCredentials(string.Empty, string.Empty), customHttpClient);
 
+            var account = new TeamsChannelAccount
+            {
+                Id = "id-1",
+                Name = "name-1",
+                AadObjectId = "aadobject-1",
+                Email = "test@microsoft.com",
+                GivenName = "given-1",
+                Surname = "surname-1",
+                UserPrincipalName = "t@microsoft.com",
+            };
+
             var activity = new Activity
             {
                 Type = ActivityTypes.ConversationUpdate,
-                MembersAdded = new List<ChannelAccount>
-                {
-                    new TeamsChannelAccount
-                    {
-                        Id = "id-1",
-                        Name = "name-1",
-                        AadObjectId = "aadobject-1",
-                        Email = "test@microsoft.com",
-                        GivenName = "given-1",
-                        Surname = "surname-1",
-                        UserPrincipalName = "t@microsoft.com",
-                    },
-                },
                 Recipient = new ChannelAccount { Id = "b" },
                 ChannelData = new TeamsChannelData
                 {
@@ -179,6 +168,7 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                 },
                 ChannelId = Channels.Msteams,
             };
+            activity.MembersAdded.Add(account);
 
             // code taken from connector - i.e. the send or serialize side
             var serializationSettings = new JsonSerializerSettings();
@@ -222,14 +212,11 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             var activity = new Activity
             {
                 Type = ActivityTypes.ConversationUpdate,
-                MembersRemoved = new List<ChannelAccount>
-                {
-                    new ChannelAccount { Id = "a" },
-                },
                 Recipient = new ChannelAccount { Id = "b" },
                 ChannelData = new TeamsChannelData { EventType = "teamMemberRemoved" },
                 ChannelId = Channels.Msteams,
             };
+            activity.MembersRemoved.Add(new ChannelAccount { Id = "a" });
             var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
 
             // Act

--- a/tests/Microsoft.Bot.Connector.Streaming.Tests/Application/StreamingRequestHandlerTests.cs
+++ b/tests/Microsoft.Bot.Connector.Streaming.Tests/Application/StreamingRequestHandlerTests.cs
@@ -111,19 +111,17 @@ namespace Microsoft.Bot.Connector.Streaming.Tests.Application
             // Arrange
             var handler = new StreamingRequestHandler(new MockBot(), new FakeCloudAdapter(), new NamedPipeStreamingConnection(Guid.NewGuid().ToString(), null));
             var conversationId = Guid.NewGuid().ToString();
-            var membersAdded = new List<ChannelAccount>();
             var member = new ChannelAccount
             {
                 Id = "123",
                 Name = "bot",
             };
-            membersAdded.Add(member);
             var activity = new Activity
             {
                 Type = "conversationUpdate",
-                MembersAdded = membersAdded,
                 Conversation = new ConversationAccount(null, null, conversationId),
             };
+            activity.MembersAdded.Add(member);
 
             var payload = new MemoryStream(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(activity, SerializationSettings.DefaultDeserializationSettings)));
             var fakeContentStreamId = Guid.NewGuid();
@@ -184,19 +182,18 @@ namespace Microsoft.Bot.Connector.Streaming.Tests.Application
             // Arrange
             var handler = new StreamingRequestHandler(new MockBot(), new FakeCloudAdapter(), new NamedPipeStreamingConnection(Guid.NewGuid().ToString(), null));
             var conversationId = Guid.NewGuid().ToString();
-            var membersAdded = new List<ChannelAccount>();
             var member = new ChannelAccount
             {
                 Id = "123",
                 Name = "bot",
             };
-            membersAdded.Add(member);
+
             var activity = new Activity
             {
                 Type = "conversationUpdate",
-                MembersAdded = membersAdded,
                 Conversation = new ConversationAccount(null, null, conversationId),
             };
+            activity.MembersAdded.Add(member);
 
             var payload = new MemoryStream(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(activity, SerializationSettings.DefaultDeserializationSettings)));
             var fakeContentStreamId = Guid.NewGuid();
@@ -221,19 +218,18 @@ namespace Microsoft.Bot.Connector.Streaming.Tests.Application
             // Arrange
             var handler = new StreamingRequestHandler(new MockBot(), new FakeCloudAdapter(), new NamedPipeStreamingConnection(Guid.NewGuid().ToString(), null));
             var conversationId = Guid.NewGuid().ToString();
-            var membersAdded = new List<ChannelAccount>();
             var member = new ChannelAccount
             {
                 Id = "123",
                 Name = "bot",
             };
-            membersAdded.Add(member);
             var activity = new Activity
             {
                 Type = "conversationUpdate",
-                MembersAdded = membersAdded,
+
                 Conversation = new ConversationAccount(null, null, conversationId),
             };
+            activity.MembersAdded.Add(member);
 
             var payload = new MemoryStream(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(activity, SerializationSettings.DefaultDeserializationSettings)));
             var fakeContentStreamId = Guid.NewGuid();
@@ -260,20 +256,18 @@ namespace Microsoft.Bot.Connector.Streaming.Tests.Application
             var handler = new StreamingRequestHandler(new MockBot(), new FakeCloudAdapter(), new NamedPipeStreamingConnection(Guid.NewGuid().ToString(), null));
             var conversationId = Guid.NewGuid().ToString();
             const string serviceUrl = "urn:FakeName:fakeProtocol://fakePath";
-            var membersAdded = new List<ChannelAccount>();
             var member = new ChannelAccount
             {
                 Id = "123",
                 Name = "bot",
             };
-            membersAdded.Add(member);
             var activity = new Activity
             {
                 ServiceUrl = serviceUrl,
                 Type = "conversationUpdate",
-                MembersAdded = membersAdded,
                 Conversation = new ConversationAccount(null, null, conversationId),
             };
+            activity.MembersAdded.Add(member);
 
             var payload = new MemoryStream(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(activity, SerializationSettings.DefaultDeserializationSettings)));
             var fakeContentStreamId = Guid.NewGuid();

--- a/tests/Microsoft.Bot.Connector.Streaming.Tests/Integration/EndToEndMiniLoadTests.cs
+++ b/tests/Microsoft.Bot.Connector.Streaming.Tests/Integration/EndToEndMiniLoadTests.cs
@@ -168,40 +168,36 @@ namespace Microsoft.Bot.Connector.Streaming.Tests.Integration
             var logger = XUnitLogger.CreateLogger(_testOutput);
 
             // Arrange
-            var activities = new[]
+            var activity = new Activity
             {
-                new Activity
-                {
-                    Id = Guid.NewGuid().ToString("N"),
-                    Type = ActivityTypes.Message,
-                    From = new ChannelAccount { Id = "testUser" },
-                    Conversation = new ConversationAccount { Id = Guid.NewGuid().ToString("N") },
-                    Recipient = new ChannelAccount { Id = "testBot" },
-                    ServiceUrl = "wss://InvalidServiceUrl/api/messages",
-                    ChannelId = "test",
-                    Text = "1"
-                },
-                new Activity
-                {
-                    Id = Guid.NewGuid().ToString("N"),
-                    Type = ActivityTypes.Message,
-                    From = new ChannelAccount { Id = "testUser" },
-                    Conversation = new ConversationAccount { Id = Guid.NewGuid().ToString("N") },
-                    Recipient = new ChannelAccount { Id = "testBot" },
-                    ServiceUrl = "wss://InvalidServiceUrl/api/messages",
-                    ChannelId = "test",
-                    Text = "2",
-                    Attachments = new List<Attachment>
-                    {
-                        new Attachment
-                        {
-                            Name = @"Resources\architecture-resize.png",
-                            ContentType = "image/png",
-                            ContentUrl = $"data:image/png;base64,{Convert.ToBase64String(File.ReadAllBytes(Path.Combine(Environment.CurrentDirectory, @"Resources", "architecture-resize.png")))}",
-                        }
-                    }
-                }
+                Id = Guid.NewGuid().ToString("N"),
+                Type = ActivityTypes.Message,
+                From = new ChannelAccount { Id = "testUser" },
+                Conversation = new ConversationAccount { Id = Guid.NewGuid().ToString("N") },
+                Recipient = new ChannelAccount { Id = "testBot" },
+                ServiceUrl = "wss://InvalidServiceUrl/api/messages",
+                ChannelId = "test",
+                Text = "1"
             };
+            var activityWithAttachment = new Activity
+            {
+                Id = Guid.NewGuid().ToString("N"),
+                Type = ActivityTypes.Message,
+                From = new ChannelAccount { Id = "testUser" },
+                Conversation = new ConversationAccount { Id = Guid.NewGuid().ToString("N") },
+                Recipient = new ChannelAccount { Id = "testBot" },
+                ServiceUrl = "wss://InvalidServiceUrl/api/messages",
+                ChannelId = "test",
+                Text = "2",
+            };
+            activityWithAttachment.Attachments.Add(new Attachment
+            {
+                Name = @"Resources\architecture-resize.png",
+                ContentType = "image/png",
+                ContentUrl = $"data:image/png;base64,{Convert.ToBase64String(File.ReadAllBytes(Path.Combine(Environment.CurrentDirectory, @"Resources", "architecture-resize.png")))}",
+            });
+
+            var activities = new[] { activity, activityWithAttachment };
 
             var verifiedResponses = activities.ToDictionary(a => a.Id, a => false);
 
@@ -211,15 +207,13 @@ namespace Microsoft.Bot.Connector.Streaming.Tests.Integration
                 {
                     case "1":
                         var response1 = MessageFactory.Text("Echo: 1");
-                        response1.Attachments = new List<Attachment>
-                        {
+                        response1.Attachments.Add(
                             new Attachment
                             {
                                 Name = @"Resources\architecture-resize.png",
                                 ContentType = "image/png",
                                 ContentUrl = $"data:image/png;base64,{Convert.ToBase64String(File.ReadAllBytes(Path.Combine(Environment.CurrentDirectory, @"Resources", "architecture-resize.png")))}",
-                            }
-                        };
+                            });
                         return turnContext.SendActivityAsync(response1, cancellationToken);
 
                     case "2":
@@ -300,42 +294,36 @@ namespace Microsoft.Bot.Connector.Streaming.Tests.Integration
         {
             var logger = XUnitLogger.CreateLogger(_testOutput);
 
-            var activities = new[]
+            var activity = new Activity
             {
-                new Activity
-                {
-                    Id = Guid.NewGuid().ToString("N"),
-                    Type = ActivityTypes.Message,
-                    From = new ChannelAccount { Id = "testUser" },
-                    Conversation = new ConversationAccount { Id = Guid.NewGuid().ToString("N") },
-                    Recipient = new ChannelAccount { Id = "testBot" },
-                    ServiceUrl = "wss://InvalidServiceUrl/api/messages",
-                    ChannelId = "test",
-                    Text = "hi",
-                    Attachments = new List<Attachment>
-                    {
-                        new Attachment
-                        {
-                            Name = @"Resources\architecture-resize.png",
-                            ContentType = "image/png",
-                            ContentUrl = $"data:image/png;base64,{Convert.ToBase64String(File.ReadAllBytes(Path.Combine(Environment.CurrentDirectory, @"Resources", "architecture-resize.png")))}",
-                        }
-                    }
-                }
+                Id = Guid.NewGuid().ToString("N"),
+                Type = ActivityTypes.Message,
+                From = new ChannelAccount { Id = "testUser" },
+                Conversation = new ConversationAccount { Id = Guid.NewGuid().ToString("N") },
+                Recipient = new ChannelAccount { Id = "testBot" },
+                ServiceUrl = "wss://InvalidServiceUrl/api/messages",
+                ChannelId = "test",
+                Text = "hi",
             };
+            activity.Attachments.Add(new Attachment
+            {
+                Name = @"Resources\architecture-resize.png",
+                ContentType = "image/png",
+                ContentUrl = $"data:image/png;base64,{Convert.ToBase64String(File.ReadAllBytes(Path.Combine(Environment.CurrentDirectory, @"Resources", "architecture-resize.png")))}",
+            });
+
+            var activities = new[] { activity };
 
             var bot = new StreamingTestBot((turnContext, cancellationToken) =>
             {
                 var response = MessageFactory.Text("Echo: hi");
-                response.Attachments = new List<Attachment>
-                {
+                response.Attachments.Add(
                     new Attachment
                     {
                         Name = @"Resources\architecture-resize.png",
                         ContentType = "image/png",
                         ContentUrl = $"data:image/png;base64,{Convert.ToBase64String(File.ReadAllBytes(Path.Combine(Environment.CurrentDirectory, @"Resources", "architecture-resize.png")))}",
-                    }
-                };
+                    });
                 return turnContext.SendActivityAsync(response, cancellationToken);
             });
 

--- a/tests/Microsoft.Bot.Connector.Tests/ConversationsTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/ConversationsTests.cs
@@ -584,6 +584,20 @@ namespace Microsoft.Bot.Connector.Tests
         [Fact]
         public async Task SendCardToConversation()
         {
+            var heroCardStatic = new HeroCard()
+            {
+                Title = "A static image",
+                Subtitle = "JPEG image",
+                Images = new CardImage[] { new CardImage() { Url = "https://docs.microsoft.com/bot-framework/media/designing-bots/core/dialogs-screens.png" } }
+            };
+
+            var heroCardAnimation = new HeroCard()
+            {
+                Title = "An animation",
+                Subtitle = "GIF image",
+                Images = new CardImage[] { new CardImage() { Url = "http://i.giphy.com/Ki55RUbOV5njy.gif" } },
+            };
+
             var activity = new Activity()
             {
                 Type = ActivityTypes.Message,
@@ -591,30 +605,22 @@ namespace Microsoft.Bot.Connector.Tests
                 From = Bot,
                 Name = "acticity",
                 Text = "TEST Send Card to Conversation",
-                Attachments = new Attachment[]
+            };
+
+            ((List<Attachment>)activity.Attachments).AddRange(
+                new List<Attachment>()
                 {
                     new Attachment()
                     {
                         ContentType = HeroCard.ContentType,
-                        Content = new HeroCard()
-                        {
-                            Title = "A static image",
-                            Subtitle = "JPEG image",
-                            Images = new CardImage[] { new CardImage() { Url = "https://docs.microsoft.com/bot-framework/media/designing-bots/core/dialogs-screens.png" } },
-                        },
+                        Content = heroCardStatic,
                     },
                     new Attachment()
                     {
                         ContentType = HeroCard.ContentType,
-                        Content = new HeroCard()
-                        {
-                            Title = "An animation",
-                            Subtitle = "GIF image",
-                            Images = new CardImage[] { new CardImage() { Url = "http://i.giphy.com/Ki55RUbOV5njy.gif" } },
-                        },
+                        Content = heroCardAnimation,
                     },
-                },
-            };
+                });
 
             var createMessage = new ConversationParameters()
             {

--- a/tests/Microsoft.Bot.Schema.Tests/ActivityTest.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/ActivityTest.cs
@@ -65,12 +65,9 @@ namespace Microsoft.Bot.Schema.Tests
                 Text = null,
                 Type = "mention",
             };
-            var lst = new List<Entity>();
 
             var output = JsonConvert.SerializeObject(mention);
-            var entity = JsonConvert.DeserializeObject<Entity>(output);
-            lst.Add(entity);
-            activity.Entities = lst;
+            activity.Entities.Add(JsonConvert.DeserializeObject<Entity>(output));
 
             var strippedActivityText = activity.RemoveRecipientMention();
             Assert.Equal(strippedActivityText, expectedStrippedName);
@@ -93,12 +90,9 @@ namespace Microsoft.Bot.Schema.Tests
                 Text = "<at>firstName</at>",
                 Type = "mention",
             };
-            var lst = new List<Entity>();
 
             var output = JsonConvert.SerializeObject(mention);
-            var entity = JsonConvert.DeserializeObject<Entity>(output);
-            lst.Add(entity);
-            activity.Entities = lst;
+            activity.Entities.Add(JsonConvert.DeserializeObject<Entity>(output));
 
             var strippedActivityText = activity.RemoveRecipientMention();
             Assert.Equal(strippedActivityText, expectedStrippedName);
@@ -466,14 +460,10 @@ namespace Microsoft.Bot.Schema.Tests
         [Fact]
         public void CanSetProperties()
         {
-            var activity = new Activity()
-            {
-                Properties = new JObject()
-            };
+            var activity = new Activity();
 
-            var props = activity.Properties;
-            Assert.NotNull(props);
-            Assert.IsType<JObject>(props);
+            Assert.NotNull(activity.Properties);
+            Assert.IsType<JObject>(activity.Properties);
         }
 
         // Default locale intentionally oddly-cased to check that it isn't defaulted somewhere, but tests stay in English

--- a/tests/Microsoft.Bot.Schema.Tests/ActivityTestData.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/ActivityTestData.cs
@@ -28,7 +28,9 @@ namespace Microsoft.Bot.Schema.Tests
             {
                 yield return new object[] { new Activity() { Text = "text" }, true };
                 yield return new object[] { new Activity() { Summary = "summary" }, true };
-                yield return new object[] { new Activity() { Attachments = GetAttachments() }, true };
+                var activity = new Activity();
+                ((List<Attachment>)activity.Attachments).AddRange(GetAttachments());
+                yield return new object[] { activity, true };
                 yield return new object[] { new Activity() { ChannelData = new MyChannelData() }, true };
                 yield return new object[] { new Activity(), false };
             }
@@ -50,29 +52,32 @@ namespace Microsoft.Bot.Schema.Tests
                     new List<Entity>() { new Entity() },
                     false,
                 };
+
+                var entity = new Entity()
+                {
+                    Type = "mention",
+                };
+                entity.Properties.Merge(new JObject()
+                {
+                    {
+                        "Mentioned",
+                        new JObject()
+                        {
+                            { "Id", "ChannelAccountId" },
+                            { "Name", "AccountName" },
+                            { "Properties", new JObject() },
+                            { "Role", "ChannelAccountRole" },
+                        }
+                    },
+                    { "Text", "text" },
+                    { "Type", "mention" },
+                });
+
                 yield return new object[]
                 {
                     new List<Entity>()
                     {
-                        new Entity()
-                        {
-                            Type = "mention",
-                            Properties = new JObject()
-                            {
-                                { 
-                                    "Mentioned",
-                                    new JObject()
-                                    {
-                                        { "Id", "ChannelAccountId" },
-                                        { "Name", "AccountName" },
-                                        { "Properties", new JObject() },
-                                        { "Role", "ChannelAccountRole" },
-                                    }
-                                },
-                                { "Text", "text" },
-                                { "Type", "mention" },
-                            },
-                        }
+                        entity
                     },
                     true
                 };

--- a/tests/Microsoft.Bot.Schema.Tests/AttachmentTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/AttachmentTests.cs
@@ -19,10 +19,7 @@ namespace Microsoft.Bot.Schema.Tests
             var thumbnailUrl = "thumbnailUrl";
             var properties = new JObject();
 
-            var attachment = new Attachment(contentType, contentUrl, content, name, thumbnailUrl)
-            {
-                Properties = properties
-            };
+            var attachment = new Attachment(contentType, contentUrl, content, name, thumbnailUrl);
 
             Assert.NotNull(attachment);
             Assert.IsType<Attachment>(attachment);

--- a/tests/Microsoft.Bot.Schema.Tests/IActivityExtensionsTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/IActivityExtensionsTests.cs
@@ -27,8 +27,8 @@ namespace Microsoft.Bot.Schema.Tests
             var message = new Activity()
             {
                 Type = ActivityTypes.Message,
-                Entities = entities,
             };
+            ((List<Entity>)message.Entities).AddRange(entities);
             var mentionsId = ActivityExtensions.MentionsId(message, "ChannelAccountId");
 
             Assert.Equal(expectsMention, mentionsId);
@@ -41,7 +41,6 @@ namespace Microsoft.Bot.Schema.Tests
             var message = new Activity()
             {
                 Type = ActivityTypes.Message,
-                Entities = entities,
                 Recipient = new ChannelAccount
                 {
                     Id = "ChannelAccountId",
@@ -50,6 +49,7 @@ namespace Microsoft.Bot.Schema.Tests
                     Role = "ChannelAccountRole",
                 }
             };
+            ((List<Entity>)message.Entities).AddRange(entities);
 
             var mentionsRecipient = ActivityExtensions.MentionsRecipient(message);
 


### PR DESCRIPTION
Addresses # 6099
#minor

## Description
This PR removes the exclusions of the FxCop rule [CA2227](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2227) (Collection properties must be read-only) in **Activity** and **Attachment** related classes.

### Detailed Changes
- Updated Collection properties (Dictionary, List, JObject)' accessor from `set` to `private set`.
- Initialized collection properties with empty collections.
- Replaced direct set of the properties with calls to the Collections' methods _Add(), AddRange(), Merge()_, and _Clear()_ depending on the case.
- Updated `null` validations with `Count()` or `Any()` validations.
- The following properties were updated:
   - Microsoft.Bot.Schema/Activity: MembersAdded, MembersRemoved, ReactionsAdded, ReactionsRemoved, Attachments, Entities, ListenFor, and TextHighlights.
   - Microsoft.Bot.Schema/ActivityEx: Properties.
   - Microsoft.Bot.Schema/Attachment: Properties.
   - Microsoft.Bot.Schema/AttachmentInfo: Views.
   - Microsoft.Bot.Schema/IActivity: Entities.
   - Microsoft.Bot.Schema/IMessageActivity: Attachments.
   - Microsoft.Bot.Schema/IMessageReactionActivity: ReactionsAdded, ReactionsRemoved.
   - Microsoft.Bot.Schema/ISuggestionActivity: TextHighlights.

## Testing
This image shows the tests passing after the changes.
![image](https://user-images.githubusercontent.com/44245136/154278898-76dbcfed-be0e-4e1b-b7d2-7f01a2fc1dcc.png)
