### PR TITLE
[#5276] Update code analysis to latest VS recommendations - Fix error rules - Part 4

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizerOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizerOptions.cs
@@ -52,13 +52,13 @@ namespace Microsoft.Bot.Builder.AI.Luis
         /// Gets or sets a value indicating whether to log personal information that came from the user to telemetry.
         /// </summary>
         /// <value>If true, personal information is logged to Telemetry; otherwise the properties will be filtered.</value>
-        public bool LogPersonalInformation { get; set; } = false;
+        public bool LogPersonalInformation { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether flag to indicate if full results from the LUIS API should be returned with the recognizer result.
         /// </summary>
         /// <value>A value indicating whether full results from the LUIS API should be returned with the recognizer result.</value>
-        public bool IncludeAPIResults { get; set; } = false;
+        public bool IncludeAPIResults { get; set; }
 
         // Support original ITurnContext
         internal abstract Task<RecognizerResult> RecognizeInternalAsync(ITurnContext turnContext, HttpClient httpClient, CancellationToken cancellationToken);

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/V3/LuisPredictionOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/V3/LuisPredictionOptions.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Bot.Builder.AI.LuisV3
         /// <value>
         /// True for returning all intents.
         /// </value>
-        public bool IncludeAllIntents { get; set; } = false;
+        public bool IncludeAllIntents { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether or not instance data should be included in response.
@@ -49,7 +49,7 @@ namespace Microsoft.Bot.Builder.AI.LuisV3
         /// <value>
         /// A value indicating whether or not instance data should be included in response.
         /// </value>
-        public bool IncludeInstanceData { get; set; } = false;
+        public bool IncludeInstanceData { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether API results should be included.

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/V3/LuisRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/V3/LuisRecognizer.cs
@@ -403,7 +403,7 @@ namespace Microsoft.Bot.Builder.AI.LuisV3
                     uri.Path += $"/versions/{options.Version}/predict";
                 }
 
-                var response = await DefaultHttpClient.PostAsync(uri.Uri, new StringContent(content.ToString(), System.Text.Encoding.UTF8, "application/json")).ConfigureAwait(false);
+                var response = await DefaultHttpClient.PostAsync(uri.Uri, new StringContent(content.ToString(), System.Text.Encoding.UTF8, "application/json"), cancellationToken).ConfigureAwait(false);
                 response.EnsureSuccessStatusCode();
                 luisResponse = (JObject)JsonConvert.DeserializeObject(await response.Content.ReadAsStringAsync().ConfigureAwait(false));
                 var prediction = (JObject)luisResponse["prediction"];

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/V3/LuisRecognizerOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/V3/LuisRecognizerOptions.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Bot.Builder.AI.LuisV3
         /// Gets or sets a value indicating whether to log personal information that came from the user to telemetry.
         /// </summary>
         /// <value>If true, personal information is logged to Telemetry; otherwise the properties will be filtered.</value>
-        public bool LogPersonalInformation { get; set; } = false;
+        public bool LogPersonalInformation { get; set; }
 
         /// <summary>
         /// Gets or sets the handler for sending http calls.

--- a/libraries/Microsoft.Bot.Builder.AI.Orchestrator/OrchestratorRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.Orchestrator/OrchestratorRecognizer.cs
@@ -41,9 +41,9 @@ namespace Microsoft.Bot.Builder.AI.Orchestrator
 
         private const float UnknownIntentFilterScore = 0.4F;
         private static ConcurrentDictionary<string, OrchestratorDictionaryEntry> orchestratorMap = new ConcurrentDictionary<string, OrchestratorDictionaryEntry>();
-        private OrchestratorDictionaryEntry _orchestrator = null;
-        private ILabelResolver _resolver = null;
-        private bool _isResolverMockup = false;
+        private OrchestratorDictionaryEntry _orchestrator;
+        private ILabelResolver _resolver;
+        private bool _isResolverMockup;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="OrchestratorRecognizer"/> class.

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
@@ -490,7 +490,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
                     await stepContext.Context.SendActivityAsync(activity, cancellationToken: cancellationToken).ConfigureAwait(false);
                 }
 
-                return await stepContext.EndDialogAsync().ConfigureAwait(false);
+                return await stepContext.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
             }
 
             // If previous QnAId is present, replace the dialog
@@ -519,7 +519,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
                 }
             }
 
