### PR TITLE
[#6099] Remove low impact FxCop exclusions - Rule VSTHRD200

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Authentication/AdalAuthenticator.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AdalAuthenticator.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Bot.Connector.Authentication
         {
             var watch = Stopwatch.StartNew();
 
-            var result = await Retry.Run(
+            var result = await Retry.RunAsync(
                 task: () => AcquireTokenAsync(forceRefresh),
                 retryExceptionHandler: (ex, ct) => HandleAdalException(ex, ct)).ConfigureAwait(false);
 

--- a/libraries/Microsoft.Bot.Connector/Authentication/ManagedIdentityAuthenticator.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ManagedIdentityAuthenticator.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Bot.Connector.Authentication
             var watch = Stopwatch.StartNew();
 
             var result = await Retry
-                .Run(() => AcquireTokenAsync(forceRefresh), HandleTokenProviderException)
+                .RunAsync(() => AcquireTokenAsync(forceRefresh), HandleTokenProviderException)
                 .ConfigureAwait(false);
 
             watch.Stop();

--- a/libraries/Microsoft.Bot.Connector/Authentication/MsalAppCredentials.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/MsalAppCredentials.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Bot.Connector.Authentication
         {
             var watch = Stopwatch.StartNew();
 
-            var result = await Retry.Run(
+            var result = await Retry.RunAsync(
                 task: () => AcquireTokenAsync(forceRefresh),
                 retryExceptionHandler: (ex, ct) => HandleMsalException(ex, ct)).ConfigureAwait(false);
 

--- a/libraries/Microsoft.Bot.Connector/Authentication/Retry.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/Retry.cs
@@ -19,9 +19,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="task">A reference to the action to retry.</param>
         /// <param name="retryExceptionHandler">A reference to the method that handles exceptions.</param>
         /// <returns>A result object.</returns>
-#pragma warning disable VSTHRD200 // Use "Async" suffix for async methods (can't change this without breaking binary compat)
-        public static async Task<TResult> Run<TResult>(Func<Task<TResult>> task, Func<Exception, int, RetryParams> retryExceptionHandler)
-#pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
+        public static async Task<TResult> RunAsync<TResult>(Func<Task<TResult>> task, Func<Exception, int, RetryParams> retryExceptionHandler)
         {
             RetryParams retry;
             var exceptions = new List<Exception>();

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/RetryTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/RetryTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
                 ExceptionToThrow = null,
             };
 
-            var result = await Retry.Run(
+            var result = await Retry.RunAsync(
                 task: () => faultyClass.FaultyTask(),
                 retryExceptionHandler: (ex, ct) => faultyClass.ExceptionHandler(ex, ct));
 
@@ -35,7 +35,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
                 TriesUntilSuccess = 3,
             };
 
-            var result = await Retry.Run(
+            var result = await Retry.RunAsync(
                 task: () => faultyClass.FaultyTask(),
                 retryExceptionHandler: (ex, ct) => faultyClass.ExceptionHandler(ex, ct));
 
@@ -53,7 +53,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
             };
 
             await Assert.ThrowsAsync<AggregateException>(async () =>
-                await Retry.Run(
+                await Retry.RunAsync(
                     task: () => faultyClass.FaultyTask(),
                     retryExceptionHandler: (ex, ct) => faultyClass.ExceptionHandler(ex, ct)));
         }


### PR DESCRIPTION
Fixes # 6099
#minor

## Description
This PR removes the exclusions of the FxCop rule VSTHRD200 (Use "Async" suffix for async methods).

### Detailed Changes
- Renamed method `Run` as `RunAsync` in the _Retry_ class.
- Updated references to the method and unit tests.

## Testing
This image shows the tests passing after the changes.
![image](https://user-images.githubusercontent.com/44245136/154278898-76dbcfed-be0e-4e1b-b7d2-7f01a2fc1dcc.png)
