### PR TITLE
[#6099] Remove low impact FxCop exclusions - Rule CA2227 (Part 8/8)

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotStateSet.cs
+++ b/libraries/Microsoft.Bot.Builder/BotStateSet.cs
@@ -24,12 +24,10 @@ namespace Microsoft.Bot.Builder
         }
 
         /// <summary>
-        /// Gets or sets the BotStates list for the BotStateSet.
+        /// Gets the BotStates list for the BotStateSet.
         /// </summary>
         /// <value>The BotState objects managed by this class.</value>
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
-        public List<BotState> BotStates { get; set; } = new List<BotState>();
-#pragma warning restore CA2227 // Collection properties should be read only
+        public List<BotState> BotStates { get; } = new List<BotState>();
 
         /// <summary>
         /// Adds a bot state object to the set.

--- a/libraries/Microsoft.Bot.Schema/Entity.cs
+++ b/libraries/Microsoft.Bot.Schema/Entity.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Bot.Schema
         public string Type { get; set; }
 
         /// <summary>
-        /// Gets or sets properties that are not otherwise defined by the <see cref="Entity"/> type but that
+        /// Gets properties that are not otherwise defined by the <see cref="Entity"/> type but that
         /// might appear in the REST JSON object.
         /// </summary>
         /// <value>The extended properties for the object.</value>
@@ -40,9 +40,7 @@ namespace Microsoft.Bot.Schema
         /// the JSON object is deserialized, but are instead stored in this property. Such properties
         /// will be written to a JSON object when the instance is serialized.</remarks>
         [JsonExtensionData(ReadData = true, WriteData = true)]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
-        public JObject Properties { get; set; } = new JObject();
-#pragma warning restore CA2227 // Collection properties should be read only
+        public JObject Properties { get; private set; } = new JObject();
 
         /// <summary>
         /// Retrieve internal payload.

--- a/libraries/Microsoft.Bot.Schema/ExpectedReplies.cs
+++ b/libraries/Microsoft.Bot.Schema/ExpectedReplies.cs
@@ -26,19 +26,16 @@ namespace Microsoft.Bot.Schema
         /// to the ExpectedReplies schema.</param>
         public ExpectedReplies(IList<Activity> activities = default)
         {
-            Activities = activities;
+            Activities = activities ?? new List<Activity>();
             CustomInit();
         }
 
         /// <summary>
