### PR TITLE
[#6292] Update Blobs from Functional to Unit tests

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsStorage.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
@@ -13,6 +14,8 @@ using Azure.Storage;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Newtonsoft.Json;
+
+[assembly: InternalsVisibleTo("Microsoft.Bot.Builder.Azure.Tests")]
 
 namespace Microsoft.Bot.Builder.Azure.Blobs
 {
@@ -84,6 +87,28 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
             _checkForContainerExistence = 1;
 
             _containerClient = new BlobContainerClient(dataConnectionString, containerName);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BlobsStorage"/> class.
+        /// </summary>
+        /// <param name="containerClient">The custom implementation of BlobContainerClient.</param>
+        /// <param name="jsonSerializer">If passing in a custom JsonSerializer, we recommend the following settings:
+        /// <para>jsonSerializer.TypeNameHandling = TypeNameHandling.None.</para>
+        /// <para>jsonSerializer.NullValueHandling = NullValueHandling.Include.</para>
+        /// <para>jsonSerializer.ContractResolver = new DefaultContractResolver().</para>
+        /// </param>
+        internal BlobsStorage(BlobContainerClient containerClient, JsonSerializer jsonSerializer = null)
+        {
+            _containerClient = containerClient;
+
+            _jsonSerializer = jsonSerializer ?? JsonSerializer.Create(new JsonSerializerSettings
+            {
+                TypeNameHandling = TypeNameHandling.All,
+            });
+
+            // Triggers a check for the existence of the container
+            _checkForContainerExistence = 1;
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsTranscriptStore.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsTranscriptStore.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Azure;
 using Azure.Storage;
@@ -14,6 +15,8 @@ using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Microsoft.Bot.Schema;
 using Newtonsoft.Json;
+
+[assembly: InternalsVisibleTo("Microsoft.Bot.Builder.Azure.Tests")]
 
 namespace Microsoft.Bot.Builder.Azure.Blobs
 {
@@ -97,6 +100,25 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
 
                     return containerClient;
                 }, isThreadSafe: true);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BlobsTranscriptStore"/> class.
+        /// </summary>
+        /// <param name="containerClient">The custom implementation of BlobContainerClient.</param>
+        /// <param name="jsonSerializer">If passing in a custom JsonSerializer, we recommend the following settings:
+        /// <para>jsonSerializer.TypeNameHandling = TypeNameHandling.None.</para>
+        /// <para>jsonSerializer.NullValueHandling = NullValueHandling.Include.</para>
+        /// <para>jsonSerializer.ContractResolver = new DefaultContractResolver().</para>
+        /// </param>
+        internal BlobsTranscriptStore(BlobContainerClient containerClient, JsonSerializer jsonSerializer = null)
+        {
+            _containerClient = new Lazy<BlobContainerClient>(() => containerClient);
+
+            _jsonSerializer = jsonSerializer ?? JsonSerializer.Create(new JsonSerializerSettings
+            {
+                TypeNameHandling = TypeNameHandling.All,
+            });
         }
 
         /// <summary>

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/BlobsStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/BlobsStorageTests.cs
@@ -2,80 +2,238 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Reflection;
-using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading;
+using Azure;
+using Azure.Storage;
 using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
 using Microsoft.Bot.Builder.Azure.Blobs;
+using Moq;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Xunit;
-using Xunit.Abstractions;
-using Xunit.Sdk;
 
 namespace Microsoft.Bot.Builder.Azure.Tests
 {
-    public class BlobsStorageTests : BlobStorageBaseTests, IAsyncLifetime
+    public class BlobsStorageTests
     {
-        private readonly string _testName;
+        private const string ConnectionString = @"UseDevelopmentStorage=true";
 
-        public BlobsStorageTests(ITestOutputHelper testOutputHelper)
+        private BlobsStorage _storage;
+        private readonly Mock<BlobClient> _client = new Mock<BlobClient>();
+        
+        [Fact]
+        public void ConstructorValidation()
         {
-            var helper = (TestOutputHelper)testOutputHelper;
+            // Should work.
+            _ = new BlobsStorage(
+                ConnectionString,
+                "containerName",
+                JsonSerializer.Create(new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All }));
 
-            var test = (ITest)helper.GetType().GetField("test", BindingFlags.NonPublic | BindingFlags.Instance)
-                .GetValue(helper);
+            // No dataConnectionString. Should throw.
+            Assert.Throws<ArgumentNullException>(() => new BlobsStorage(null, "containerName"));
+            Assert.Throws<ArgumentNullException>(() => new BlobsStorage(string.Empty, "containerName"));
 
-            _testName = test.TestCase.TestMethod.Method.Name;
-
-            if (StorageEmulatorHelper.CheckEmulator())
-            {
-                new BlobContainerClient(ConnectionString, ContainerName)
-                    .DeleteIfExistsAsync().ConfigureAwait(false);
-            }
-        }
-
-        protected override string ContainerName => $"blobs{_testName.ToLower().Replace("_", string.Empty)}";
-
-        public Task InitializeAsync()
-        {
-            return Task.CompletedTask;
-        }
-
-        public async Task DisposeAsync()
-        {
-            if (StorageEmulatorHelper.CheckEmulator())
-            {
-                await new BlobContainerClient(ConnectionString, ContainerName)
-                    .DeleteIfExistsAsync().ConfigureAwait(false);
-            }
+            // No containerName. Should throw.
+            Assert.Throws<ArgumentNullException>(() => new BlobsStorage(ConnectionString, null));
+            Assert.Throws<ArgumentNullException>(() => new BlobsStorage(ConnectionString, string.Empty));
         }
 
         [Fact]
-        public void BlobStorageParamTest()
+        public async void WriteAsyncValidation()
         {
-            if (StorageEmulatorHelper.CheckEmulator())
-            {
-                Assert.Throws<ArgumentNullException>(() =>
-                    new BlobsStorage(null, ContainerName));
+            InitStorage();
 
-                Assert.Throws<ArgumentNullException>(() =>
-                    new BlobsStorage(ConnectionString, null));
-
-                Assert.Throws<ArgumentNullException>(() =>
-                    new BlobsStorage(string.Empty, ContainerName));
-
-                Assert.Throws<ArgumentNullException>(() =>
-                    new BlobsStorage(ConnectionString, string.Empty));
-            }
+            // No changes. Should throw.
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _storage.WriteAsync(null));
         }
 
-        protected override IStorage GetStorage(bool typeNameHandlingNone = false)
+        [Fact]
+        public async void WriteAsync()
         {
-            if (typeNameHandlingNone)
-            {
-                return new BlobsStorage(ConnectionString, ContainerName, new JsonSerializer() { TypeNameHandling = TypeNameHandling.None });
-            }
+            InitStorage();
 
-            return new BlobsStorage(ConnectionString, ContainerName);
+            _client.Setup(e => e.UploadAsync(
+                It.IsAny<Stream>(),
+                It.IsAny<BlobHttpHeaders>(),
+                It.IsAny<IDictionary<string, string>>(),
+                It.IsAny<BlobRequestConditions>(),
+                It.IsAny<IProgress<long>>(),
+                It.IsAny<AccessTier?>(),
+                It.IsAny<StorageTransferOptions>(),
+                It.IsAny<CancellationToken>()));
+
+            var changes = new Dictionary<string, object>
+            {
+                { "key1", new StoreItem() },
+                { "key2", new StoreItem { ETag = "*" } },
+                { "key3", new StoreItem { ETag = "ETag" } },
+            };
+
+            await _storage.WriteAsync(changes);
+
+            _client.Verify(
+                e => e.UploadAsync(
+                    It.IsAny<Stream>(),
+                    It.IsAny<BlobHttpHeaders>(),
+                    It.IsAny<IDictionary<string, string>>(),
+                    It.IsAny<BlobRequestConditions>(),
+                    It.IsAny<IProgress<long>>(),
+                    It.IsAny<AccessTier?>(),
+                    It.IsAny<StorageTransferOptions>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Exactly(3));
+        }
+
+        [Fact]
+        public async void WriteAsyncHttpBadRequestFailure()
+        {
+            InitStorage();
+
+            _client.Setup(e => e.UploadAsync(
+                    It.IsAny<Stream>(),
+                    It.IsAny<BlobHttpHeaders>(),
+                    It.IsAny<IDictionary<string, string>>(),
+                    It.IsAny<BlobRequestConditions>(),
+                    It.IsAny<IProgress<long>>(),
+                    It.IsAny<AccessTier?>(),
+                    It.IsAny<StorageTransferOptions>(),
+                    It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new RequestFailedException((int)HttpStatusCode.BadRequest, "error", BlobErrorCode.InvalidBlockList.ToString(), null));
+
+            var changes = new Dictionary<string, object> { { "key", new StoreItem() } };
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _storage.WriteAsync(changes));
+        }
+
+        [Fact]
+        public async void DeleteAsyncValidation()
+        {
+            InitStorage();
+
+            // No keys. Should throw.
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _storage.DeleteAsync(null));
+        }
+
+        [Fact]
+        public async void DeleteAsync()
+        {
+            InitStorage();
+
+            _client.Setup(e => e.DeleteIfExistsAsync(It.IsAny<DeleteSnapshotsOption>(), It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()));
+
+            await _storage.DeleteAsync(new string[] { "key" });
+
+            _client.Verify(e => e.DeleteIfExistsAsync(It.IsAny<DeleteSnapshotsOption>(), It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async void ReadAsyncValidation()
+        {
+            InitStorage();
+
+            // No keys. Should throw.
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _storage.ReadAsync(null));
+        }
+
+        [Fact]
+        public async void ReadAsync()
+        {
+            InitStorage();
+
+            Stream stream = new MemoryStream(Encoding.ASCII.GetBytes("{\"ETag\":\"*\"}"));
+            var blobDownloadInfo = BlobsModelFactory.BlobDownloadInfo(content: stream);
+            var response = new Mock<Response<BlobDownloadInfo>>();
+
+            response.SetupGet(e => e.Value).Returns(blobDownloadInfo);
+
+            _client.Setup(e => e.DownloadAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(response.Object);
+
+            var items = await _storage.ReadAsync(new string[] { "key" });
+
+            Assert.Single(items);
+            Assert.Equal("*", JObject.FromObject(items).GetValue("key")?.Value<string>("ETag"));
+            _client.Verify(e => e.DownloadAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async void ReadAsyncHttpPreconditionFailure()
+        {
+            InitStorage();
+
+            Stream stream = new MemoryStream(Encoding.ASCII.GetBytes("{\"ETag\":\"*\"}"));
+            var blobDownloadInfo = BlobsModelFactory.BlobDownloadInfo(content: stream);
+            var response = new Mock<Response<BlobDownloadInfo>>();
+
+            response.SetupGet(e => e.Value).Returns(blobDownloadInfo);
+
+            _client.Setup(e => e.DownloadAsync(It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new RequestFailedException((int)HttpStatusCode.PreconditionFailed, "error"))
+                .Callback(() =>
+                {
+                    // Break the retry process.
+                    _client.Setup(e => e.DownloadAsync(It.IsAny<CancellationToken>()))
+                        .ReturnsAsync(response.Object);
+                });
+
+            var items = await _storage.ReadAsync(new string[] { "key" });
+
+            Assert.Single(items);
+            Assert.Equal("*", JObject.FromObject(items).GetValue("key")?.Value<string>("ETag"));
+            _client.Verify(e => e.DownloadAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
+        }
+
+        [Fact]
+        public async void ReadAsyncHttpNotFoundFailure()
+        {
+            InitStorage();
+
+            // RequestFailedException => NotFound
+            var requestFailedException = new RequestFailedException((int)HttpStatusCode.NotFound, "error");
+            _client.Setup(e => e.DownloadAsync(It.IsAny<CancellationToken>()))
+                .ThrowsAsync(requestFailedException)
+                .Callback(() =>
+                {
+                    // AggregateException => RequestFailedException => NotFound
+                    _client.Setup(e => e.DownloadAsync(It.IsAny<CancellationToken>()))
+                        .ThrowsAsync(new AggregateException(requestFailedException));
+                });
+
+            var items = await _storage.ReadAsync(new string[] { "key1", "key2" });
+
+            Assert.Empty(items);
+            _client.Verify(e => e.DownloadAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
+        }
+
+        [Fact]
+        public async void GetBlobNameValidation()
+        {
+            InitStorage();
+
+            // Empty keys. Should throw.
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _storage.DeleteAsync(new string[] { string.Empty }));
+        }
+
+        private void InitStorage()
+        {
+            var container = new Mock<BlobContainerClient>();
+
+            container.Setup(e => e.GetBlobClient(It.IsAny<string>()))
+                .Returns(_client.Object);
+            container.Setup(e => e.CreateIfNotExistsAsync(It.IsAny<PublicAccessType>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<BlobContainerEncryptionScopeOptions>(), It.IsAny<CancellationToken>()));
+
+            _storage = new BlobsStorage(container.Object);
+        }
+
+        private class StoreItem : IStoreItem
+        {
+            public string ETag { get; set; }
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/BlobsTranscriptStoreTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/BlobsTranscriptStoreTests.cs
@@ -2,182 +2,357 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Reflection;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure;
 using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
 using Microsoft.Bot.Builder.Azure.Blobs;
 using Microsoft.Bot.Schema;
+using Moq;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Xunit;
-using Xunit.Abstractions;
-using Xunit.Sdk;
 
-// These tests require Azure Storage Emulator v5.7
-// The emulator must be installed at this path C:\Program Files (x86)\Microsoft SDKs\Azure\Storage Emulator\AzureStorageEmulator.exe
-// More info: https://docs.microsoft.com/azure/storage/common/storage-use-emulator
 namespace Microsoft.Bot.Builder.Azure.Tests
 {
     [Trait("TestCategory", "Storage")]
     [Trait("TestCategory", "Storage - BlobsTranscriptStore")]
-    public class BlobsTranscriptStoreTests : TranscriptStoreBaseTests, IAsyncLifetime
+    public class BlobsTranscriptStoreTests
     {
-        private readonly string _testName;
+        private const string ConnectionString = @"UseDevelopmentStorage=true";
 
-        public BlobsTranscriptStoreTests(ITestOutputHelper testOutputHelper)
+        private BlobsTranscriptStore _storage;
+        private readonly Mock<BlobClient> _client = new Mock<BlobClient>();
+        private readonly Mock<BlobContainerClient> _container = new Mock<BlobContainerClient>();
+        private readonly Activity _activity = new Activity
         {
-            var helper = (TestOutputHelper)testOutputHelper;
+            Type = ActivityTypes.Message,
+            Text = "Text",
+            Id = "Id",
+            ChannelId = "ChannelId",
+            Conversation = new ConversationAccount { Id = "Conversation-Id" },
+            Timestamp = new DateTimeOffset(),
+            From = new ChannelAccount { Id = "From-Id" },
+            Recipient = new ChannelAccount { Id = "Recipient-Id" }
+        };
 
-            var test = (ITest)helper.GetType().GetField("test", BindingFlags.NonPublic | BindingFlags.Instance)
-                .GetValue(helper);
-
-            _testName = test.TestCase.TestMethod.Method.Name;
-
-            if (StorageEmulatorHelper.CheckEmulator())
-            {
-                new BlobContainerClient(BlobStorageEmulatorConnectionString, ContainerName)
-                    .DeleteIfExistsAsync().ConfigureAwait(false);
-            }
-        }
-
-        protected override string ContainerName => $"blobstranscript{_testName.ToLower()}";
-
-        protected override ITranscriptStore TranscriptStore => new BlobsTranscriptStore(BlobStorageEmulatorConnectionString, ContainerName);
-
-        public Task InitializeAsync()
-        {
-            return Task.CompletedTask;
-        }
-
-        public async Task DisposeAsync()
-        {
-            if (StorageEmulatorHelper.CheckEmulator())
-            {
-                await new BlobContainerClient(BlobStorageEmulatorConnectionString, ContainerName)
-                    .DeleteIfExistsAsync().ConfigureAwait(false);
-            }
-        }
-
-        // These tests require Azure Storage Emulator v5.7
         [Fact]
-        public async Task LongIdAddTest()
+        public void ConstructorValidation()
         {
-            if (StorageEmulatorHelper.CheckEmulator())
-            {
-                try
-                {
-                    var a = CreateActivity(0, 0, LongId);
+            // Should work.
+            _ = new BlobsTranscriptStore(
+                ConnectionString,
+                "containerName",
+                JsonSerializer.Create(new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All }));
 
-                    await TranscriptStore.LogActivityAsync(a);
-                    throw new XunitException("Should have thrown an error");
-                }
-                catch (System.Xml.XmlException xmlEx)
+            // No dataConnectionString. Should throw.
+            Assert.Throws<ArgumentNullException>(() => new BlobsTranscriptStore(null, "containerName"));
+            Assert.Throws<ArgumentNullException>(() => new BlobsTranscriptStore(string.Empty, "containerName"));
+
+            // No containerName. Should throw.
+            Assert.Throws<ArgumentNullException>(() => new BlobsTranscriptStore(ConnectionString, null));
+            Assert.Throws<ArgumentNullException>(() => new BlobsTranscriptStore(ConnectionString, string.Empty));
+        }
+
+        [Fact]
+        public async void LogActivityAsync()
+        {
+            InitStorage();
+
+            await _storage.LogActivityAsync(_activity);
+
+            _client.Verify(e => e.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async void LogActivityAsyncMessageUpdate()
+        {
+            InitStorage();
+
+            _activity.Type = ActivityTypes.MessageUpdate;
+
+            await _storage.LogActivityAsync(_activity);
+
+            _client.Verify(e => e.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async void LogActivityAsyncMessageUpdateNotFound()
+        {
+            InitStorage();
+
+            _activity.Type = ActivityTypes.MessageUpdate;
+
+            Stream stream = new MemoryStream(Encoding.ASCII.GetBytes(string.Empty));
+            var blobDownloadInfo = BlobsModelFactory.BlobDownloadInfo(content: stream);
+            var response = new Mock<Response<BlobDownloadInfo>>();
+
+            response.SetupGet(e => e.Value).Returns(blobDownloadInfo);
+            _client.Setup(e => e.DownloadAsync()).ReturnsAsync(response.Object);
+
+            await _storage.LogActivityAsync(_activity);
+
+            _client.Verify(e => e.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+            _client.Verify(e => e.DownloadAsync(), Times.Once);
+        }
+
+        [Fact]
+        public async void LogActivityAsyncMessageDelete()
+        {
+            InitStorage();
+
+            _activity.Type = ActivityTypes.MessageDelete;
+
+            await _storage.LogActivityAsync(_activity);
+
+            _client.Verify(e => e.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async void LogActivityAsyncContinuationToken()
+        {
+            InitStorage();
+
+            var continuationPage = GeneratePage(0, "0");
+            var finalPage = GeneratePage(0);
+            var processed = false;
+
+            _container.Setup(e => e.GetBlobsAsync(It.IsAny<BlobTraits>(), It.IsAny<BlobStates>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(() =>
                 {
-                    // Unfortunately, Azure.Storage.Blobs v12.4.4 currently throws this XmlException for long keys :(
-                    if (xmlEx.Message == "'\"' is an unexpected token. Expecting whitespace. Line 1, position 50.")
+                    if (processed)
                     {
-                        return;
+                        return finalPage.Object;
                     }
-                }
 
-                throw new XunitException("Should have thrown an error");
-            }
-        }
+                    processed = true;
+                    return continuationPage.Object;
+                });
 
-        // These tests require Azure Storage Emulator v5.7
-        [Fact]
-        public void BlobTranscriptParamTest()
-        {
-            if (StorageEmulatorHelper.CheckEmulator())
-            {
-                Assert.Throws<ArgumentNullException>(() =>
-                    new BlobsTranscriptStore(null, ContainerName));
+            _activity.Type = ActivityTypes.MessageUpdate;
 
-                Assert.Throws<ArgumentNullException>(() =>
-                    new BlobsTranscriptStore(BlobStorageEmulatorConnectionString, null));
+            await _storage.LogActivityAsync(_activity);
 
-                Assert.Throws<ArgumentNullException>(() =>
-                    new BlobsTranscriptStore(string.Empty, ContainerName));
-
-                Assert.Throws<ArgumentNullException>(() =>
-                    new BlobsTranscriptStore(BlobStorageEmulatorConnectionString, string.Empty));
-            }
+            _client.Verify(e => e.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Fact]
-        public async Task GenericActivityOverwriteThrowsTest()
+        public async void LogActivityAsyncHttpPreconditionFailure()
         {
-            if (StorageEmulatorHelper.CheckEmulator())
-            {
-                var conversationId = "GenericActivityOverwriteThrowsTest";
+            InitStorage();
+            var precondition = true;
 
-                var activity = CreateActivity(99, conversationId);
-
-                await TranscriptStore.LogActivityAsync(activity);
-                var loggedActivities = await TranscriptStore.GetTranscriptActivitiesAsync(ChannelId, conversationId);
-
-                Assert.Equal("100", loggedActivities.Items[0].Id);
-
-                await Assert.ThrowsAsync<RequestFailedException>(async () => await TranscriptStore.LogActivityAsync(activity));
-            }
-        }
-
-        [Fact]
-        public async Task UpdateActivityOverwriteDoesNotThrowTest()
-        {
-            if (StorageEmulatorHelper.CheckEmulator())
-            {
-                var conversationId = "UpdateActivityOverwriteDoesNotThrowTest";
-
-                var activity = CreateActivity(99, conversationId);
-                activity.ChannelData = new
+            _container.Setup(e => e.GetBlobsAsync(It.IsAny<BlobTraits>(), It.IsAny<BlobStates>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(() =>
                 {
-                    value = "original"
-                };
+                    if (!precondition)
+                    {
+                        throw new Exception("error");
+                    }
 
-                await TranscriptStore.LogActivityAsync(activity);
-                var loggedActivities = await TranscriptStore.GetTranscriptActivitiesAsync(ChannelId, conversationId);
+                    precondition = false;
+                    throw new RequestFailedException((int)HttpStatusCode.PreconditionFailed, "error");
+                });
 
-                Assert.Equal("100", loggedActivities.Items[0].Id);
-                Assert.Equal("original", (loggedActivities.Items[0].ChannelData as JToken)["value"]);
+            _activity.Type = ActivityTypes.MessageUpdate;
 
-                activity.Type = ActivityTypes.MessageUpdate;
-                activity.ChannelData = new
-                {
-                    value = "overwritten"
-                };
+            await Assert.ThrowsAsync<Exception>(() => _storage.LogActivityAsync(_activity));
 
-                await TranscriptStore.LogActivityAsync(activity);
-                loggedActivities = await TranscriptStore.GetTranscriptActivitiesAsync(ChannelId, conversationId);
-
-                Assert.Single(loggedActivities.Items);
-                Assert.Equal("overwritten", (loggedActivities.Items[0].ChannelData as JToken)["value"]);
-            }
+            _container.Verify(e => e.GetBlobsAsync(It.IsAny<BlobTraits>(), It.IsAny<BlobStates>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
         }
 
         [Fact]
-        public async Task TombstonedActivityOverwriteDoesNotThrowTest()
+        public async void GetTranscriptActivitiesAsyncValidation()
         {
-            if (StorageEmulatorHelper.CheckEmulator())
+            InitStorage();
+
+            // No channelId. Should throw.
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _storage.GetTranscriptActivitiesAsync(null, "conversationId"));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _storage.GetTranscriptActivitiesAsync(string.Empty, "conversationId"));
+
+            // No conversationId. Should throw.
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _storage.GetTranscriptActivitiesAsync("channelId", null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _storage.GetTranscriptActivitiesAsync("channelId", string.Empty));
+        }
+
+        [Fact]
+        public async void GetTranscriptActivitiesAsync()
+        {
+            InitStorage();
+
+            var pageResult = await _storage.GetTranscriptActivitiesAsync("channelId", "conversationId");
+
+            Assert.NotNull(pageResult);
+            Assert.Single(pageResult.Items);
+            Assert.Equal(_activity.Id, pageResult.Items[0].Id);
+            _client.Verify(e => e.DownloadAsync(), Times.Once);
+        }
+
+        [Fact]
+        public async void GetTranscriptActivitiesAsyncContinuationToken()
+        {
+            InitStorage();
+
+            var pageResult = await _storage.GetTranscriptActivitiesAsync("channelId", "conversationId", "1");
+
+            Assert.NotNull(pageResult);
+            Assert.Empty(pageResult.Items);
+            _client.Verify(e => e.DownloadAsync(), Times.Never);
+        }
+
+        [Fact]
+        public async void GetTranscriptActivitiesAsyncFullPageSize()
+        {
+            const int pageSize = 20;
+            InitStorage(20);
+
+            var pageResult = await _storage.GetTranscriptActivitiesAsync("channelId", "conversationId");
+
+            Assert.NotNull(pageResult);
+            Assert.Equal(pageSize, pageResult.Items.Length);
+            Assert.Equal(pageSize.ToString(), pageResult.ContinuationToken);
+            _client.Verify(e => e.DownloadAsync(), Times.Exactly(20));
+        }
+
+        [Fact]
+        public async void ListTranscriptsAsyncValidation()
+        {
+            InitStorage();
+
+            // No channelId. Should throw.
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _storage.ListTranscriptsAsync(null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _storage.ListTranscriptsAsync(string.Empty));
+        }
+
+        [Fact]
+        public async void ListTranscriptsAsync()
+        {
+            InitStorage();
+
+            var pageResult = await _storage.ListTranscriptsAsync("channelId");
+
+            Assert.NotNull(pageResult);
+            Assert.Single(pageResult.Items);
+            Assert.Equal("1", pageResult.Items[0].Id);
+        }
+
+        [Fact]
+        public async void ListTranscriptsAsyncContinuationToken()
+        {
+            InitStorage();
+
+            var pageResult = await _storage.ListTranscriptsAsync("channelId", "1");
+
+            Assert.NotNull(pageResult);
+            Assert.Empty(pageResult.Items);
+            _client.Verify(e => e.DownloadAsync(), Times.Never);
+        }
+
+        [Fact]
+        public async void ListTranscriptsAsyncFullPageSize()
+        {
+            const int pageSize = 20;
+            InitStorage(pageSize);
+
+            var pageResult = await _storage.ListTranscriptsAsync("channelId");
+
+            Assert.NotNull(pageResult);
+            Assert.Equal(pageSize, pageResult.Items.Length);
+            Assert.Equal(pageSize.ToString(), pageResult.ContinuationToken);
+        }
+
+        [Fact]
+        public async void DeleteTranscriptAsyncValidation()
+        {
+            InitStorage();
+
+            // No channelId. Should throw.
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _storage.DeleteTranscriptAsync(null, "conversationId"));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _storage.DeleteTranscriptAsync(string.Empty, "conversationId"));
+
+            // No conversationId. Should throw.
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _storage.DeleteTranscriptAsync("channelId", null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _storage.DeleteTranscriptAsync("channelId", string.Empty));
+        }
+
+        [Fact]
+        public async void DeleteTranscriptAsync()
+        {
+            InitStorage();
+
+            _client.Setup(e => e.DeleteIfExistsAsync(It.IsAny<DeleteSnapshotsOption>(), It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()));
+
+            await _storage.DeleteTranscriptAsync("channelId", "conversationId");
+
+            _client.Verify(e => e.DeleteIfExistsAsync(It.IsAny<DeleteSnapshotsOption>(), It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        private void InitStorage(int pageSize = 1)
+        {
+            var page = GeneratePage(pageSize);
+
+            _container.Setup(e => e.GetBlobsAsync(It.IsAny<BlobTraits>(), It.IsAny<BlobStates>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(page.Object);
+            _container.Setup(e => e.GetBlobClient(It.IsAny<string>()))
+                .Returns(_client.Object);
+            _client.Setup(e => e.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()));
+            _client.Setup(e => e.DownloadAsync())
+                .ReturnsAsync(() =>
+                {
+                    Stream stream = new MemoryStream(Encoding.ASCII.GetBytes(JsonConvert.SerializeObject(_activity)));
+                    var blobDownloadInfo = BlobsModelFactory.BlobDownloadInfo(content: stream);
+                    var response = new Mock<Response<BlobDownloadInfo>>();
+
+                    response.SetupGet(e => e.Value).Returns(blobDownloadInfo);
+                    return response.Object;
+                });
+
+            _storage = new BlobsTranscriptStore(_container.Object);
+        }
+
+        private Mock<AsyncPageable<BlobItem>> GeneratePage(int pageSize = 1, string continuationToken = default)
+        {
+            var page = new Mock<Page<BlobItem>>();
+            var asyncPageable = new Mock<AsyncPageable<BlobItem>>();
+
+            async IAsyncEnumerable<Page<BlobItem>> GenerateItems()
             {
-                var conversationId = "TombstonedActivityOverwriteDoesNotThrowTest";
-
-                var activity = CreateActivity(99, conversationId);
-
-                await TranscriptStore.LogActivityAsync(activity);
-                var loggedActivities = await TranscriptStore.GetTranscriptActivitiesAsync(ChannelId, conversationId);
-
-                Assert.Equal("100", loggedActivities.Items[0].Id);
-
-                activity.Type = ActivityTypes.MessageDelete;
-
-                await TranscriptStore.LogActivityAsync(activity);
-                loggedActivities = await TranscriptStore.GetTranscriptActivitiesAsync(ChannelId, conversationId);
-
-                Assert.Single(loggedActivities.Items);
-                Assert.Equal("deleted", loggedActivities.Items[0].From.Id);
+                yield return await Task.FromResult(page.Object);
             }
+
+            var items = GenerateItems();
+            var blobItems = GenerateBlobItems(pageSize);
+
+            page.SetupGet(e => e.ContinuationToken).Returns(continuationToken);
+            page.SetupGet(e => e.Values).Returns(blobItems);
+
+            asyncPageable.Setup(e => e.AsPages(It.IsAny<string>(), It.IsAny<int?>()))
+                .Returns(items);
+
+            return asyncPageable;
+        }
+
+        private IReadOnlyList<BlobItem> GenerateBlobItems(int pageSize = 1)
+        {
+            var blobItems = new List<BlobItem>();
+            for (var i = 1; i <= pageSize; i++)
+            {
+                var blobItem = BlobsModelFactory.BlobItem(
+                    name: i.ToString(),
+                    metadata: new Dictionary<string, string>
+                    {
+                        { "Id", _activity.Id },
+                        { "Timestamp", DateTime.Now.ToString(CultureInfo.InvariantCulture) }
+                    });
+                blobItems.Add(blobItem);
+            }
+
+            return blobItems;
         }
     }
 }


### PR DESCRIPTION
Addresses # 6292

## Description
This PR removes the existing Functional tests and as a replacement, it adds support for internal testing to the `BlobsStorage` and `BlobsTranscriptStore` classes, and introduces all the necessary unit tests, increasing the **code coverage up to 94%**.
These new tests do not require the Storage Emulator to be running.

## Specific Changes
- Updates the `BlobsStorage` and `BlobsTranscriptStore` classes, adding a new internal constructor.
- Adds new unit tests to the `BlobsStorageTests` and `BlobsTranscriptStoreTests` classes for each method, constructor, method validations, etc.

## Testing
The following images show the new unit tests and the code coverage.
![image](https://user-images.githubusercontent.com/62260472/164308134-342c24e7-1727-4896-9501-69787e9de9f8.png)