### PR TITLE
[#6292] Update CosmosDbStorage from Functional to Unit tests

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Documents;
@@ -11,6 +12,9 @@ using Microsoft.Azure.Documents.Client;
 using Microsoft.Azure.Documents.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+
+[assembly: InternalsVisibleTo("Microsoft.Bot.Builder.Azure.Tests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 
 namespace Microsoft.Bot.Builder.Azure
 {
@@ -411,11 +415,14 @@ namespace Microsoft.Bot.Builder.Azure
         /// <summary>
         /// Internal data structure for storing items in a CosmosDB Collection.
         /// </summary>
-        private class DocumentStoreItem
+        internal class DocumentStoreItem : IStoreItem
         {
             /// <summary>
             /// Gets or sets the sanitized Id/Key used as PrimaryKey.
             /// </summary>
+            /// <value>
+            /// The sanitized Id/Key used as PrimaryKey.
+            /// </value>
             [JsonProperty("id")]
             public string Id { get; set; }
 
@@ -426,6 +433,9 @@ namespace Microsoft.Bot.Builder.Azure
             /// Note: There is a Typo in the property name ("ReadlId"), that can't be changed due to compatability concerns. The
             /// Json is correct due to the JsonProperty field, but the Typo needs to stay.
             /// </remarks>
+            /// <value>
+            /// The un-sanitized Id/Key.
+            /// </value>
             [JsonProperty("realId")]
             public string ReadlId { get; internal set; }
 
@@ -434,12 +444,18 @@ namespace Microsoft.Bot.Builder.Azure
             /// <summary>
             /// Gets or sets the persisted object.
             /// </summary>
+            /// <value>
+            /// The persisted object.
+            /// </value>
             [JsonProperty("document")]
             public JObject Document { get; set; }
 
             /// <summary>
             /// Gets or sets the ETag information for handling optimistic concurrency updates.
             /// </summary>
+            /// <value>
+            /// The ETag information for handling optimistic concurrency updates.
+            /// </value>
             [JsonProperty("_etag")]
             public string ETag { get; set; }
         }

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
@@ -20,8 +20,8 @@ namespace Microsoft.Bot.Builder.Azure.Tests
     [Trait("TestCategory", "Storage - CosmosDB")]
     public class CosmosDbStorageTests
     {
-        private readonly Uri _cosmosDBEndpoint = new Uri("https://localhost:8081");
-        private readonly string _authKey = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+        private const string AuthKey = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+        private readonly Uri _cosmosDbEndpoint = new Uri("https://localhost:8081");
 
         private CosmosDbStorage _storage;
         private readonly Mock<IDocumentClient> _documentClient = new Mock<IDocumentClient>();
@@ -39,8 +39,8 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             _ = new CosmosDbStorage(
                 cosmosDbStorageOptions: new CosmosDbStorageOptions
                 {
-                    CosmosDBEndpoint = _cosmosDBEndpoint,
-                    AuthKey = _authKey,
+                    CosmosDBEndpoint = _cosmosDbEndpoint,
+                    AuthKey = AuthKey,
                     DatabaseId = "DatabaseId",
                     CollectionId = "CollectionId",
                 },
@@ -59,15 +59,15 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             // No Auth Key. Should throw.
             Assert.Throws<ArgumentException>(() => new CosmosDbStorage(new CosmosDbStorageOptions()
             {
-                CosmosDBEndpoint = _cosmosDBEndpoint,
+                CosmosDBEndpoint = _cosmosDbEndpoint,
                 AuthKey = null,
             }));
 
             // No Database Id. Should throw.
             Assert.Throws<ArgumentException>(() => new CosmosDbStorage(new CosmosDbStorageOptions()
             {
-                CosmosDBEndpoint = _cosmosDBEndpoint,
-                AuthKey = _authKey,
+                CosmosDBEndpoint = _cosmosDbEndpoint,
+                AuthKey = AuthKey,
                 DatabaseId = null,
             }));
             Assert.Throws<ArgumentException>(() => new CosmosDbStorage(documentClient, new CosmosDbCustomClientOptions()
@@ -78,8 +78,8 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             // No Collection Id. Should throw.
             Assert.Throws<ArgumentException>(() => new CosmosDbStorage(new CosmosDbStorageOptions()
             {
-                CosmosDBEndpoint = _cosmosDBEndpoint,
-                AuthKey = _authKey,
+                CosmosDBEndpoint = _cosmosDbEndpoint,
+                AuthKey = AuthKey,
                 DatabaseId = "DatabaseId",
                 CollectionId = null,
             }));
@@ -93,8 +93,8 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             Assert.Throws<ArgumentNullException>(() => new CosmosDbStorage(
                 new CosmosDbStorageOptions()
                 {
-                    CosmosDBEndpoint = _cosmosDBEndpoint,
-                    AuthKey = _authKey,
+                    CosmosDBEndpoint = _cosmosDbEndpoint,
+                    AuthKey = AuthKey,
                     DatabaseId = "DatabaseId",
                     CollectionId = "CollectionId",
                 }, null));

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
@@ -3,568 +3,258 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Diagnostics;
-using System.IO;
-using System.Net;
+using System.Linq;
+using System.Linq.Expressions;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.Client;
-using Microsoft.Bot.Builder.Adapters;
-using Microsoft.Bot.Builder.Dialogs;
-using Microsoft.Bot.Builder.Tests;
+using Microsoft.Azure.Documents.Linq;
 using Moq;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Microsoft.Bot.Builder.Azure.Tests
 {
     [Trait("TestCategory", "Storage")]
     [Trait("TestCategory", "Storage - CosmosDB")]
-    public class CosmosDbStorageTests : StorageBaseTests, IAsyncLifetime
+    public class CosmosDbStorageTests
     {
-        // Endpoint and Authkey for the CosmosDB Emulator running locally
-        private const string CosmosServiceEndpoint = "https://localhost:8081";
-        private const string CosmosAuthKey = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
-        private const string CosmosDatabaseName = "test-CosmosDbStorageTests";
-        private const string CosmosCollectionName = "bot-storage";
-        private const string DocumentId = "UtteranceLog-001";
+        private readonly Uri _cosmosDBEndpoint = new Uri("https://localhost:8081");
+        private readonly string _authKey = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
 
-        private static readonly string EmulatorPath = Environment.ExpandEnvironmentVariables(@"%ProgramFiles%\Azure Cosmos DB Emulator\CosmosDB.Emulator.exe");
+        private CosmosDbStorage _storage;
+        private readonly Mock<IDocumentClient> _documentClient = new Mock<IDocumentClient>();
 
-        // This process has been disabled, more information can be found in the tests\Microsoft.Bot.Builder.Azure.Tests\IgnoreOnNoEmulatorFact.cs file.
-        private static readonly Lazy<bool> HasEmulator = new Lazy<bool>(() => false);
-
-        // Item used to test delete cases
-        private readonly StoreItem _itemToTest = new StoreItem { MessageList = new string[] { "hi", "how are u" }, City = "Contoso" };
-
-        private IStorage _storage;
-
-        public CosmosDbStorageTests()
+        public interface IDocumentQueryMock<T> : IDocumentQuery<T>, IOrderedQueryable<T>
         {
-            if (HasEmulator.Value)
-            {
-                _storage = new CosmosDbStorage(new CosmosDbStorageOptions
+        }
+
+        [Fact]
+        public void ConstructorValidation()
+        {
+            var documentClient = Mock.Of<IDocumentClient>();
+
+            // Should work.
+            _ = new CosmosDbStorage(
+                cosmosDbStorageOptions: new CosmosDbStorageOptions
                 {
-                    AuthKey = CosmosAuthKey,
-                    CollectionId = CosmosCollectionName,
-                    CosmosDBEndpoint = new Uri(CosmosServiceEndpoint),
-                    DatabaseId = CosmosDatabaseName,
-                });
-            }
-        }
+                    CosmosDBEndpoint = _cosmosDBEndpoint,
+                    AuthKey = _authKey,
+                    DatabaseId = "DatabaseId",
+                    CollectionId = "CollectionId",
+                },
+                jsonSerializer: JsonSerializer.Create(new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All }));
 
-        public Task InitializeAsync() 
-        {
-            return Task.CompletedTask;
-        }
-
-        public async Task DisposeAsync()
-        {
-            if (_storage != null)
-            {
-                var client = new DocumentClient(new Uri(CosmosServiceEndpoint), CosmosAuthKey);
-                try
-                {
-                    await client.DeleteDatabaseAsync(UriFactory.CreateDatabaseUri(CosmosDatabaseName)).ConfigureAwait(false);
-                }
-                catch (Exception ex)
-                {
-                    Debug.WriteLine("Error cleaning up resources: {0}", ex.ToString());
-                }
-            }
-        }
-
-        [IgnoreOnNoEmulatorFact]
-        public void Sanitize_Key_Should_Work()
-        {
-            // Note: The SanitizeKey method delegates to the CosmosDBKeyEscape class. The method is
-            // marked as obsolete, and should no longer be used. This test is here to make sure
-            // the method does actually delegate, as we can't remove it due to back-compat reasons.
-#pragma warning disable 0618
-            // Ascii code of "?" is "3f".
-            var sanitizedKey = CosmosDbStorage.SanitizeKey("?test?");
-            Assert.Equal("*3ftest*3f", sanitizedKey);
-#pragma warning restore 0618
-        }
-
-        [IgnoreOnNoEmulatorFact]
-        public void Constructor_Should_Throw_On_InvalidOptions()
-        {
             // No Options. Should throw.
             Assert.Throws<ArgumentNullException>(() => new CosmosDbStorage(null));
+            Assert.Throws<ArgumentNullException>(() => new CosmosDbStorage(documentClient, null));
 
             // No Endpoint. Should throw.
-            Assert.Throws<ArgumentException>(() => new CosmosDbStorage(new CosmosDbStorageOptions
+            Assert.Throws<ArgumentException>(() => new CosmosDbStorage(new CosmosDbStorageOptions()
             {
-                AuthKey = "test",
-                CollectionId = "testId",
-                DatabaseId = "testDb",
                 CosmosDBEndpoint = null,
             }));
 
             // No Auth Key. Should throw.
-            Assert.Throws<ArgumentException>(() => new CosmosDbStorage(new CosmosDbStorageOptions
+            Assert.Throws<ArgumentException>(() => new CosmosDbStorage(new CosmosDbStorageOptions()
             {
+                CosmosDBEndpoint = _cosmosDBEndpoint,
                 AuthKey = null,
-                CollectionId = "testId",
-                DatabaseId = "testDb",
-                CosmosDBEndpoint = new Uri("https://test.com"),
             }));
 
             // No Database Id. Should throw.
-            Assert.Throws<ArgumentException>(() => new CosmosDbStorage(new CosmosDbStorageOptions
+            Assert.Throws<ArgumentException>(() => new CosmosDbStorage(new CosmosDbStorageOptions()
             {
-                AuthKey = "test",
-                CollectionId = "testId",
+                CosmosDBEndpoint = _cosmosDBEndpoint,
+                AuthKey = _authKey,
                 DatabaseId = null,
-                CosmosDBEndpoint = new Uri("https://test.com"),
             }));
-
-            // No Collection Id. Should throw.
-            Assert.Throws<ArgumentException>(() => new CosmosDbStorage(new CosmosDbStorageOptions
+            Assert.Throws<ArgumentException>(() => new CosmosDbStorage(documentClient, new CosmosDbCustomClientOptions()
             {
-                AuthKey = "test",
-                CollectionId = null,
-                DatabaseId = "testDb",
-                CosmosDBEndpoint = new Uri("https://test.com"),
-            }));
-        }
-
-        [IgnoreOnNoEmulatorFact]
-        public void CustomConstructor_Should_Throw_On_InvalidOptions()
-        {
-            var customClient = GetDocumentClient().Object;
-
-            // No client. Should throw.
-            Assert.Throws<ArgumentNullException>(() => new CosmosDbStorage(null, new CosmosDbCustomClientOptions
-            {
-                CollectionId = "testId",
-                DatabaseId = "testDb",
-            }));
-
-            // No Options. Should throw.
-            Assert.Throws<ArgumentNullException>(() => new CosmosDbStorage(customClient, null));
-
-            // No Database Id. Should throw.
-            Assert.Throws<ArgumentException>(() => new CosmosDbStorage(customClient, new CosmosDbCustomClientOptions
-            {
-                CollectionId = "testId",
                 DatabaseId = null,
             }));
 
             // No Collection Id. Should throw.
-            Assert.Throws<ArgumentException>(() => new CosmosDbStorage(customClient, new CosmosDbCustomClientOptions
+            Assert.Throws<ArgumentException>(() => new CosmosDbStorage(new CosmosDbStorageOptions()
             {
+                CosmosDBEndpoint = _cosmosDBEndpoint,
+                AuthKey = _authKey,
+                DatabaseId = "DatabaseId",
                 CollectionId = null,
-                DatabaseId = "testDb",
+            }));
+            Assert.Throws<ArgumentException>(() => new CosmosDbStorage(documentClient, new CosmosDbCustomClientOptions()
+            {
+                DatabaseId = "DatabaseId",
+                CollectionId = null,
+            }));
+
+            // No JsonSerializer. Should throw.
+            Assert.Throws<ArgumentNullException>(() => new CosmosDbStorage(
+                new CosmosDbStorageOptions()
+                {
+                    CosmosDBEndpoint = _cosmosDBEndpoint,
+                    AuthKey = _authKey,
+                    DatabaseId = "DatabaseId",
+                    CollectionId = "CollectionId",
+                }, null));
+
+            // No DocumentClient. Should throw.
+            Assert.Throws<ArgumentNullException>(() => new CosmosDbStorage(null, new CosmosDbCustomClientOptions()
+            {
+                DatabaseId = "DatabaseId",
+                CollectionId = "CollectionId",
             }));
         }
 
-        [IgnoreOnNoEmulatorFact]
-        public void Connection_Policy_Configurator_Should_Be_Called_If_Present()
+        [Fact]
+        public void SanitizeKey()
         {
-            var wasCalled = false;
+            const string validKey = "Abc12345";
+            var sanitizedKey = CosmosDbStorage.SanitizeKey(validKey);
 
-            var optionsWithConfigurator = new CosmosDbStorageOptions
+            Assert.Equal(validKey, sanitizedKey);
+        }
+
+        [Fact]
+        public async void ReadAsyncValidation()
+        {
+            InitStorage();
+
+            // No keys. Should throw.
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _storage.ReadAsync(null, CancellationToken.None));
+
+            // Empty keys. Should return empty.
+            var empty = await _storage.ReadAsync(new string[] { }, CancellationToken.None);
+            Assert.Empty(empty);
+        }
+
+        [Fact]
+        public async void ReadAsync()
+        {
+            InitStorage();
+
+            var documentQuery = new Mock<IDocumentQueryMock<CosmosDbStorage.DocumentStoreItem>>();
+            var provider = new Mock<IQueryProvider>();
+
+            var resources = new List<CosmosDbStorage.DocumentStoreItem>
             {
-                AuthKey = "test",
-                CollectionId = "testId",
-                DatabaseId = "testDb",
-                CosmosDBEndpoint = new Uri("https://test.com"),
-
-                // Make sure the Callback is called.
-                ConnectionPolicyConfigurator = (ConnectionPolicy p) => wasCalled = true,
+                new CosmosDbStorage.DocumentStoreItem
+                {
+                    ReadlId = "ReadlId",
+                    ETag = "ETag1",
+                    Document = JObject.Parse("{ \"ETag\":\"ETag2\" }")
+                },
             };
 
-            var storage = new CosmosDbStorage(optionsWithConfigurator);
-            Assert.True(wasCalled, "The Connection Policy Configurator was not called.");
+            var response = new FeedResponse<CosmosDbStorage.DocumentStoreItem>(resources);
+
+            provider.Setup(e => e.CreateQuery<CosmosDbStorage.DocumentStoreItem>(It.IsAny<Expression>()))
+                .Returns(documentQuery.Object);
+            documentQuery.SetupSequence(_ => _.HasMoreResults)
+                .Returns(true)
+                .Returns(false);
+            documentQuery.Setup(e => e.ExecuteNextAsync<CosmosDbStorage.DocumentStoreItem>(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(response);
+            documentQuery.Setup(e => e.Provider)
+                .Returns(provider.Object);
+            _documentClient.Setup(e => e.CreateDocumentQuery<CosmosDbStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<SqlQuerySpec>(), It.IsAny<FeedOptions>()))
+                .Returns(documentQuery.Object);
+            
+            var items = await _storage.ReadAsync(new string[] { "key" }, CancellationToken.None);
+
+            Assert.Single(items);
+            _documentClient.Verify(e => e.CreateDocumentQuery<CosmosDbStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<SqlQuerySpec>(), It.IsAny<FeedOptions>()), Times.Once);
+            documentQuery.Verify(e => e.ExecuteNextAsync<CosmosDbStorage.DocumentStoreItem>(It.IsAny<CancellationToken>()), Times.Once);
         }
 
-        [IgnoreOnNoEmulatorFact]
-        public async Task Database_Creation_Request_Options_Should_Be_Used()
+        [Fact]
+        public async void WriteAsyncValidation()
         {
-            var documentClientMock = GetDocumentClient();
+            InitStorage();
 
-            var databaseCreationRequestOptions = new RequestOptions { OfferThroughput = 1000 };
-            var documentCollectionRequestOptions = new RequestOptions { OfferThroughput = 500 };
+            // No changes. Should throw.
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _storage.WriteAsync(null, CancellationToken.None));
 
-            var optionsWithConfigurator = new CosmosDbCustomClientOptions
-            {
-                CollectionId = "testId",
-                DatabaseId = "testDb",
-                DatabaseCreationRequestOptions = databaseCreationRequestOptions,
-                DocumentCollectionRequestOptions = documentCollectionRequestOptions,
-            };
-
-            var storage = new CosmosDbStorage(documentClientMock.Object, optionsWithConfigurator);
-            await storage.DeleteAsync(new string[] { "foo" }, CancellationToken.None);
-
-            documentClientMock.Verify(client => client.CreateDatabaseIfNotExistsAsync(It.IsAny<Database>(), databaseCreationRequestOptions), Times.Once());
-            documentClientMock.Verify(client => client.CreateDocumentCollectionIfNotExistsAsync(It.IsAny<Uri>(), It.IsAny<DocumentCollection>(), documentCollectionRequestOptions), Times.Once());
+            // Empty changes. Should return.
+            await _storage.WriteAsync(new Dictionary<string, object>(), CancellationToken.None);
         }
 
-        // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnNoEmulatorFact]
-        public async Task CreateObjectCosmosDBTest()
+        [Fact]
+        public async void WriteAsync()
         {
-            await CreateObjectTest(_storage);
-        }
+            InitStorage();
 
-        // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnNoEmulatorFact]
-        public async Task ReadUnknownCosmosDBTest()
-        {
-            await ReadUnknownTest(_storage);
-        }
+            _documentClient.Setup(e => e.UpsertDocumentAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<RequestOptions>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()));
+            _documentClient.Setup(e => e.ReplaceDocumentAsync(It.IsAny<Uri>(), It.IsAny<object>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()));
 
-        // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnNoEmulatorFact]
-        public async Task UpdateObjectCosmosDBTest()
-        {
-            await UpdateObjectTest<DocumentClientException>(_storage);
-        }
-
-        // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnNoEmulatorFact]
-        public async Task DeleteObjectCosmosDBTest()
-        {
-            await DeleteObjectTest(_storage);
-        }
-
-        // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnNoEmulatorFact]
-        public async Task HandleCrazyKeysCosmosDB()
-        {
-            await HandleCrazyKeys(_storage);
-        }
-
-        // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnNoEmulatorFact]
-        public void ConnectionPolicyConfiguratorShouldBeCalled()
-        {
-            ConnectionPolicy policyRef = null;
-
-            _storage = new CosmosDbStorage(new CosmosDbStorageOptions
-            {
-                AuthKey = CosmosAuthKey,
-                CollectionId = CosmosCollectionName,
-                CosmosDBEndpoint = new Uri(CosmosServiceEndpoint),
-                DatabaseId = CosmosDatabaseName,
-                ConnectionPolicyConfigurator = (ConnectionPolicy policy) => policyRef = policy,
-            });
-
-            Assert.NotNull(policyRef);
-        }
-
-        // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnNoEmulatorFact]
-        public async Task ReadingEmptyKeysReturnsEmptyDictionary()
-        {
-            var state = await _storage.ReadAsync(new string[] { });
-            Assert.IsType<Dictionary<string, object>>(state);
-            Assert.Equal(0, state.Count);
-        }
-
-        // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnNoEmulatorFact]
-        public async Task ReadingNullKeysThrowException()
-        {
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await _storage.ReadAsync(null));
-        }
-
-        // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnNoEmulatorFact]
-        public async Task WritingNullStoreItemsThrowException()
-        {
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await _storage.WriteAsync(null));
-        }
-
-        // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnNoEmulatorFact]
-        public async Task WritingNoStoreItemsDoesntThrow()
-        {
-            var changes = new Dictionary<string, object>();
-            await _storage.WriteAsync(changes);
-        }
-
-        // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        // For issue https://github.com/Microsoft/botbuilder-dotnet/issues/871
-        // See the linked issue for details. This issue was happening when using the CosmosDB
-        // data store for state. The stepIndex, which was an object being cast to an Int64
-        // after deserialization, was throwing an exception for not being Int32 datatype.
-        // This test checks to make sure that this error is no longer thrown.
-        //
-        // The problem was reintroduced when the prompt retry count feature was implemented:
-        // https://github.com/microsoft/botbuilder-dotnet/issues/1859
-        // The waterfall in this test has been modified to include a prompt.
-        [IgnoreOnNoEmulatorFact]
-        public async Task WaterfallCosmos()
-        {
-            var convoState = new ConversationState(_storage);
-
-            var adapter = new TestAdapter(TestAdapter.CreateConversation(nameof(WaterfallCosmos)))
-                .Use(new AutoSaveStateMiddleware(convoState));
-
-            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
-            var dialogs = new DialogSet(dialogState);
-
-            dialogs.Add(new TextPrompt(nameof(TextPrompt), async (promptContext, cancellationToken) =>
-            {
-                var result = promptContext.Recognized.Value;
-                if (result.Length > 3)
-                {
-                    var succeededMessage = MessageFactory.Text($"You got it at the {promptContext.AttemptCount}th try!");
-                    await promptContext.Context.SendActivityAsync(succeededMessage, cancellationToken);
-                    return true;
-                }
-
-                var reply = MessageFactory.Text($"Please send a name that is longer than 3 characters. {promptContext.AttemptCount}");
-                await promptContext.Context.SendActivityAsync(reply, cancellationToken);
-
-                return false;
-            }));
-
-            var steps = new WaterfallStep[]
-                {
-                    async (stepContext, ct) =>
-                    {
-                        Assert.Equal(typeof(int), stepContext.ActiveDialog.State["stepIndex"].GetType());
-                        await stepContext.Context.SendActivityAsync("step1");
-                        return Dialog.EndOfTurn;
-                    },
-                    async (stepContext, ct) =>
-                    {
-                        Assert.Equal(typeof(int), stepContext.ActiveDialog.State["stepIndex"].GetType());
-                        return await stepContext.PromptAsync(nameof(TextPrompt), new PromptOptions { Prompt = MessageFactory.Text("Please type your name.") }, ct);
-                    },
-                    async (stepContext, ct) =>
-                    {
-                        Assert.Equal(typeof(int), stepContext.ActiveDialog.State["stepIndex"].GetType());
-                        await stepContext.Context.SendActivityAsync("step3");
-                        return Dialog.EndOfTurn;
-                    },
-                };
-
-            dialogs.Add(new WaterfallDialog(nameof(WaterfallDialog), steps));
-
-            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
-                {
-                    var dc = await dialogs.CreateContextAsync(turnContext);
-
-                    await dc.ContinueDialogAsync();
-                    if (!turnContext.Responded)
-                    {
-                        await dc.BeginDialogAsync(nameof(WaterfallDialog));
-                    }
-                })
-                .Send("hello")
-                .AssertReply("step1")
-                .Send("hello")
-                .AssertReply("Please type your name.")
-                .Send("hi")
-                .AssertReply("Please send a name that is longer than 3 characters. 1")
-                .Send("hi")
-                .AssertReply("Please send a name that is longer than 3 characters. 2")
-                .Send("hi")
-                .AssertReply("Please send a name that is longer than 3 characters. 3")
-                .Send("Kyle")
-                .AssertReply("You got it at the 4th try!")
-                .AssertReply("step3")
-                .StartTestAsync();
-        }
-
-        // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnNoEmulatorFact]
-        public async Task DeleteAsyncFromSingleCollection()
-        {
-            var storage = new CosmosDbStorage(CreateCosmosDbStorageOptions());
             var changes = new Dictionary<string, object>
             {
-                { DocumentId, _itemToTest }
+                { "key1", new CosmosDbStorage.DocumentStoreItem() },
+                { "key2", new CosmosDbStorage.DocumentStoreItem { ETag = "*" } },
+                { "key3", new CosmosDbStorage.DocumentStoreItem { ETag = "ETag" } },
             };
 
-            await storage.WriteAsync(changes, CancellationToken.None);
+            await _storage.WriteAsync(changes, CancellationToken.None);
 
-            var result = await Task.WhenAny(storage.DeleteAsync(new string[] { DocumentId }, CancellationToken.None)).ConfigureAwait(false);
-            Assert.True(result.IsCompletedSuccessfully);
+            _documentClient.Verify(e => e.UpsertDocumentAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<RequestOptions>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+            _documentClient.Verify(e => e.ReplaceDocumentAsync(It.IsAny<Uri>(), It.IsAny<object>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
-        // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnNoEmulatorFact]
-        public async Task DeleteAsyncFromPartitionedCollection()
+        [Fact]
+        public async void WriteAsyncEmptyTagFailure()
         {
-            // The WriteAsync method receive a object as a parameter then encapsulate it in a object named "document"
-            // The partitionKeyPath must have the "document" value to properly route the values as partitionKey
-            // <see also cref="WriteAsync(IDictionary{string, object}, CancellationToken)"/>
-            const string partitionKeyPath = "document/city";
+            InitStorage();
 
-            await CreateCosmosDbWithPartitionedCollection(partitionKeyPath);
-
-            // Connect to the cosmosDb created before with "Contoso" as partitionKey
-            var storage = new CosmosDbStorage(CreateCosmosDbStorageOptions("Contoso"));
             var changes = new Dictionary<string, object>
             {
-                { DocumentId, _itemToTest }
+                { "key", new CosmosDbStorage.DocumentStoreItem { ETag = string.Empty } },
             };
 
-            await storage.WriteAsync(changes, CancellationToken.None);
-
-            var result = await Task.WhenAny(storage.DeleteAsync(new string[] { DocumentId }, CancellationToken.None)).ConfigureAwait(false);
-            Assert.True(result.IsCompletedSuccessfully);
+            await Assert.ThrowsAsync<ArgumentException>(() => _storage.WriteAsync(changes, CancellationToken.None));
         }
 
-        // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnNoEmulatorFact]
-        public async Task DeleteAsyncFromPartitionedCollectionWithoutPartitionKey()
+        [Fact]
+        public async void DeleteAsyncValidation()
         {
-            // The WriteAsync method receive a object as a parameter then encapsulate it in a object named "document"
-            // The partitionKeyPath must have the "document" value to properly route the values as partitionKey
-            // <see also cref="WriteAsync(IDictionary{string, object}, CancellationToken)"/>
-            const string partitionKeyPath = "document/city";
+            InitStorage();
 
-            await CreateCosmosDbWithPartitionedCollection(partitionKeyPath);
+            // No keys. Should throw.
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _storage.DeleteAsync(null, CancellationToken.None));
 
-            // Connect to the cosmosDb created before
-            var storage = new CosmosDbStorage(CreateCosmosDbStorageOptions());
-            var changes = new Dictionary<string, object>
+            // Empty keys. Should return.
+            await _storage.DeleteAsync(new string[] { }, CancellationToken.None);
+        }
+
+        [Fact]
+        public async void DeleteAsync()
+        {
+            InitStorage();
+
+            _documentClient.Setup(e => e.DeleteDocumentAsync(It.IsAny<Uri>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()));
+
+            await _storage.DeleteAsync(new string[] { "key" }, CancellationToken.None);
+
+            _documentClient.Verify(e => e.DeleteDocumentAsync(It.IsAny<Uri>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        private void InitStorage(CosmosDbCustomClientOptions storageOptions = default)
+        {
+            var connectionPolicy = new ConnectionPolicy();
+            var documentCollection = new DocumentCollection();
+            var resourceResponse = new ResourceResponse<DocumentCollection>(documentCollection);
+
+            _documentClient.SetupGet(e => e.ConnectionPolicy).Returns(connectionPolicy);
+            _documentClient.Setup(e => e.CreateDatabaseIfNotExistsAsync(It.IsAny<Database>(), It.IsAny<RequestOptions>()));
+            _documentClient.Setup(e => e.CreateDocumentCollectionIfNotExistsAsync(It.IsAny<Uri>(), It.IsAny<DocumentCollection>(), It.IsAny<RequestOptions>()))
+                .ReturnsAsync(resourceResponse);
+
+            var options = storageOptions ?? new CosmosDbCustomClientOptions
             {
-                { DocumentId, _itemToTest }
+                DatabaseId = "DatabaseId",
+                CollectionId = "CollectionId",
             };
-
-            await storage.WriteAsync(changes, CancellationToken.None);
-
-            // Should throw InvalidOperationException: PartitionKey value must be supplied for this operation.
-            await Assert.ThrowsAsync<InvalidOperationException>(async () => await storage.DeleteAsync(new string[] { DocumentId }, CancellationToken.None));
-        }
-
-        // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnNoEmulatorFact]
-        public async Task ReadAsyncWithPartitionKey()
-        {
-            // The WriteAsync method receive a object as a parameter then encapsulate it in a object named "document"
-            // The partitionKeyPath must have the "document" value to properly route the values as partitionKey
-            // <see also cref="WriteAsync(IDictionary{string, object}, CancellationToken)"/>
-            const string partitionKeyPath = "document/city";
-
-            await CreateCosmosDbWithPartitionedCollection(partitionKeyPath);
-
-            // Connect to the cosmosDb created before with "Contoso" as partitionKey
-            var storage = new CosmosDbStorage(CreateCosmosDbStorageOptions("Contoso"));
-            var changes = new Dictionary<string, object>
-            {
-                { DocumentId, _itemToTest }
-            };
-
-            await storage.WriteAsync(changes, CancellationToken.None);
-
-            var result = await storage.ReadAsync<StoreItem>(new string[] { DocumentId }, CancellationToken.None);
-            Assert.Equal(_itemToTest.City, result[DocumentId].City);
-        }
-
-        // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnNoEmulatorFact]
-        public async Task ReadAsyncWithoutPartitionKey()
-        {
-            // The WriteAsync method receive a object as a parameter then encapsulate it in a object named "document"
-            // The partitionKeyPath must have the "document" value to properly route the values as partitionKey
-            // <see also cref="WriteAsync(IDictionary{string, object}, CancellationToken)"/>
-            const string partitionKeyPath = "document/city";
-
-            await CreateCosmosDbWithPartitionedCollection(partitionKeyPath);
-
-            // Connect to the cosmosDb created before without partitionKey
-            var storage = new CosmosDbStorage(CreateCosmosDbStorageOptions());
-            var changes = new Dictionary<string, object>
-            {
-                { DocumentId, _itemToTest }
-            };
-
-            await storage.WriteAsync(changes, CancellationToken.None);
-
-            var badRequestExceptionThrown = false;
-            try
-            {
-                await storage.ReadAsync<StoreItem>(new string[] { DocumentId }, CancellationToken.None);
-            }
-            catch (DocumentClientException ex)
-            {
-                badRequestExceptionThrown = ex.StatusCode == HttpStatusCode.BadRequest; 
-            }
-
-            Assert.True(badRequestExceptionThrown, "Expected: DocumentClientException with HttpStatusCode.BadRequest");
-
-            // TODO: netcoreapp3.0 throws Microsoft.Azure.Documents.BadRequestException which derives from DocumentClientException, but it is internal
-            //await Assert.ThrowsAsync<DocumentClientException>(async () => await storage.ReadAsync<StoreItem>(new string[] { DocumentId }, CancellationToken.None));
-        }
-
-        // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        [IgnoreOnNoEmulatorFact]
-        public async Task StatePersistsThroughMultiTurn_TypeNameHandlingNone()
-        {
-            var storage = new CosmosDbStorage(
-                               CreateCosmosDbStorageOptions(),
-                               new JsonSerializer() { TypeNameHandling = TypeNameHandling.None });
-            await StatePersistsThroughMultiTurn(storage);
-        }
-
-        private static async Task CreateCosmosDbWithPartitionedCollection(string partitionKey)
-        {
-            using var client = new DocumentClient(new Uri(CosmosServiceEndpoint), CosmosAuthKey);
-            Database database = await client.CreateDatabaseIfNotExistsAsync(new Database { Id = CosmosDatabaseName });
-            var partitionKeyDefinition = new PartitionKeyDefinition { Paths = new Collection<string> { $"/{partitionKey}" } };
-            var collectionDefinition = new DocumentCollection { Id = CosmosCollectionName, PartitionKey = partitionKeyDefinition };
-
-            await client.CreateDocumentCollectionIfNotExistsAsync(database.SelfLink, collectionDefinition);
-        }
-
-        private static CosmosDbStorageOptions CreateCosmosDbStorageOptions(string partitionKey = "")
-        {
-            return new CosmosDbStorageOptions()
-            {
-                PartitionKey = partitionKey,
-                AuthKey = CosmosAuthKey,
-                CollectionId = CosmosCollectionName,
-                CosmosDBEndpoint = new Uri(CosmosServiceEndpoint),
-                DatabaseId = CosmosDatabaseName,
-            };
-        }
-
-        private Mock<IDocumentClient> GetDocumentClient()
-        {
-            var mock = new Mock<IDocumentClient>();
-
-            mock.Setup(client => client.CreateDatabaseIfNotExistsAsync(It.IsAny<Database>(), It.IsAny<RequestOptions>()))
-                .ReturnsAsync(() =>
-                {
-                    var database = new Database();
-                    database.SetPropertyValue("SelfLink", "dummyDB_SelfLink");
-                    return new ResourceResponse<Database>(database);
-                });
-
-            mock.Setup(client => client.CreateDocumentCollectionIfNotExistsAsync(It.IsAny<Uri>(), It.IsAny<DocumentCollection>(), It.IsAny<RequestOptions>()))
-                .ReturnsAsync(() =>
-                {
-                    var documentCollection = new DocumentCollection();
-                    documentCollection.SetPropertyValue("SelfLink", "dummyDC_SelfLink");
-                    return new ResourceResponse<DocumentCollection>(documentCollection);
-                });
-
-            mock.Setup(client => client.ConnectionPolicy).Returns(new ConnectionPolicy());
-
-            return mock;
-        }
-
-        internal class StoreItem : IStoreItem
-        {
-            [JsonProperty(PropertyName = "messageList")]
-            public string[] MessageList { get; set; }
-
-            [JsonProperty(PropertyName = "city")]
-            public string City { get; set; }
-
-            public string ETag { get; set; }
+            _storage = new CosmosDbStorage(_documentClient.Object, options);
         }
     }
 }


### PR DESCRIPTION
Addresses # 6292

## Description
This PR removes the existing Functional tests and as a replacement, it adds support for internal testing to the `CosmosDbStorage` class, and introduces all the necessary unit tests, increasing the **code coverage up to 86%**.

## Specific Changes
- Updates the `CosmosDbStorage.DocumentStoreItem` class accessibility from `private` to `internal`, so it can be accessed from the tests.
- Removed all the existing tests in `CosmosDbStorageTests` class.
- Adds new unit tests to the `CosmosDbStorageTests` class for each method, constructor, method validations, etc.

## Testing
The following image shows the new unit tests and the code coverage.
![image](https://user-images.githubusercontent.com/62260472/163255258-d02e12e0-f8b7-412d-ac8a-ec7f1ccde338.png)