-        /// Gets or sets a collection of Activities that conforms to the
-        /// ExpectedReplies schema.
+        /// Gets a collection of Activities that conforms to the ExpectedReplies schema.
         /// </summary>
         /// <value>The collection of activities that conforms to the ExpectedREplies schema.</value>
         [JsonProperty(PropertyName = "activities")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<Activity> Activities { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<Activity> Activities { get; private set; } = new List<Activity>();
 
         /// <summary>
         /// An initialization method that performs custom operations like setting defaults.

--- a/libraries/Microsoft.Bot.Schema/MicrosoftPayMethodData.cs
+++ b/libraries/Microsoft.Bot.Schema/MicrosoftPayMethodData.cs
@@ -38,8 +38,8 @@ namespace Microsoft.Bot.Schema
         public MicrosoftPayMethodData(string merchantId = default, IList<string> supportedNetworks = default, IList<string> supportedTypes = default)
         {
             MerchantId = merchantId;
-            SupportedNetworks = supportedNetworks;
-            SupportedTypes = supportedTypes;
+            SupportedNetworks = supportedNetworks ?? new List<string>();
+            SupportedTypes = supportedTypes ?? new List<string>();
         }
 
         /// <summary>
@@ -72,23 +72,19 @@ namespace Microsoft.Bot.Schema
         public string Mode { get; set; }
 
         /// <summary>
-        /// Gets or sets supported payment networks (e.g., "visa" and
+        /// Gets supported payment networks (e.g., "visa" and
         /// "mastercard").
         /// </summary>
         /// <value>The supported payment networks.</value>
         [JsonProperty(PropertyName = "supportedNetworks")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<string> SupportedNetworks { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<string> SupportedNetworks { get; private set; } = new List<string>();
 
         /// <summary>
-        /// Gets or sets supported payment types (e.g., "credit").
+        /// Gets supported payment types (e.g., "credit").
         /// </summary>
         /// <value>The supported payment types.</value>
         [JsonProperty(PropertyName = "supportedTypes")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<string> SupportedTypes { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<string> SupportedTypes { get; private set; } = new List<string>();
 
         /// <summary>
         /// Get Microsoft Pay method data.
@@ -96,9 +92,9 @@ namespace Microsoft.Bot.Schema
         /// <returns>Payment method data.</returns>
         public PaymentMethodData ToPaymentMethodData()
         {
-            return new PaymentMethodData
+            var supportedMethods = new List<string> { MethodName };
+            return new PaymentMethodData(supportedMethods: supportedMethods)
             {
-                SupportedMethods = new List<string> { MethodName },
                 Data = this,
             };
         }

--- a/libraries/Microsoft.Bot.Schema/PagedMembersResult.cs
+++ b/libraries/Microsoft.Bot.Schema/PagedMembersResult.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Bot.Schema
         public PagedMembersResult(string continuationToken = default, IList<ChannelAccount> members = default)
         {
             ContinuationToken = continuationToken;
-            Members = members;
+            Members = members ?? new List<ChannelAccount>();
             CustomInit();
         }
 
@@ -39,13 +39,11 @@ namespace Microsoft.Bot.Schema
         public string ContinuationToken { get; set; }
 
         /// <summary>
-        /// Gets or sets the Channel Accounts.
+        /// Gets the Channel Accounts.
         /// </summary>
         /// <value>The Channel Accounts.</value>
         [JsonProperty(PropertyName = "members")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<ChannelAccount> Members { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<ChannelAccount> Members { get; private set; } = new List<ChannelAccount>();
 
         /// <summary>
         /// An initialization method that performs custom operations like setting defaults.

--- a/libraries/Microsoft.Bot.Schema/PaymentAddress.cs
+++ b/libraries/Microsoft.Bot.Schema/PaymentAddress.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Bot.Schema
         public PaymentAddress(string country = default, IList<string> addressLine = default, string region = default, string city = default, string dependentLocality = default, string postalCode = default, string sortingCode = default, string languageCode = default, string organization = default, string recipient = default, string phone = default)
         {
             Country = country;
-            AddressLine = addressLine;
+            AddressLine = addressLine ?? new List<string>();
             Region = region;
             City = city;
             DependentLocality = dependentLocality;
@@ -76,16 +76,14 @@ namespace Microsoft.Bot.Schema
         public string Country { get; set; }
 
         /// <summary>
-        /// Gets or sets this is the most specific part of the address. It can
+        /// Gets this is the most specific part of the address. It can
         /// include, for example, a street name, a house number, apartment
         /// number, a rural delivery route, descriptive instructions, or a post
         /// office box number.
         /// </summary>
         /// <value>The most specific part of the address.</value>
         [JsonProperty(PropertyName = "addressLine")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat)
-        public IList<string> AddressLine { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<string> AddressLine { get; private set; } = new List<string>();
 
         /// <summary>
         /// Gets or sets this is the top level administrative subdivision of

--- a/libraries/Microsoft.Bot.Schema/PaymentDetails.cs
+++ b/libraries/Microsoft.Bot.Schema/PaymentDetails.cs
@@ -36,9 +36,9 @@ namespace Microsoft.Bot.Schema
         public PaymentDetails(PaymentItem total = default, IList<PaymentItem> displayItems = default, IList<PaymentShippingOption> shippingOptions = default, IList<PaymentDetailsModifier> modifiers = default, string error = default)
         {
             Total = total;
-            DisplayItems = displayItems;
-            ShippingOptions = shippingOptions;
-            Modifiers = modifiers;
+            DisplayItems = displayItems ?? new List<PaymentItem>();
+            ShippingOptions = shippingOptions ?? new List<PaymentShippingOption>();
+            Modifiers = modifiers ?? new List<PaymentDetailsModifier>();
             Error = error;
             CustomInit();
         }
@@ -51,34 +51,28 @@ namespace Microsoft.Bot.Schema
         public PaymentItem Total { get; set; }
 
         /// <summary>
-        /// Gets or sets contains line items for the payment request that the
+        /// Gets contains line items for the payment request that the
         /// user agent may display.
         /// </summary>
         /// <value>The items for the payment request.</value>
         [JsonProperty(PropertyName = "displayItems")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<PaymentItem> DisplayItems { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<PaymentItem> DisplayItems { get; private set; } = new List<PaymentItem>();
 
         /// <summary>
-        /// Gets or sets a sequence containing the different shipping options
+        /// Gets a sequence containing the different shipping options
         /// for the user to choose from.
         /// </summary>
         /// <value>The the different shipping options for the user to choose from.</value>
         [JsonProperty(PropertyName = "shippingOptions")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<PaymentShippingOption> ShippingOptions { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<PaymentShippingOption> ShippingOptions { get; private set; } = new List<PaymentShippingOption>();
 
         /// <summary>
-        /// Gets or sets contains modifiers for particular payment method
+        /// Gets contains modifiers for particular payment method
         /// identifiers.
         /// </summary>
         /// <value>The modifiers for a particular payment method.</value>
         [JsonProperty(PropertyName = "modifiers")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<PaymentDetailsModifier> Modifiers { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<PaymentDetailsModifier> Modifiers { get; private set; } = new List<PaymentDetailsModifier>();
 
         /// <summary>
         /// Gets or sets error description.

--- a/libraries/Microsoft.Bot.Schema/PaymentDetailsModifier.cs
+++ b/libraries/Microsoft.Bot.Schema/PaymentDetailsModifier.cs
@@ -39,21 +39,19 @@ namespace Microsoft.Bot.Schema
         /// methods.</param>
         public PaymentDetailsModifier(IList<string> supportedMethods = default, PaymentItem total = default, IList<PaymentItem> additionalDisplayItems = default, object data = default)
         {
-            SupportedMethods = supportedMethods;
+            SupportedMethods = supportedMethods ?? new List<string>();
             Total = total;
-            AdditionalDisplayItems = additionalDisplayItems;
+            AdditionalDisplayItems = additionalDisplayItems ?? new List<PaymentItem>();
             Data = data;
             CustomInit();
         }
 
         /// <summary>
-        /// Gets or sets contains a sequence of payment method identifiers.
+        /// Gets contains a sequence of payment method identifiers.
         /// </summary>
         /// <value>The supported method identifiers.</value>
         [JsonProperty(PropertyName = "supportedMethods")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<string> SupportedMethods { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<string> SupportedMethods { get; private set; } = new List<string>();
 
         /// <summary>
         /// Gets or sets this value overrides the total field in the
@@ -65,15 +63,13 @@ namespace Microsoft.Bot.Schema
         public PaymentItem Total { get; set; }
 
         /// <summary>
-        /// Gets or sets provides additional display items that are appended to
+        /// Gets provides additional display items that are appended to
         /// the displayItems field in the PaymentDetails dictionary for the
         /// payment method identifiers in the supportedMethods field.
         /// </summary>
         /// <value>The additional display items that are appended to the displayItems field in PaymentDetails.</value>
         [JsonProperty(PropertyName = "additionalDisplayItems")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<PaymentItem> AdditionalDisplayItems { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<PaymentItem> AdditionalDisplayItems { get; private set; } = new List<PaymentItem>();
 
         /// <summary>
         /// Gets or sets a JSON-serializable object that provides optional

--- a/libraries/Microsoft.Bot.Schema/PaymentMethodData.cs
+++ b/libraries/Microsoft.Bot.Schema/PaymentMethodData.cs
@@ -33,20 +33,18 @@ namespace Microsoft.Bot.Schema
         /// methods.</param>
         public PaymentMethodData(IList<string> supportedMethods = default, object data = default)
         {
-            SupportedMethods = supportedMethods;
+            SupportedMethods = supportedMethods ?? new List<string>();
             Data = data;
             CustomInit();
         }
 
         /// <summary>
-        /// Gets or sets required sequence of strings containing payment method
+        /// Gets required sequence of strings containing payment method
         /// identifiers for payment methods that the merchant web site accepts.
         /// </summary>
         /// <value>The supported payment methods.</value>
         [JsonProperty(PropertyName = "supportedMethods")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<string> SupportedMethods { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<string> SupportedMethods { get; private set; } = new List<string>();
 
         /// <summary>
         /// Gets or sets a JSON-serializable object that provides optional

--- a/libraries/Microsoft.Bot.Schema/PaymentRequest.cs
+++ b/libraries/Microsoft.Bot.Schema/PaymentRequest.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Bot.Schema
         public PaymentRequest(string id = default, IList<PaymentMethodData> methodData = default, PaymentDetails details = default, PaymentOptions options = default, string expires = default)
         {
             Id = id;
-            MethodData = methodData;
+            MethodData = methodData ?? new List<PaymentMethodData>();
             Details = details;
             Options = options;
             Expires = expires;
@@ -58,13 +58,11 @@ namespace Microsoft.Bot.Schema
         public string Id { get; set; }
 
         /// <summary>
-        /// Gets or sets allowed payment methods for this request.
+        /// Gets allowed payment methods for this request.
         /// </summary>
         /// <value>The payment methods for this request.</value>
         [JsonProperty(PropertyName = "methodData")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<PaymentMethodData> MethodData { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<PaymentMethodData> MethodData { get; private set; } = new List<PaymentMethodData>();
 
         /// <summary>
         /// Gets or sets details for this request.

--- a/libraries/Microsoft.Bot.Schema/SemanticAction.cs
+++ b/libraries/Microsoft.Bot.Schema/SemanticAction.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Bot.Schema
         public SemanticAction(string id = default, IDictionary<string, Entity> entities = default)
         {
             Id = id;
-            Entities = entities;
+            Entities = entities ?? new Dictionary<string, Entity>();
             CustomInit();
         }
 
@@ -39,13 +39,11 @@ namespace Microsoft.Bot.Schema
         public string Id { get; set; }
 
         /// <summary>
-        /// Gets or sets entities associated with this action.
+        /// Gets entities associated with this action.
         /// </summary>
         /// <value>The entities associated with this action.</value>
         [JsonProperty(PropertyName = "entities")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IDictionary<string, Entity> Entities { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IDictionary<string, Entity> Entities { get; private set; } = new Dictionary<string, Entity>();
 
         /// <summary>
         /// Gets or sets state of this action. Allowed values: `start`,

--- a/tests/Microsoft.Bot.Schema.Tests/ActivityTestData.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/ActivityTestData.cs
@@ -50,29 +50,32 @@ namespace Microsoft.Bot.Schema.Tests
                     new List<Entity>() { new Entity() },
                     false,
                 };
+
+                var entity = new Entity()
+                {
+                    Type = "mention",
+                };
+                entity.Properties.Merge(new JObject()
+                { 
+                    {
+                        "Mentioned",
+                        new JObject()
+                        {
+                            { "Id", "ChannelAccountId" },
+                            { "Name", "AccountName" },
+                            { "Properties", new JObject() },
+                            { "Role", "ChannelAccountRole" },
+                        }
+                    },
+                    { "Text", "text" },
+                    { "Type", "mention" },
+                });
+
                 yield return new object[]
                 {
                     new List<Entity>()
                     {
-                        new Entity()
-                        {
-                            Type = "mention",
-                            Properties = new JObject()
-                            {
-                                { 
-                                    "Mentioned",
-                                    new JObject()
-                                    {
-                                        { "Id", "ChannelAccountId" },
-                                        { "Name", "AccountName" },
-                                        { "Properties", new JObject() },
-                                        { "Role", "ChannelAccountRole" },
-                                    }
-                                },
-                                { "Text", "text" },
-                                { "Type", "mention" },
-                            },
-                        }
+                        entity
                     },
                     true
                 };


### PR DESCRIPTION
Addresses # 6099
#minor

## Description
This PR removes the exclusions of the FxCop rule [CA2227](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2227) (Collection properties must be read-only) in **Bot.Schema** classes.

### Detailed Changes
- Updated Collection properties (Dictionary, List, JObject)' accessor from `set` to `private set`.
- Initialized collection properties with empty collections.
- Replaced direct set of the properties with calls to the Collections' methods _Add(), AddRange(), Merge()_, and _Clear()_ depending on the case.
- Updated `null` validations with `Count()` or `Any()` validations.
- The following properties were updated:
   - Microsoft.Bot.Builder/BotStateSet: BotStates.
   - Microsoft.Bot.Schema/Entity: Properties
   - Microsoft.Bot.Schema/ExpectedReplies: Activities.
   - Microsoft.Bot.Schema/MicrosoftPayMethodData: SupportedNetworks, SupportedTypes.
   - Microsoft.Bot.Schema/PagedMembersResult: Members.
   - Microsoft.Bot.Schema/PaymentAddress: AddressLine.
   - Microsoft.Bot.Schema/PaymentDetails: DisplayItems, ShippingOptions, Modifiers.
   - Microsoft.Bot.Schema/PaymentDetailsModifier: SupportedMethods, AdditionalDisplayItems.
   - Microsoft.Bot.Schema/PaymentMethodData: SupportedMethods
   - Microsoft.Bot.Schema/PaymentRequest: MethodData.
   - Microsoft.Bot.Schema/SemanticAction: Entities

## Testing
This image shows the tests passing after the changes.
![image](https://user-images.githubusercontent.com/44245136/154278898-76dbcfed-be0e-4e1b-b7d2-7f01a2fc1dcc.png)
