### PR TITLE
[#6100] Remove unnecessary partial classes - Consolidate Cards

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Extensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Extensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Bot.Builder.Dialogs
     /// <summary>
     /// Extension method on object <see cref="object"/>.
     /// </summary>
-    internal static partial class Extensions
+    internal static class Extensions
     {
         /// <summary>
         /// Extension Method on object to cast to type T to support TypeNameHandling.None during storage serialization.

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Bot.Builder.Dialogs
 
                     prompt.Attachments.Add(new Attachment
                     {
-                        ContentType = SigninCard.ContentType,
+                        ContentType = ContentTypes.SigninCard,
                         Content = new SigninCard(buttons: buttons)
                         {
                             Text = settings.Text,
@@ -169,7 +169,7 @@ namespace Microsoft.Bot.Builder.Dialogs
 
                 prompt.Attachments.Add(new Attachment
                 {
-                    ContentType = OAuthCard.ContentType,
+                    ContentType = ContentTypes.OAuthCard,
                     Content = new OAuthCard(buttons: buttons)
                     {
                         Text = settings.Text,

--- a/libraries/Microsoft.Bot.Builder.Dialogs/SkillDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/SkillDialog.cs
@@ -317,7 +317,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                 return false;
             }
 
-            var oauthCardAttachment = activity.Attachments?.FirstOrDefault(a => a?.ContentType == OAuthCard.ContentType);
+            var oauthCardAttachment = activity.Attachments?.FirstOrDefault(a => a?.ContentType == ContentTypes.OAuthCard);
             if (oauthCardAttachment != null)
             {
                 var oauthCard = ((JObject)oauthCardAttachment.Content).ToObject<OAuthCard>();

--- a/libraries/Microsoft.Bot.Builder/ActivityFactory.cs
+++ b/libraries/Microsoft.Bot.Builder/ActivityFactory.cs
@@ -19,14 +19,14 @@ namespace Microsoft.Bot.Builder
 
         private static readonly Dictionary<string, string> GenericCardTypeMapping = new Dictionary<string, string>
         {
-            { nameof(HeroCard).ToLowerInvariant(), HeroCard.ContentType },
-            { nameof(ThumbnailCard).ToLowerInvariant(), ThumbnailCard.ContentType },
-            { nameof(AudioCard).ToLowerInvariant(), AudioCard.ContentType },
-            { nameof(VideoCard).ToLowerInvariant(), VideoCard.ContentType },
-            { nameof(AnimationCard).ToLowerInvariant(), AnimationCard.ContentType },
-            { nameof(SigninCard).ToLowerInvariant(), SigninCard.ContentType },
-            { nameof(OAuthCard).ToLowerInvariant(), OAuthCard.ContentType },
-            { nameof(ReceiptCard).ToLowerInvariant(), ReceiptCard.ContentType },
+            { nameof(HeroCard).ToLowerInvariant(), ContentTypes.HeroCard },
+            { nameof(ThumbnailCard).ToLowerInvariant(), ContentTypes.ThumbnailCard },
+            { nameof(AudioCard).ToLowerInvariant(), ContentTypes.AudioCard },
+            { nameof(VideoCard).ToLowerInvariant(), ContentTypes.VideoCard },
+            { nameof(AnimationCard).ToLowerInvariant(), ContentTypes.AnimationCard },
+            { nameof(SigninCard).ToLowerInvariant(), ContentTypes.SigninCard },
+            { nameof(OAuthCard).ToLowerInvariant(), ContentTypes.OAuthCard },
+            { nameof(ReceiptCard).ToLowerInvariant(), ContentTypes.ReceiptCard },
         };
 
         /// <summary>
@@ -284,7 +284,7 @@ namespace Microsoft.Bot.Builder
 
                     case "image":
                     case "images":
-                        if (type == HeroCard.ContentType || type == ThumbnailCard.ContentType)
+                        if (type == ContentTypes.HeroCard || type == ContentTypes.ThumbnailCard)
                         {
                             // then it's images
                             if (card["images"] == null)

--- a/libraries/Microsoft.Bot.Schema/AnimationCard.cs
+++ b/libraries/Microsoft.Bot.Schema/AnimationCard.cs
@@ -9,16 +9,8 @@ namespace Microsoft.Bot.Schema
     /// <summary>
     /// An animation card (Ex: gif or short video clip).
     /// </summary>
-    public partial class AnimationCard
+    public class AnimationCard
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AnimationCard"/> class.
-        /// </summary>
-        public AnimationCard()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="AnimationCard"/> class.
         /// </summary>
@@ -56,7 +48,6 @@ namespace Microsoft.Bot.Schema
             Aspect = aspect;
             Duration = duration;
             Value = value;
-            CustomInit();
         }
 
         /// <summary>
@@ -149,10 +140,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The supplementary parameter for this card.</value>
         [JsonProperty(PropertyName = "value")]
         public object Value { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/AudioCard.cs
+++ b/libraries/Microsoft.Bot.Schema/AudioCard.cs
@@ -7,14 +7,8 @@ namespace Microsoft.Bot.Schema
     using Newtonsoft.Json;
 
     /// <summary>Audio card.</summary>
-    public partial class AudioCard
+    public class AudioCard
     {
-        /// <summary>Initializes a new instance of the <see cref="AudioCard"/> class.</summary>
-        public AudioCard()
-        {
-            CustomInit();
-        }
-
         /// <summary>Initializes a new instance of the <see cref="AudioCard"/> class.</summary>
         /// <param name="title">Title of this card.</param>
         /// <param name="subtitle">Subtitle of this card.</param>
@@ -46,7 +40,6 @@ namespace Microsoft.Bot.Schema
             Aspect = aspect;
             Duration = duration;
             Value = value;
-            CustomInit();
         }
 
         /// <summary>
@@ -139,8 +132,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The supplementary parameter for this card.</value>
         [JsonProperty(PropertyName = "value")]
         public object Value { get; set; }
-
-        /// <summary>An initialization method that performs custom operations like setting defaults.</summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/BasicCard.cs
+++ b/libraries/Microsoft.Bot.Schema/BasicCard.cs
@@ -3,20 +3,12 @@
 
 namespace Microsoft.Bot.Schema
 {
-    using System.Collections;
     using System.Collections.Generic;
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary> A basic card.</summary>
-    public partial class BasicCard
+    public class BasicCard
     {
-        /// <summary>Initializes a new instance of the <see cref="BasicCard"/> class.</summary>
-        public BasicCard()
-        {
-            CustomInit();
-        }
-
         /// <summary>Initializes a new instance of the <see cref="BasicCard"/> class.</summary>
         /// <param name="title">Title of the card.</param>
         /// <param name="subtitle">Subtitle of the card.</param>
@@ -32,7 +24,6 @@ namespace Microsoft.Bot.Schema
             Images = images ?? new List<CardImage>();
             Buttons = buttons ?? new List<CardAction>();
             Tap = tap;
-            CustomInit();
         }
 
         /// <summary>Gets or sets title of the card.</summary>
@@ -64,8 +55,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The action that will activate when user taps card.</value>
         [JsonProperty(PropertyName = "tap")]
         public CardAction Tap { get; set; }
-
-        /// <summary>An initialization method that performs custom operations like setting defaults.</summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/CardEx.cs
+++ b/libraries/Microsoft.Bot.Schema/CardEx.cs
@@ -4,9 +4,9 @@
 namespace Microsoft.Bot.Schema
 {
     /// <summary>
-    /// Extension methods for converting strongly typed Card objects to <see cref="Attachment"/>.
+    /// Extension methods for Cards.
     /// </summary>
-    public static partial class Extensions
+    public static class CardEx
     {
         /// <summary>
         /// Creates a new attachment from <see cref="HeroCard"/>.

--- a/libraries/Microsoft.Bot.Schema/CardEx.cs
+++ b/libraries/Microsoft.Bot.Schema/CardEx.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Bot.Schema
         /// <returns> The generated attachment.</returns>
         public static Attachment ToAttachment(this HeroCard card)
         {
-            return CreateAttachment(card, HeroCard.ContentType);
+            return CreateAttachment(card, ContentTypes.HeroCard);
         }
 
         /// <summary>
@@ -25,7 +25,7 @@ namespace Microsoft.Bot.Schema
         /// <returns> The generated attachment.</returns>
         public static Attachment ToAttachment(this ThumbnailCard card)
         {
-            return CreateAttachment(card, ThumbnailCard.ContentType);
+            return CreateAttachment(card, ContentTypes.ThumbnailCard);
         }
 
         /// <summary>
@@ -35,7 +35,7 @@ namespace Microsoft.Bot.Schema
         /// <returns> The generated attachment.</returns>
         public static Attachment ToAttachment(this SigninCard card)
         {
-            return CreateAttachment(card, SigninCard.ContentType);
+            return CreateAttachment(card, ContentTypes.SigninCard);
         }
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace Microsoft.Bot.Schema
         /// <returns> The generated attachment.</returns>
         public static Attachment ToAttachment(this ReceiptCard card)
         {
-            return CreateAttachment(card, ReceiptCard.ContentType);
+            return CreateAttachment(card, ContentTypes.ReceiptCard);
         }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Microsoft.Bot.Schema
         /// <returns> The generated attachment.</returns>
         public static Attachment ToAttachment(this AudioCard card)
         {
-            return CreateAttachment(card, AudioCard.ContentType);
+            return CreateAttachment(card, ContentTypes.AudioCard);
         }
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace Microsoft.Bot.Schema
         /// <returns> The generated attachment.</returns>
         public static Attachment ToAttachment(this VideoCard card)
         {
-            return CreateAttachment(card, VideoCard.ContentType);
+            return CreateAttachment(card, ContentTypes.VideoCard);
         }
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace Microsoft.Bot.Schema
         /// <returns> The generated attachment.</returns>
         public static Attachment ToAttachment(this AnimationCard card)
         {
-            return CreateAttachment(card, AnimationCard.ContentType);
+            return CreateAttachment(card, ContentTypes.AnimationCard);
         }
 
         /// <summary>
@@ -85,7 +85,7 @@ namespace Microsoft.Bot.Schema
         /// <returns> The generated attachment.</returns>
         public static Attachment ToAttachment(this OAuthCard card)
         {
-            return CreateAttachment(card, OAuthCard.ContentType);
+            return CreateAttachment(card, ContentTypes.OAuthCard);
         }
 
         private static Attachment CreateAttachment<T>(T card, string contentType)

--- a/libraries/Microsoft.Bot.Schema/CardImage.cs
+++ b/libraries/Microsoft.Bot.Schema/CardImage.cs
@@ -3,18 +3,11 @@
 
 namespace Microsoft.Bot.Schema
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>An image on a card.</summary>
-    public partial class CardImage
+    public class CardImage
     {
-        /// <summary>Initializes a new instance of the <see cref="CardImage"/> class.</summary>
-        public CardImage()
-        {
-            CustomInit();
-        }
-
         /// <summary>Initializes a new instance of the <see cref="CardImage"/> class.</summary>
         /// <param name="url">URL thumbnail image for major content property.</param>
         /// <param name="alt">Image description intended for screen readers.</param>
@@ -24,7 +17,6 @@ namespace Microsoft.Bot.Schema
             Url = url;
             Alt = alt;
             Tap = tap;
-            CustomInit();
         }
 
         /// <summary>Gets or sets URL thumbnail image for major content property.</summary>
@@ -43,8 +35,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The action assigned to the specific attachment.</value>
         [JsonProperty(PropertyName = "tap")]
         public CardAction Tap { get; set; }
-
-        /// <summary>An initialization method that performs custom operations like setting defaults.</summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/ContentTypes.cs
+++ b/libraries/Microsoft.Bot.Schema/ContentTypes.cs
@@ -1,103 +1,51 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace Microsoft.Bot.Schema
 {
     /// <summary>
-    /// ThumbnailCard ContentType value.
+    /// Defines values for Cards' ContentTypes.
     /// </summary>
-    [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1402: Maintainability Rules : File may only contain a single type.", Justification = "The card partial classes should be place in the same file to keep the readability of the code.")]
-    public partial class ThumbnailCard
+    public static class ContentTypes
     {
         /// <summary>
         /// The content type value of a <see cref="ThumbnailCard"/>.
         /// </summary>
-        public const string ContentType = "application/vnd.microsoft.card.thumbnail";
-    }
+        public const string ThumbnailCard = "application/vnd.microsoft.card.thumbnail";
 
-    /// <summary>
-    /// HeroCard ContentType value.
-    /// </summary>
-    [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1402: Maintainability Rules : File may only contain a single type.", Justification = "The card partial classes should be place in the same file to keep the readability of the code.")]
-    public partial class HeroCard
-    {
         /// <summary>
         /// The content type value of a <see cref="HeroCard"/>.
         /// </summary>
-        public const string ContentType = "application/vnd.microsoft.card.hero";
-    }
+        public const string HeroCard = "application/vnd.microsoft.card.hero";
 
-    /// <summary>
-    /// ReceiptCard ContentType value.
-    /// </summary>
-    [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1402: Maintainability Rules : File may only contain a single type.", Justification = "The card partial classes should be place in the same file to keep the readability of the code.")]
-    public partial class ReceiptCard
-    {
         /// <summary>
         /// The content type value of a <see cref="ReceiptCard"/>.
         /// </summary>
-        public const string ContentType = "application/vnd.microsoft.card.receipt";
-    }
+        public const string ReceiptCard = "application/vnd.microsoft.card.receipt";
 
-    /// <summary>
-    /// SigninCard ContentType value.
-    /// </summary>
-    [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1402: Maintainability Rules : File may only contain a single type.", Justification = "The card partial classes should be place in the same file to keep the readability of the code.")]
-    public partial class SigninCard
-    {
         /// <summary>
         /// The content type value of a <see cref="SigninCard"/>.
         /// </summary>
-        public const string ContentType = "application/vnd.microsoft.card.signin";
-    }
+        public const string SigninCard = "application/vnd.microsoft.card.signin";
 
-    /// <summary>
-    /// AnimationCard ContentType value.
-    /// </summary>
-    [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1402: Maintainability Rules : File may only contain a single type.", Justification = "The card partial classes should be place in the same file to keep the readability of the code.")]
-    public partial class AnimationCard
-    {
         /// <summary>
         /// The content type value of a <see cref="AnimationCard"/>.
         /// </summary>
-        public const string ContentType = "application/vnd.microsoft.card.animation";
-    }
+        public const string AnimationCard = "application/vnd.microsoft.card.animation";
 
-    /// <summary>
-    /// AudioCard ContentType value.
-    /// </summary>
-    [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1402: Maintainability Rules : File may only contain a single type.", Justification = "The card partial classes should be place in the same file to keep the readability of the code.")]
-    public partial class AudioCard
-    {
         /// <summary>
         /// The content type value of a <see cref="AudioCard"/>.
         /// </summary>
-        public const string ContentType = "application/vnd.microsoft.card.audio";
-    }
+        public const string AudioCard = "application/vnd.microsoft.card.audio";
 
-    /// <summary>
-    /// VideoCard ContentType value.
-    /// </summary>
-    [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1402: Maintainability Rules : File may only contain a single type.", Justification = "The card partial classes should be place in the same file to keep the readability of the code.")]
-    public partial class VideoCard
-    {
         /// <summary>
         /// The content type value of a <see cref="VideoCard"/>.
         /// </summary>
-        public const string ContentType = "application/vnd.microsoft.card.video";
-    }
+        public const string VideoCard = "application/vnd.microsoft.card.video";
 
-    /// <summary>
-    /// OAuthCard ContentType value.
-    /// </summary>
-    [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1402: Maintainability Rules : File may only contain a single type.", Justification = "The card partial classes should be place in the same file to keep the readability of the code.")]
-    public partial class OAuthCard
-    {
         /// <summary>
         /// The content type value of a <see cref="OAuthCard"/>.
         /// </summary>
-        public const string ContentType = "application/vnd.microsoft.card.oauth";
+        public const string OAuthCard = "application/vnd.microsoft.card.oauth";
     }
 }

--- a/libraries/Microsoft.Bot.Schema/HeroCard.cs
+++ b/libraries/Microsoft.Bot.Schema/HeroCard.cs
@@ -9,16 +9,8 @@ namespace Microsoft.Bot.Schema
     /// <summary>
     /// A Hero card (card with a single, large image).
     /// </summary>
-    public partial class HeroCard
+    public class HeroCard
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="HeroCard"/> class.
-        /// </summary>
-        public HeroCard()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="HeroCard"/> class.
         /// </summary>
@@ -38,7 +30,6 @@ namespace Microsoft.Bot.Schema
             Images = images ?? new List<CardImage>();
             Buttons = buttons ?? new List<CardAction>();
             Tap = tap;
-            CustomInit();
         }
 
         /// <summary>
@@ -83,10 +74,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The action that willl be activated when user taps on the card itself.</value>
         [JsonProperty(PropertyName = "tap")]
         public CardAction Tap { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/OAuthCard.cs
+++ b/libraries/Microsoft.Bot.Schema/OAuthCard.cs
@@ -3,24 +3,14 @@
 
 namespace Microsoft.Bot.Schema
 {
-    using System.Collections;
     using System.Collections.Generic;
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// A card representing a request to perform a sign in via OAuth.
     /// </summary>
-    public partial class OAuthCard
+    public class OAuthCard
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="OAuthCard"/> class.
-        /// </summary>
-        public OAuthCard()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="OAuthCard"/> class.
         /// </summary>
@@ -33,7 +23,6 @@ namespace Microsoft.Bot.Schema
             Text = text;
             ConnectionName = connectionName;
             Buttons = buttons ?? new List<CardAction>();
-            CustomInit();
         }
 
         /// <summary>
@@ -63,10 +52,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The actions used to perform sign-in.</value>
         [JsonProperty(PropertyName = "buttons")]
         public IList<CardAction> Buttons { get; private set; } = new List<CardAction>();
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/ReceiptCard.cs
+++ b/libraries/Microsoft.Bot.Schema/ReceiptCard.cs
@@ -9,16 +9,8 @@ namespace Microsoft.Bot.Schema
     /// <summary>
     /// A receipt card.
     /// </summary>
-    public partial class ReceiptCard
+    public class ReceiptCard
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ReceiptCard"/> class.
-        /// </summary>
-        public ReceiptCard()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ReceiptCard"/> class.
         /// </summary>
@@ -43,7 +35,6 @@ namespace Microsoft.Bot.Schema
             Tax = tax;
             Vat = vat;
             Buttons = buttons ?? new List<CardAction>();
-            CustomInit();
         }
 
         /// <summary>
@@ -102,10 +93,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The actions applicable to the current card.</value>
         [JsonProperty(PropertyName = "buttons")]
         public IList<CardAction> Buttons { get; private set; } = new List<CardAction>();
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/SigninCard.cs
+++ b/libraries/Microsoft.Bot.Schema/SigninCard.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Bot.Schema
     /// <summary>
     /// A card representing a request to sign in.
     /// </summary>
-    public partial class SigninCard
+    public class SigninCard
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SigninCard"/> class.

--- a/libraries/Microsoft.Bot.Schema/ThumbnailCard.cs
+++ b/libraries/Microsoft.Bot.Schema/ThumbnailCard.cs
@@ -3,24 +3,14 @@
 
 namespace Microsoft.Bot.Schema
 {
-    using System.Collections;
     using System.Collections.Generic;
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// A thumbnail card (card with a single, small thumbnail image).
     /// </summary>
-    public partial class ThumbnailCard
+    public class ThumbnailCard
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ThumbnailCard"/> class.
-        /// </summary>
-        public ThumbnailCard()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ThumbnailCard"/> class.
         /// </summary>
@@ -40,7 +30,6 @@ namespace Microsoft.Bot.Schema
             Images = images ?? new List<CardImage>();
             Buttons = buttons ?? new List<CardAction>();
             Tap = tap;
-            CustomInit();
         }
 
         /// <summary>
@@ -85,10 +74,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The action that activates when the user taps on the card itself.</value>
         [JsonProperty(PropertyName = "tap")]
         public CardAction Tap { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/VideoCard.cs
+++ b/libraries/Microsoft.Bot.Schema/VideoCard.cs
@@ -9,16 +9,8 @@ namespace Microsoft.Bot.Schema
     /// <summary>
     /// Video card.
     /// </summary>
-    public partial class VideoCard
+    public class VideoCard
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="VideoCard"/> class.
-        /// </summary>
-        public VideoCard()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="VideoCard"/> class.
         /// </summary>
@@ -56,7 +48,6 @@ namespace Microsoft.Bot.Schema
             Aspect = aspect;
             Duration = duration;
             Value = value;
-            CustomInit();
         }
 
         /// <summary>
@@ -149,10 +140,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The supplementary parameter for this card.</value>
         [JsonProperty(PropertyName = "value")]
         public object Value { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/testbots/Skills/Parent/ParentBot.cs
+++ b/testbots/Skills/Parent/ParentBot.cs
@@ -139,7 +139,7 @@ namespace Microsoft.BotBuilderSamples
             var activity = activities[0];
             if (activity.Attachments != null)
             {
-                foreach (var attachment in activity.Attachments.Where(a => a?.ContentType == OAuthCard.ContentType))
+                foreach (var attachment in activity.Attachments.Where(a => a?.ContentType == ContentTypes.OAuthCard))
                 {
                     var oauthCard = ((JObject)attachment.Content).ToObject<OAuthCard>();
                     if (oauthCard.TokenExchangeResource != null)

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/CloudOAuthPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/CloudOAuthPromptTests.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.Single(sentActivity.Attachments);
 
             var sentActivityAttachment = sentActivity.Attachments.First();
-            Assert.Equal(OAuthCard.ContentType, sentActivityAttachment.ContentType);
+            Assert.Equal(ContentTypes.OAuthCard, sentActivityAttachment.ContentType);
             Assert.IsType<OAuthCard>(sentActivityAttachment.Content);
 
             // TODO: complete verification of shape of outbound attachment
@@ -272,7 +272,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.Single(sentActivity.Attachments);
 
             var sentActivityAttachment = sentActivity.Attachments.First();
-            Assert.Equal(SigninCard.ContentType, sentActivityAttachment.ContentType);
+            Assert.Equal(ContentTypes.SigninCard, sentActivityAttachment.ContentType);
             Assert.IsType<SigninCard>(sentActivityAttachment.Content);
 
             // TODO: complete verification of shape of outbound attachment

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/OAuthPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/OAuthPromptTests.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .AssertReply(activity =>
             {
                 Assert.Single(((Activity)activity).Attachments);
-                Assert.Equal(OAuthCard.ContentType, ((Activity)activity).Attachments[0].ContentType);
+                Assert.Equal(ContentTypes.OAuthCard, ((Activity)activity).Attachments[0].ContentType);
 
                 Assert.Equal(InputHints.AcceptingInput, ((Activity)activity).InputHint);
 
@@ -262,7 +262,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .AssertReply(activity =>
             {
                 Assert.Single(((Activity)activity).Attachments);
-                Assert.Equal(OAuthCard.ContentType, ((Activity)activity).Attachments[0].ContentType);
+                Assert.Equal(ContentTypes.OAuthCard, ((Activity)activity).Attachments[0].ContentType);
 
                 Assert.Equal(InputHints.AcceptingInput, ((Activity)activity).InputHint);
             })
@@ -309,7 +309,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .AssertReply(activity =>
             {
                 Assert.Single(((Activity)activity).Attachments);
-                Assert.Equal(OAuthCard.ContentType, ((Activity)activity).Attachments[0].ContentType);
+                Assert.Equal(ContentTypes.OAuthCard, ((Activity)activity).Attachments[0].ContentType);
                 Assert.Equal(InputHints.AcceptingInput, ((Activity)activity).InputHint);
 
                 // Add an exchangable token to the adapter
@@ -379,7 +379,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .AssertReply(activity =>
             {
                 Assert.Single(((Activity)activity).Attachments);
-                Assert.Equal(OAuthCard.ContentType, ((Activity)activity).Attachments[0].ContentType);
+                Assert.Equal(ContentTypes.OAuthCard, ((Activity)activity).Attachments[0].ContentType);
                 Assert.Equal(InputHints.AcceptingInput, ((Activity)activity).InputHint);
 
                 // No exchangable token is added to the adapter
@@ -447,7 +447,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .AssertReply(activity =>
             {
                 Assert.Single(((Activity)activity).Attachments);
-                Assert.Equal(OAuthCard.ContentType, ((Activity)activity).Attachments[0].ContentType);
+                Assert.Equal(ContentTypes.OAuthCard, ((Activity)activity).Attachments[0].ContentType);
                 Assert.Equal(InputHints.AcceptingInput, ((Activity)activity).InputHint);
 
                 // No exchangable token is added to the adapter
@@ -512,7 +512,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .AssertReply(activity =>
             {
                 Assert.Single(((Activity)activity).Attachments);
-                Assert.Equal(OAuthCard.ContentType, ((Activity)activity).Attachments[0].ContentType);
+                Assert.Equal(ContentTypes.OAuthCard, ((Activity)activity).Attachments[0].ContentType);
                 Assert.Equal(InputHints.AcceptingInput, ((Activity)activity).InputHint);
 
                 // No exchangable token is added to the adapter
@@ -575,7 +575,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 .AssertReply(activity =>
                 {
                     Assert.Single(((Activity)activity).Attachments);
-                    Assert.Equal(SigninCard.ContentType, ((Activity)activity).Attachments[0].ContentType);
+                    Assert.Equal(ContentTypes.SigninCard, ((Activity)activity).Attachments[0].ContentType);
                 })
                 .StartTestAsync();
         }
@@ -623,7 +623,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 .AssertReply(activity => 
                 { 
                     Assert.Single(((Activity)activity).Attachments); 
-                    Assert.Equal(OAuthCard.ContentType, ((Activity)activity).Attachments[0].ContentType); 
+                    Assert.Equal(ContentTypes.OAuthCard, ((Activity)activity).Attachments[0].ContentType); 
                     var oAuthCard = (OAuthCard)((Activity)activity).Attachments[0].Content; 
                     var cardAction = oAuthCard.Buttons[0];
                     Assert.Equal(shouldHaveSignInLink, cardAction.Value != null);
@@ -702,7 +702,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .AssertReply(activity =>
             {
                 Assert.Single(((Activity)activity).Attachments);
-                Assert.Equal(OAuthCard.ContentType, ((Activity)activity).Attachments[0].ContentType);
+                Assert.Equal(ContentTypes.OAuthCard, ((Activity)activity).Attachments[0].ContentType);
                 Assert.Equal(InputHints.AcceptingInput, ((Activity)activity).InputHint);
             })
             .Send(messageActivityWithNullText)
@@ -754,7 +754,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .AssertReply(activity =>
             {
                 Assert.Single(((Activity)activity).Attachments);
-                Assert.Equal(OAuthCard.ContentType, ((Activity)activity).Attachments[0].ContentType);
+                Assert.Equal(ContentTypes.OAuthCard, ((Activity)activity).Attachments[0].ContentType);
             })
             .Send("blah")
             .AssertReply("Ended.")
@@ -831,7 +831,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .AssertReply(activity =>
             {
                 Assert.Single(((Activity)activity).Attachments);
-                Assert.Equal(OAuthCard.ContentType, ((Activity)activity).Attachments[0].ContentType);
+                Assert.Equal(ContentTypes.OAuthCard, ((Activity)activity).Attachments[0].ContentType);
 
                 Assert.Equal(InputHints.AcceptingInput, ((Activity)activity).InputHint);
 
@@ -886,7 +886,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .AssertReply(activity =>
             {
                 Assert.Single(((Activity)activity).Attachments);
-                Assert.Equal(OAuthCard.ContentType, ((Activity)activity).Attachments[0].ContentType);
+                Assert.Equal(ContentTypes.OAuthCard, ((Activity)activity).Attachments[0].ContentType);
 
                 // Add a magic code to the adapter
                 adapter.AddUserToken(ConnectionName, activity.ChannelId, activity.Recipient.Id, Token, MagicCode);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/SkillDialogTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/SkillDialogTests.cs
@@ -401,7 +401,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var oauthCard = new OAuthCard { TokenExchangeResource = new TokenExchangeResource { Uri = uri } };
             var attachment = new Attachment
             {
-                ContentType = OAuthCard.ContentType,
+                ContentType = ContentTypes.OAuthCard,
                 Content = JObject.FromObject(oauthCard)
             };
 

--- a/tests/Microsoft.Bot.Connector.Tests/ConversationsTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/ConversationsTests.cs
@@ -611,12 +611,12 @@ namespace Microsoft.Bot.Connector.Tests
                 {
                     new Attachment()
                     {
-                        ContentType = HeroCard.ContentType,
+                        ContentType = ContentTypes.HeroCard,
                         Content = heroCardStatic,
                     },
                     new Attachment()
                     {
-                        ContentType = HeroCard.ContentType,
+                        ContentType = ContentTypes.HeroCard,
                         Content = heroCardAnimation,
                     },
                 });


### PR DESCRIPTION
Addresses # 6100
#minor

## Description
This PR consolidates the Card classes that were split into different files.

## Specific Changes
  - Removed the _partial_ modifier from the different Card classes and removed the partial _CustomInit_ method.
  - Created `ContentTypes` class with the definition for the Cards' content type.
  - Removed the `partial` modifier from the `Extensions` class.
  - Define new `CardEx` class with the extension methods `toAttachment()` used for the cards.

## Testing
This image shows the tests passing after the changes.
![image](https://user-images.githubusercontent.com/44245136/156618795-ba85f68b-70d8-4e82-8f7a-cab3057db9bb.png)