-            return await stepContext.EndDialogAsync().ConfigureAwait(false);
+            return await stepContext.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         private static void ResetOptions(DialogContext dc, QnAMakerDialogOptions dialogOptions)
@@ -599,7 +599,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
 
                     // Get active learning suggestion card activity.
                     var message = QnACardBuilder.GetSuggestionsCard(suggestedQuestions, dialogOptions.ResponseOptions.ActiveLearningCardTitle, dialogOptions.ResponseOptions.CardNoMatchText);
-                    await stepContext.Context.SendActivityAsync(message).ConfigureAwait(false);
+                    await stepContext.Context.SendActivityAsync(message, cancellationToken).ConfigureAwait(false);
 
                     stepContext.ActiveDialog.State[Options] = dialogOptions;
                     stepContext.ActiveDialog.State[SuggestedQuestionsData] = suggestedQuestions;
@@ -666,7 +666,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
                         await stepContext.Context.SendActivityAsync(activity, cancellationToken: cancellationToken).ConfigureAwait(false);
                     }
 
-                    return await stepContext.EndDialogAsync().ConfigureAwait(false);
+                    return await stepContext.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
@@ -708,7 +708,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
 
                     // Get multi-turn prompts card activity.
                     var message = QnACardBuilder.GetQnAPromptsCard(answer, dialogOptions.ResponseOptions.CardNoMatchText);
-                    await stepContext.Context.SendActivityAsync(message).ConfigureAwait(false);
+                    await stepContext.Context.SendActivityAsync(message, cancellationToken).ConfigureAwait(false);
 
                     return new DialogTurnResult(DialogTurnStatus.Waiting);
                 }

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
@@ -289,7 +289,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
         /// <value>
         /// The flag to indicate in personal information should be logged in telemetry.
         /// </value>
-        public bool LogPersonalInformation { get; set; } = false;
+        public bool LogPersonalInformation { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether gets or sets environment of knowledgebase to be called. 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/ComponentDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/ComponentDialog.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Bot.Builder.Dialogs
 
             await EnsureInitializedAsync(outerDc).ConfigureAwait(false);
 
-            await this.CheckForVersionChangeAsync(outerDc).ConfigureAwait(false);
+            await this.CheckForVersionChangeAsync(outerDc, cancellationToken).ConfigureAwait(false);
 
             var innerDc = this.CreateChildContext(outerDc);
             var turnResult = await OnBeginDialogAsync(innerDc, options, cancellationToken).ConfigureAwait(false);
@@ -106,7 +106,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         {
             await EnsureInitializedAsync(outerDc).ConfigureAwait(false);
 
-            await this.CheckForVersionChangeAsync(outerDc).ConfigureAwait(false);
+            await this.CheckForVersionChangeAsync(outerDc, cancellationToken).ConfigureAwait(false);
 
             // Continue execution of inner dialog
             var innerDc = this.CreateChildContext(outerDc);
@@ -157,7 +157,7 @@ namespace Microsoft.Bot.Builder.Dialogs
 
             await EnsureInitializedAsync(outerDc).ConfigureAwait(false);
 
-            await this.CheckForVersionChangeAsync(outerDc).ConfigureAwait(false);
+            await this.CheckForVersionChangeAsync(outerDc, cancellationToken).ConfigureAwait(false);
 
             // Containers are typically leaf nodes on the stack but the dev is free to push other dialogs
             // on top of the stack which will result in the container receiving an unexpected call to

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
@@ -428,7 +428,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                             }
 
                             // End the active dialog
-                            await dialogContext.EndActiveDialogAsync(DialogReason.CancelCalled).ConfigureAwait(false);
+                            await dialogContext.EndActiveDialogAsync(DialogReason.CancelCalled, cancellationToken: cancellationToken).ConfigureAwait(false);
                         }
                         else
                         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ChoicePrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ChoicePrompt.cs
