### PR TITLE
[#6100] Remove unnecessary partial classes - Schema/Teams classes (1/2)

### DIFF
--- a/libraries/Microsoft.Bot.Schema/Teams/AppBasedLinkQuery.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/AppBasedLinkQuery.cs
@@ -8,16 +8,8 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// Invoke request body type for app-based link query.
     /// </summary>
-    public partial class AppBasedLinkQuery
+    public class AppBasedLinkQuery
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AppBasedLinkQuery"/> class.
-        /// </summary>
-        public AppBasedLinkQuery()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the  <see cref="AppBasedLinkQuery"/> class.
         /// </summary>
@@ -25,7 +17,6 @@ namespace Microsoft.Bot.Schema.Teams
         public AppBasedLinkQuery(string url = default)
         {
             Url = url;
-            CustomInit();
         }
 
         /// <summary>
@@ -43,10 +34,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The state, which is the magic code for OAuth Flow.</value>
         [JsonProperty(PropertyName = "state")]
         public string State { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/CacheInfo.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/CacheInfo.cs
@@ -8,16 +8,8 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// A cache info object which notifies Teams how long an object should be cached for.
     /// </summary>
-    public partial class CacheInfo
+    public class CacheInfo
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CacheInfo"/> class.
-        /// </summary>
-        public CacheInfo()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="CacheInfo"/> class.
         /// </summary>
@@ -27,7 +19,6 @@ namespace Microsoft.Bot.Schema.Teams
         {
             CacheType = cacheType;
             CacheDuration = cacheDuration;
-            CustomInit();
         }
 
         /// <summary>
@@ -43,10 +34,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The time in seconds for which the cached object should remain in the cache.</value>
         [JsonProperty(PropertyName = "cacheDuration")]
         public int CacheDuration { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/ChannelInfo.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/ChannelInfo.cs
@@ -3,22 +3,13 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// A channel info object which describes the channel.
     /// </summary>
-    public partial class ChannelInfo
+    public class ChannelInfo
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ChannelInfo"/> class.
-        /// </summary>
-        public ChannelInfo()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ChannelInfo"/> class.
         /// </summary>
@@ -28,7 +19,6 @@ namespace Microsoft.Bot.Schema.Teams
         {
             Id = id;
             Name = name;
-            CustomInit();
         }
 
         /// <summary>
@@ -44,10 +34,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The channel name.</value>
         [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/ConversationList.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/ConversationList.cs
@@ -11,16 +11,8 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// List of channels under a team.
     /// </summary>
-    public partial class ConversationList
+    public class ConversationList
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ConversationList"/> class.
-        /// </summary>
-        public ConversationList()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ConversationList"/> class.
         /// </summary>
@@ -28,7 +20,6 @@ namespace Microsoft.Bot.Schema.Teams
         public ConversationList(IList<ChannelInfo> conversations = default)
         {
             Conversations = conversations ?? new List<ChannelInfo>();
-            CustomInit();
         }
 
         /// <summary>
@@ -37,10 +28,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The conversations.</value>
         [JsonProperty(PropertyName = "conversations")]
         public IList<ChannelInfo> Conversations { get; private set; } = new List<ChannelInfo>();
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/FileConsentCardResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/FileConsentCardResponse.cs
@@ -10,16 +10,8 @@ namespace Microsoft.Bot.Schema.Teams
     /// Represents the value of the invoke activity sent when the user acts on
     /// a file consent card.
     /// </summary>
-    public partial class FileConsentCardResponse
+    public class FileConsentCardResponse
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="FileConsentCardResponse"/> class.
-        /// </summary>
-        public FileConsentCardResponse()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="FileConsentCardResponse"/> class.
         /// </summary>
@@ -34,7 +26,6 @@ namespace Microsoft.Bot.Schema.Teams
             Action = action;
             Context = context;
             UploadInfo = uploadInfo;
-            CustomInit();
         }
 
         /// <summary>
@@ -59,10 +50,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The information about the file to be uploaded.</value>
         [JsonProperty(PropertyName = "uploadInfo")]
         public FileUploadInfo UploadInfo { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/MeetingDetails.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MeetingDetails.cs
@@ -8,16 +8,8 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// Specific details of a Teams meeting.
     /// </summary>
-    public partial class MeetingDetails : MeetingDetailsBase
+    public class MeetingDetails : MeetingDetailsBase
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MeetingDetails"/> class.
-        /// </summary>
-        public MeetingDetails()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MeetingDetails"/> class.
         /// </summary>
@@ -42,8 +34,6 @@ namespace Microsoft.Bot.Schema.Teams
             ScheduledStartTime = scheduledStartTime;
             ScheduledEndTime = scheduledEndTime;
             Type = type;
-
-            CustomInit();
         }
 
         /// <summary>
@@ -81,10 +71,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// </value>
         [JsonProperty(PropertyName = "type")]
         public string Type { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/MeetingDetailsBase.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MeetingDetailsBase.cs
@@ -8,16 +8,8 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// Specific details of a Teams meeting.
     /// </summary>
-    public partial class MeetingDetailsBase
+    public class MeetingDetailsBase
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MeetingDetailsBase"/> class.
-        /// </summary>
-        internal MeetingDetailsBase()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MeetingDetailsBase"/> class.
         /// </summary>
@@ -32,8 +24,6 @@ namespace Microsoft.Bot.Schema.Teams
             Id = id;
             JoinUrl = joinUrl;
             Title = title;
-
-            CustomInit();
         }
 
         /// <summary>
@@ -62,10 +52,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// </value>
         [JsonProperty(PropertyName = "title")]
         public string Title { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/MeetingEndEventDetails.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MeetingEndEventDetails.cs
@@ -8,16 +8,8 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// Specific details of a Teams meeting end event.
     /// </summary>
-    public partial class MeetingEndEventDetails : MeetingEventDetails
+    public class MeetingEndEventDetails : MeetingEventDetails
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MeetingEndEventDetails"/> class.
-        /// </summary>
-        public MeetingEndEventDetails()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MeetingEndEventDetails"/> class.
         /// </summary>
@@ -35,8 +27,6 @@ namespace Microsoft.Bot.Schema.Teams
             : base(id, joinUrl, title, meetingType)
         {
             EndTime = endTime;
-
-            CustomInit();
         }
 
         /// <summary>
@@ -47,10 +37,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// </value>
         [JsonProperty(PropertyName = "EndTime")]
         public DateTime EndTime { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/MeetingEventDetails.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MeetingEventDetails.cs
@@ -8,16 +8,8 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// Specific details of a Teams meeting.
     /// </summary>
-    public partial class MeetingEventDetails : MeetingDetailsBase
+    public class MeetingEventDetails : MeetingDetailsBase
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MeetingEventDetails"/> class.
-        /// </summary>
-        internal MeetingEventDetails()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MeetingEventDetails"/> class.
         /// </summary>
@@ -33,8 +25,6 @@ namespace Microsoft.Bot.Schema.Teams
             : base(id, joinUrl, title)
         {
             MeetingType = meetingType;
-
-            CustomInit();
         }
 
         /// <summary>
@@ -45,10 +35,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// </value>
         [JsonProperty(PropertyName = "MeetingType")]
         public string MeetingType { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/MeetingInfo.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MeetingInfo.cs
@@ -7,16 +7,8 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// General information about a Teams meeting.
     /// </summary>
-    public partial class MeetingInfo
+    public class MeetingInfo
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MeetingInfo"/> class.
-        /// </summary>
-        public MeetingInfo()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MeetingInfo"/> class.
         /// </summary>
@@ -28,7 +20,6 @@ namespace Microsoft.Bot.Schema.Teams
             Details = details;
             Conversation = conversation;
             Organizer = organizer;
-            CustomInit();
         }
 
         /// <summary>
@@ -57,10 +48,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// </value>
         [JsonProperty(PropertyName = "organizer")]
         public TeamsChannelAccount Organizer { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/MeetingParticipantInfo.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MeetingParticipantInfo.cs
@@ -8,16 +8,8 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// Teams meeting participant details.
     /// </summary>
-    public partial class MeetingParticipantInfo
+    public class MeetingParticipantInfo
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MeetingParticipantInfo"/> class.
-        /// </summary>
-        public MeetingParticipantInfo()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MeetingParticipantInfo"/> class.
         /// </summary>
@@ -27,7 +19,6 @@ namespace Microsoft.Bot.Schema.Teams
         { 
             Role = role;
             InMeeting = inMeeting;
-            CustomInit();
         }
         
         /// <summary>
@@ -47,10 +38,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// </value>
         [JsonProperty(PropertyName = "role")]
         public string Role { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/MeetingStartEventDetails.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MeetingStartEventDetails.cs
@@ -8,16 +8,8 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// Specific details of a Teams meeting start event.
     /// </summary>
-    public partial class MeetingStartEventDetails : MeetingEventDetails
+    public class MeetingStartEventDetails : MeetingEventDetails
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MeetingStartEventDetails"/> class.
-        /// </summary>
-        public MeetingStartEventDetails()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MeetingStartEventDetails"/> class.
         /// </summary>
@@ -35,8 +27,6 @@ namespace Microsoft.Bot.Schema.Teams
             : base(id, joinUrl, title, meetingType)
         {
             StartTime = startTime;
-
-            CustomInit();
         }
 
         /// <summary>
@@ -47,10 +37,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// </value>
         [JsonProperty(PropertyName = "StartTime")]
         public DateTime StartTime { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/MessageActionsPayload.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MessageActionsPayload.cs
@@ -4,25 +4,15 @@
 namespace Microsoft.Bot.Schema.Teams
 {
     using System;
-    using System.Collections;
     using System.Collections.Generic;
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Represents the individual message within a chat or channel where a
     /// message actions is taken.
     /// </summary>
-    public partial class MessageActionsPayload
+    public class MessageActionsPayload
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MessageActionsPayload"/> class.
-        /// </summary>
-        public MessageActionsPayload()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MessageActionsPayload"/> class.
         /// </summary>
@@ -72,7 +62,6 @@ namespace Microsoft.Bot.Schema.Teams
             Attachments = attachments ?? new List<MessageActionsPayloadAttachment>();
             Mentions = mentions ?? new List<MessageActionsPayloadMention>();
             Reactions = reactions ?? new List<MessageActionsPayloadReaction>();
-            CustomInit();
         }
 
         /// <summary>
@@ -197,10 +186,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The link back to the message.</value>
         [JsonProperty(PropertyName = "linkToMessage")]
         public Uri LinkToMessage { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/MessageActionsPayloadApp.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MessageActionsPayloadApp.cs
@@ -3,22 +3,13 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Represents an application entity.
     /// </summary>
-    public partial class MessageActionsPayloadApp
+    public class MessageActionsPayloadApp
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MessageActionsPayloadApp"/> class.
-        /// </summary>
-        public MessageActionsPayloadApp()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MessageActionsPayloadApp"/> class.
         /// </summary>
@@ -33,7 +24,6 @@ namespace Microsoft.Bot.Schema.Teams
             ApplicationIdentityType = applicationIdentityType;
             Id = id;
             DisplayName = displayName;
-            CustomInit();
         }
 
         /// <summary>
@@ -58,10 +48,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The plaintext display name of the application.</value>
         [JsonProperty(PropertyName = "displayName")]
         public string DisplayName { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/MessageActionsPayloadAttachment.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MessageActionsPayloadAttachment.cs
@@ -3,22 +3,13 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Represents the attachment in a message.
     /// </summary>
-    public partial class MessageActionsPayloadAttachment
+    public class MessageActionsPayloadAttachment
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MessageActionsPayloadAttachment"/> class.
-        /// </summary>
-        public MessageActionsPayloadAttachment()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MessageActionsPayloadAttachment"/> class.
         /// </summary>
@@ -40,7 +31,6 @@ namespace Microsoft.Bot.Schema.Teams
             Content = content;
             Name = name;
             ThumbnailUrl = thumbnailUrl;
-            CustomInit();
         }
 
         /// <summary>
@@ -90,10 +80,5 @@ namespace Microsoft.Bot.Schema.Teams
 #pragma warning disable CA1056 // Uri properties should not be strings
         public string ThumbnailUrl { get; set; }
 #pragma warning restore CA1056 // Uri properties should not be strings
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/MessageActionsPayloadBody.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MessageActionsPayloadBody.cs
@@ -3,22 +3,13 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Plaintext/HTML representation of the content of the message.
     /// </summary>
-    public partial class MessageActionsPayloadBody
+    public class MessageActionsPayloadBody
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MessageActionsPayloadBody"/> class.
-        /// </summary>
-        public MessageActionsPayloadBody()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MessageActionsPayloadBody"/> class.
         /// </summary>
@@ -29,7 +20,6 @@ namespace Microsoft.Bot.Schema.Teams
         {
             ContentType = contentType;
             Content = content;
-            CustomInit();
         }
 
         /// <summary>
@@ -46,10 +36,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The content of the body.</value>
         [JsonProperty(PropertyName = "content")]
         public string Content { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/MessageActionsPayloadConversation.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MessageActionsPayloadConversation.cs
@@ -3,22 +3,13 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Represents a team or channel entity.
     /// </summary>
-    public partial class MessageActionsPayloadConversation
+    public class MessageActionsPayloadConversation
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MessageActionsPayloadConversation"/> class.
-        /// </summary>
-        public MessageActionsPayloadConversation()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MessageActionsPayloadConversation"/> class.
         /// </summary>
@@ -33,7 +24,6 @@ namespace Microsoft.Bot.Schema.Teams
             ConversationIdentityType = conversationIdentityType;
             Id = id;
             DisplayName = displayName;
-            CustomInit();
         }
 
         /// <summary>
@@ -58,10 +48,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The plaintext display name of the team or channel.</value>
         [JsonProperty(PropertyName = "displayName")]
         public string DisplayName { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/MessageActionsPayloadFrom.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MessageActionsPayloadFrom.cs
@@ -3,23 +3,14 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Represents a user, application, or conversation type that either sent
     /// or was referenced in a message.
     /// </summary>
-    public partial class MessageActionsPayloadFrom
+    public class MessageActionsPayloadFrom
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MessageActionsPayloadFrom"/> class.
-        /// </summary>
-        public MessageActionsPayloadFrom()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MessageActionsPayloadFrom"/> class.
         /// </summary>
@@ -32,7 +23,6 @@ namespace Microsoft.Bot.Schema.Teams
             User = user;
             Application = application;
             Conversation = conversation;
-            CustomInit();
         }
 
         /// <summary>
@@ -55,10 +45,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The conversation details.</value>
         [JsonProperty(PropertyName = "conversation")]
         public MessageActionsPayloadConversation Conversation { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/MessageActionsPayloadMention.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MessageActionsPayloadMention.cs
@@ -3,22 +3,13 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Represents the entity that was mentioned in the message.
     /// </summary>
-    public partial class MessageActionsPayloadMention
+    public class MessageActionsPayloadMention
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MessageActionsPayloadMention"/> class.
-        /// </summary>
-        public MessageActionsPayloadMention()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MessageActionsPayloadMention"/> class.
         /// </summary>
@@ -32,7 +23,6 @@ namespace Microsoft.Bot.Schema.Teams
             Id = id;
             MentionText = mentionText;
             Mentioned = mentioned;
-            CustomInit();
         }
 
         /// <summary>
@@ -55,10 +45,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>Details of the mentioned entity.</value>
         [JsonProperty(PropertyName = "mentioned")]
         public MessageActionsPayloadFrom Mentioned { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/MessageActionsPayloadReaction.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MessageActionsPayloadReaction.cs
@@ -3,22 +3,13 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Represents the reaction of a user to a message.
     /// </summary>
-    public partial class MessageActionsPayloadReaction
+    public class MessageActionsPayloadReaction
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MessageActionsPayloadReaction"/> class.
-        /// </summary>
-        public MessageActionsPayloadReaction()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MessageActionsPayloadReaction"/> class.
         /// </summary>
@@ -34,7 +25,6 @@ namespace Microsoft.Bot.Schema.Teams
             ReactionType = reactionType;
             CreatedDateTime = createdDateTime;
             User = user;
-            CustomInit();
         }
 
         /// <summary>
@@ -59,10 +49,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The user with which the reaction is associated.</value>
         [JsonProperty(PropertyName = "user")]
         public MessageActionsPayloadFrom User { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/MessageActionsPayloadUser.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MessageActionsPayloadUser.cs
@@ -3,22 +3,13 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Represents a user entity.
     /// </summary>
-    public partial class MessageActionsPayloadUser
+    public class MessageActionsPayloadUser
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MessageActionsPayloadUser"/> class.
-        /// </summary>
-        public MessageActionsPayloadUser()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MessageActionsPayloadUser"/> class.
         /// </summary>
@@ -33,7 +24,6 @@ namespace Microsoft.Bot.Schema.Teams
             UserIdentityType = userIdentityType;
             Id = id;
             DisplayName = displayName;
-            CustomInit();
         }
 
         /// <summary>
@@ -58,10 +48,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The plaintext display name of the user.</value>
         [JsonProperty(PropertyName = "displayName")]
         public string DisplayName { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionAction.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionAction.cs
@@ -9,16 +9,8 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// Messaging extension action.
     /// </summary>
-    public partial class MessagingExtensionAction : TaskModuleRequest
+    public class MessagingExtensionAction : TaskModuleRequest
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MessagingExtensionAction"/> class.
-        /// </summary>
-        public MessagingExtensionAction()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MessagingExtensionAction"/> class.
         /// </summary>
@@ -43,7 +35,6 @@ namespace Microsoft.Bot.Schema.Teams
             BotMessagePreviewAction = botMessagePreviewAction;
             BotActivityPreview = botActivityPreview ?? new List<Activity>();
             MessagePayload = messagePayload;
-            CustomInit();
         }
 
         /// <summary>
@@ -89,10 +80,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The state parameter passed back to the bot after authentication flow.</value>
         [JsonProperty(PropertyName = "state")]
         public string State { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionActionResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionActionResponse.cs
@@ -3,22 +3,13 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Response of messaging extension action.
     /// </summary>
-    public partial class MessagingExtensionActionResponse
+    public class MessagingExtensionActionResponse
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MessagingExtensionActionResponse"/> class.
-        /// </summary>
-        public MessagingExtensionActionResponse()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MessagingExtensionActionResponse"/> class.
         /// </summary>
@@ -29,7 +20,6 @@ namespace Microsoft.Bot.Schema.Teams
         {
             Task = task;
             ComposeExtension = composeExtension;
-            CustomInit();
         }
 
         /// <summary>
@@ -53,10 +43,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The <see cref="CacheInfo "/> for this <see cref="MessagingExtensionActionResponse"/>.</value>
         [JsonProperty(PropertyName = "cacheInfo")]
         public CacheInfo CacheInfo { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionAttachment.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionAttachment.cs
@@ -3,22 +3,13 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Messaging extension attachment.
     /// </summary>
-    public partial class MessagingExtensionAttachment : Attachment
+    public class MessagingExtensionAttachment : Attachment
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MessagingExtensionAttachment"/> class.
-        /// </summary>
-        public MessagingExtensionAttachment()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MessagingExtensionAttachment"/> class.
         /// </summary>
@@ -32,7 +23,6 @@ namespace Microsoft.Bot.Schema.Teams
             : base(contentType, contentUrl, content, name, thumbnailUrl)
         {
             Preview = preview;
-            CustomInit();
         }
 
         /// <summary>
@@ -41,10 +31,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The preview.</value>
         [JsonProperty(PropertyName = "preview")]
         public Attachment Preview { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionParameter.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionParameter.cs
@@ -8,16 +8,8 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// Messaging extension query parameters.
     /// </summary>
-    public partial class MessagingExtensionParameter
+    public class MessagingExtensionParameter
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MessagingExtensionParameter"/> class.
-        /// </summary>
-        public MessagingExtensionParameter()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MessagingExtensionParameter"/> class.
         /// </summary>
@@ -27,7 +19,6 @@ namespace Microsoft.Bot.Schema.Teams
         {
             Name = name;
             Value = value;
-            CustomInit();
         }
 
         /// <summary>
@@ -43,10 +34,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The value of the parameter.</value>
         [JsonProperty(PropertyName = "value")]
         public object Value { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionQuery.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionQuery.cs
@@ -3,24 +3,14 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Collections;
     using System.Collections.Generic;
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Messaging extension query.
     /// </summary>
-    public partial class MessagingExtensionQuery
+    public class MessagingExtensionQuery
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MessagingExtensionQuery"/> class.
-        /// </summary>
-        public MessagingExtensionQuery()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MessagingExtensionQuery"/> class.
         /// </summary>
@@ -34,7 +24,6 @@ namespace Microsoft.Bot.Schema.Teams
             Parameters = parameters ?? new List<MessagingExtensionParameter>();
             QueryOptions = queryOptions;
             State = state;
-            CustomInit();
         }
 
         /// <summary>
@@ -65,10 +54,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The state parameter passed back to the bot after authentication/configuration flow.</value>
         [JsonProperty(PropertyName = "state")]
         public string State { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionQueryOptions.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionQueryOptions.cs
@@ -3,22 +3,13 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Messaging extension query options.
     /// </summary>
-    public partial class MessagingExtensionQueryOptions
+    public class MessagingExtensionQueryOptions
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MessagingExtensionQueryOptions"/> class.
-        /// </summary>
-        public MessagingExtensionQueryOptions()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MessagingExtensionQueryOptions"/> class.
         /// </summary>
@@ -28,7 +19,6 @@ namespace Microsoft.Bot.Schema.Teams
         {
             Skip = skip;
             Count = count;
-            CustomInit();
         }
 
         /// <summary>
@@ -44,10 +34,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The number of entities to fetch.</value>
         [JsonProperty(PropertyName = "count")]
         public int? Count { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionResponse.cs
@@ -3,22 +3,13 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Messaging extension response.
     /// </summary>
-    public partial class MessagingExtensionResponse
+    public class MessagingExtensionResponse
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MessagingExtensionResponse"/> class.
-        /// </summary>
-        public MessagingExtensionResponse()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MessagingExtensionResponse"/> class.
         /// </summary>
@@ -26,7 +17,6 @@ namespace Microsoft.Bot.Schema.Teams
         public MessagingExtensionResponse(MessagingExtensionResult composeExtension = default)
         {
             ComposeExtension = composeExtension;
-            CustomInit();
         }
 
         /// <summary>
@@ -43,10 +33,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The <see cref="CacheInfo"/> for this <see cref="MessagingExtensionResponse"/>.</value>
         [JsonProperty(PropertyName = "cacheInfo")]
         public CacheInfo CacheInfo { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionResult.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionResult.cs
@@ -3,24 +3,14 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Collections;
     using System.Collections.Generic;
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Messaging extension result.
     /// </summary>
-    public partial class MessagingExtensionResult
+    public class MessagingExtensionResult
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MessagingExtensionResult"/> class.
-        /// </summary>
-        public MessagingExtensionResult()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MessagingExtensionResult"/> class.
         /// </summary>
@@ -41,7 +31,6 @@ namespace Microsoft.Bot.Schema.Teams
             SuggestedActions = suggestedActions;
             Text = text;
             ActivityPreview = activityPreview;
-            CustomInit();
         }
 
         /// <summary>
@@ -88,10 +77,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The message activity to preview.</value>
         [JsonProperty(PropertyName = "activityPreview")]
         public Activity ActivityPreview { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionSuggestedAction.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionSuggestedAction.cs
@@ -9,16 +9,8 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// Messaging extension Actions (Only when type is auth or config).
     /// </summary>
-    public partial class MessagingExtensionSuggestedAction
+    public class MessagingExtensionSuggestedAction
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MessagingExtensionSuggestedAction"/> class.
-        /// </summary>
-        public MessagingExtensionSuggestedAction()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MessagingExtensionSuggestedAction"/> class.
         /// </summary>
@@ -26,7 +18,6 @@ namespace Microsoft.Bot.Schema.Teams
         public MessagingExtensionSuggestedAction(IList<CardAction> actions = default)
         {
             Actions = actions ?? new List<CardAction>();
-            CustomInit();
         }
 
         /// <summary>
@@ -35,10 +26,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The actions.</value>
         [JsonProperty(PropertyName = "actions")]
         public IList<CardAction> Actions { get; private set; } = new List<CardAction>();
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }


### PR DESCRIPTION
Addresses # 6100
#minor

## Description
This PR removes the `partial` modifier from classes with only one definition in **_Microsoft.Bot.Schema/Teams_**.

## Specific Changes
  - Removed the `partial` modifier from classes with only one definition.
  - Removed partial method `CustomInit` and the constructor that was using it.
  - Removed unnecessary using statements.

## Testing
This image shows the tests passing after the changes.
![image](https://user-images.githubusercontent.com/44245136/156618795-ba85f68b-70d8-4e82-8f7a-cab3057db9bb.png)