@@ -140,11 +140,11 @@ namespace Microsoft.Bot.Builder.Dialogs
             var choiceStyle = options.Style ?? Style;
             if (isRetry && options.RetryPrompt != null)
             {
-                prompt = AppendChoices(options.RetryPrompt, channelId, choices, choiceStyle, choiceOptions);
+                prompt = AppendChoices(options.RetryPrompt, channelId, choices, choiceStyle, choiceOptions, cancellationToken);
             }
             else
             {
-                prompt = AppendChoices(options.Prompt, channelId, choices, choiceStyle, choiceOptions);
+                prompt = AppendChoices(options.Prompt, channelId, choices, choiceStyle, choiceOptions, cancellationToken);
             }
 
             // Send prompt

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ConfirmPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ConfirmPrompt.cs
@@ -145,11 +145,11 @@ namespace Microsoft.Bot.Builder.Dialogs
             var style = options.Style ?? Style;
             if (isRetry && options.RetryPrompt != null)
             {
-                prompt = AppendChoices(options.RetryPrompt, channelId, choices, style, choiceOptions);
+                prompt = AppendChoices(options.RetryPrompt, channelId, choices, style, choiceOptions, cancellationToken);
             }
             else
             {
-                prompt = AppendChoices(options.Prompt, channelId, choices, style, choiceOptions);
+                prompt = AppendChoices(options.Prompt, channelId, choices, style, choiceOptions, cancellationToken);
             }
 
             // Send prompt

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
@@ -228,7 +228,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             {
                 // Perform base recognition
                 var state = dc.ActiveDialog.State;
-                var recognized = await OnRecognizeAsync(dc.Context, (IDictionary<string, object>)state[PersistedState], (PromptOptions)state[PersistedOptions]).ConfigureAwait(false);
+                var recognized = await OnRecognizeAsync(dc.Context, (IDictionary<string, object>)state[PersistedState], (PromptOptions)state[PersistedOptions], cancellationToken).ConfigureAwait(false);
                 return recognized.Succeeded;
             }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptRecognizerResult.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptRecognizerResult.cs
@@ -35,6 +35,6 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <value>
         /// The default value is `false`.
         /// </value>
-        public bool AllowInterruption { get; set; } = false;
+        public bool AllowInterruption { get; set; }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Testing/Adapters/TestAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.Testing/Adapters/TestAdapter.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Bot.Builder.Adapters
         private readonly IDictionary<ExchangableTokenKey, string> _exchangableToken = new Dictionary<ExchangableTokenKey, string>();
         private readonly IList<TokenMagicCode> _magicCodes = new List<TokenMagicCode>();
 
-        private int _nextId = 0;
+        private int _nextId;
         private Queue<TaskCompletionSource<IActivity>> _queuedRequests = new Queue<TaskCompletionSource<IActivity>>();
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Testing/Adapters/TestAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.Testing/Adapters/TestAdapter.cs
@@ -267,7 +267,7 @@ namespace Microsoft.Bot.Builder.Adapters
                     // more realistic tests.
                     var delayMs = Convert.ToInt32(activity.Value, CultureInfo.InvariantCulture);
 
-                    await Task.Delay(delayMs).ConfigureAwait(false);
+                    await Task.Delay(delayMs, cancellationToken).ConfigureAwait(false);
                 }
                 else if (activity.Type == ActivityTypes.Trace)
                 {

--- a/libraries/Microsoft.Bot.Builder/MemoryStorage.cs
+++ b/libraries/Microsoft.Bot.Builder/MemoryStorage.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Bot.Builder
         private readonly JsonSerializer _stateJsonSerializer;
         private readonly Dictionary<string, JObject> _memory;
         private readonly object _syncroot = new object();
-        private int _eTag = 0;
+        private int _eTag;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MemoryStorage"/> class.

--- a/libraries/Microsoft.Bot.Connector.Streaming/Application/StreamingTransportClient.cs
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Application/StreamingTransportClient.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Bot.Connector.Streaming.Application
         private StreamingSession _session;
 
         private CancellationTokenSource _disconnectCts;
-        private volatile bool _disposed = false;
+        private volatile bool _disposed;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="StreamingTransportClient"/> class.
@@ -55,7 +55,7 @@ namespace Microsoft.Bot.Connector.Streaming.Application
         public event DisconnectedEventHandler Disconnected;
 
         /// <inheritdoc />
-        public bool IsConnected { get; private set; } = false;
+        public bool IsConnected { get; private set; }
 
         /// <summary>
         /// Gets the <see cref="ILogger"/> instance for the streaming client.

--- a/libraries/Microsoft.Bot.Connector.Streaming/Transport/TransportHandler.cs
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Transport/TransportHandler.cs
@@ -42,7 +42,9 @@ namespace Microsoft.Bot.Connector.Streaming.Transport
             {
                 ReadResult result;
 
+#pragma warning disable CA2016 // Forward the 'CancellationToken' parameter to methods
                 result = await input.ReadAsync().ConfigureAwait(false);
+#pragma warning restore CA2016 // Forward the 'CancellationToken' parameter to methods
 
                 if (result.IsCanceled)
                 {
@@ -67,7 +69,9 @@ namespace Microsoft.Bot.Connector.Streaming.Transport
                                 {
                                     input.AdvanceTo(buffer.Start, buffer.End);
 
+#pragma warning disable CA2016 // Forward the 'CancellationToken' parameter to methods
                                     result = await input.ReadAsync().ConfigureAwait(false);
+#pragma warning restore CA2016 // Forward the 'CancellationToken' parameter to methods
 
                                     if (result.IsCanceled)
                                     {
@@ -164,7 +168,8 @@ namespace Microsoft.Bot.Connector.Streaming.Transport
 
             await WriteAsync(
                 header: responseHeader,
-                writeFunc: async pipeWriter => await pipeWriter.WriteAsync(responseBytes).ConfigureAwait(false)).ConfigureAwait(false);
+                writeFunc: async pipeWriter => await pipeWriter.WriteAsync(responseBytes).ConfigureAwait(false),
+                cancellationToken).ConfigureAwait(false);
         }
 
         public virtual async Task SendRequestAsync(Guid id, RequestPayload request, CancellationToken cancellationToken)
@@ -186,7 +191,8 @@ namespace Microsoft.Bot.Connector.Streaming.Transport
 
             await WriteAsync(
                 header: requestHeader,
-                writeFunc: async pipeWriter => await pipeWriter.WriteAsync(requestBytes).ConfigureAwait(false)).ConfigureAwait(false);
+                writeFunc: async pipeWriter => await pipeWriter.WriteAsync(requestBytes).ConfigureAwait(false),
+                cancellationToken).ConfigureAwait(false);
         }
 
         public virtual async Task SendStreamAsync(Guid id, Stream stream, CancellationToken cancellationToken)
@@ -212,7 +218,7 @@ namespace Microsoft.Bot.Connector.Streaming.Transport
                     End = true
                 };
 
-                await WriteAsync(streamHeader, pipeWriter => stream.CopyToAsync(pipeWriter)).ConfigureAwait(false);
+                await WriteAsync(streamHeader, pipeWriter => stream.CopyToAsync(pipeWriter), cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -321,7 +327,7 @@ namespace Microsoft.Bot.Connector.Streaming.Transport
                 try
                 {
                     HeaderSerializer.Serialize(header, _sendHeaderBuffer, 0);
-                    await output.WriteAsync(_sendHeaderBuffer).ConfigureAwait(false);
+                    await output.WriteAsync(_sendHeaderBuffer, cancellationToken).ConfigureAwait(false);
                     await writeFunc(output).ConfigureAwait(false);
                 }
                 finally

--- a/libraries/Microsoft.Bot.Connector/Authentication/AuthenticationConfiguration.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AuthenticationConfiguration.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <value>
         /// An <see cref="ClaimsValidator"/> instance used to validate the identity claims.
         /// </value>
-        public virtual ClaimsValidator ClaimsValidator { get; set; } = null;
+        public virtual ClaimsValidator ClaimsValidator { get; set; }
 
         /// <summary>
         /// Gets or sets a collection of valid JWT token issuers.

--- a/libraries/Microsoft.Bot.Connector/Authentication/CertificateAppCredentialsOptions.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/CertificateAppCredentialsOptions.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <value>
         /// ChannelAuthTenant.
         /// </value>
-        public string ChannelAuthTenant { get; set; } = null;
+        public string ChannelAuthTenant { get; set; }
 
         /// <summary>
         /// Gets or sets the OauthScope.
@@ -42,7 +42,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <value>
         /// OauthScope.
         /// </value>
-        public string OauthScope { get; set; } = null;
+        public string OauthScope { get; set; }
 
         /// <summary>
         /// Gets or sets the CustomHttpClient.
@@ -50,7 +50,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <value>
         /// CustomHttpClient.
         /// </value>
-        public HttpClient CustomHttpClient { get; set; } = null;
+        public HttpClient CustomHttpClient { get; set; }
 
         /// <summary>
         /// Gets or sets the Logger.
@@ -58,7 +58,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <value>
         /// Logger.
         /// </value>
-        public ILogger Logger { get; set; } = null;
+        public ILogger Logger { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether this parameter, if true,

--- a/libraries/Microsoft.Bot.Connector/OAuthClientConfig.cs
+++ b/libraries/Microsoft.Bot.Connector/OAuthClientConfig.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Bot.Connector
         /// <value>
         /// When using the Emulator, whether to emulate the OAuthCard behavior or use connected flows.
         /// </value>
-        public static bool EmulateOAuthCards { get; set; } = false;
+        public static bool EmulateOAuthCards { get; set; }
 
         /// <summary>
         /// Send a dummy OAuth card when the bot is being used on the Emulator for testing without fetching a real token.

--- a/libraries/Microsoft.Bot.Connector/OAuthClientOld.cs
+++ b/libraries/Microsoft.Bot.Connector/OAuthClientOld.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Bot.Connector
         /// <value>
         /// When using the Emulator, whether to emulate the OAuthCard behavior or use connected flows.
         /// </value>
-        public static bool EmulateOAuthCards { get; set; } = false;
+        public static bool EmulateOAuthCards { get; set; }
 
         /// <summary>
         /// Gets a user token for a given user and connection.

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Bot.Connector.Teams
             var url = new System.Uri(new System.Uri(baseUrl + (baseUrl.EndsWith("/", System.StringComparison.InvariantCulture) ? string.Empty : "/")), "v3/teams/{teamId}/conversations").ToString();
             url = url.Replace("{teamId}", System.Uri.EscapeDataString(teamId));
 
-            return await GetResponseAsync<ConversationList>(url, shouldTrace, invocationId).ConfigureAwait(false);
+            return await GetResponseAsync<ConversationList>(url, shouldTrace, invocationId, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -151,7 +151,7 @@ namespace Microsoft.Bot.Connector.Teams
             var url = new System.Uri(new System.Uri(baseUrl + (baseUrl.EndsWith("/", System.StringComparison.InvariantCulture) ? string.Empty : "/")), "v3/teams/{teamId}").ToString();
             url = url.Replace("{teamId}", System.Uri.EscapeDataString(teamId));
 
-            return await GetResponseAsync<TeamDetails>(url, shouldTrace, invocationId).ConfigureAwait(false);
+            return await GetResponseAsync<TeamDetails>(url, shouldTrace, invocationId, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -205,7 +205,7 @@ namespace Microsoft.Bot.Connector.Teams
             var url = new System.Uri(new System.Uri(baseUrl + (baseUrl.EndsWith("/", System.StringComparison.InvariantCulture) ? string.Empty : "/")), "v1/meetings/{meetingId}").ToString();
             url = url.Replace("{meetingId}", System.Uri.EscapeDataString(meetingId));
 
-            return await GetResponseAsync<MeetingInfo>(url, shouldTrace, invocationId, customHeaders).ConfigureAwait(false);
+            return await GetResponseAsync<MeetingInfo>(url, shouldTrace, invocationId, customHeaders, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -279,7 +279,7 @@ namespace Microsoft.Bot.Connector.Teams
             url = url.Replace("{participantId}", System.Uri.EscapeDataString(participantId));
             url = url.Replace("{tenantId}", System.Uri.EscapeDataString(tenantId));
 
-            return await GetResponseAsync<TeamsMeetingParticipant>(url, shouldTrace, invocationId).ConfigureAwait(false);
+            return await GetResponseAsync<TeamsMeetingParticipant>(url, shouldTrace, invocationId, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         private async Task<HttpOperationResponse<T>> GetResponseAsync<T>(string url, bool shouldTrace, string invocationId, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/CloudAdapter.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/CloudAdapter.cs
@@ -272,7 +272,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
             private class StreamingConnectorFactory : ConnectorFactory
             {
                 private readonly StreamingRequestHandler _requestHandler;
-                private string _serviceUrl = null;
+                private string _serviceUrl;
 
                 public StreamingConnectorFactory(StreamingRequestHandler requestHandler)
                 {


### PR DESCRIPTION
Addresses # 5276
#minor

> ### **IMPORTANT!**
> **Note:** These changes are being address as part of enabling the [.NET Analyzers](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/overview) library in the [PR # XXX]().

## Description
This PR removes unnecessary initialization, and forwards the `CancellationToken` to methods that take one.

List:
- CA2016
- CA1805

## Specific changes
- Removes unnecessary initialization variables and properties.
- Forwards the `CancellationToken` in methods that take one, from the parent method.
- Disable a few cases where forwarding the `CancellationToken` doesn't work.

## Testing
This image shows the CI pipeline successfully running after the changes.
![imagen](https://user-images.githubusercontent.com/62260472/156584317-04b6aee1-6f9a-4d51-acce-874955716025.png)