### PR TITLE
[#6292] Add unit tests for AzureBlobStorage

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
@@ -14,6 +15,8 @@ using Microsoft.WindowsAzure.Storage.Blob.Protocol;
 using Microsoft.WindowsAzure.Storage.Core;
 using Microsoft.WindowsAzure.Storage.RetryPolicies;
 using Newtonsoft.Json;
+
+[assembly: InternalsVisibleTo("Microsoft.Bot.Builder.Azure.Tests")]
 
 namespace Microsoft.Bot.Builder.Azure
 {
@@ -42,6 +45,7 @@ namespace Microsoft.Bot.Builder.Azure
         private readonly CloudStorageAccount _storageAccount;
         private readonly string _containerName;
         private int _checkforContainerExistance;
+        private readonly CloudBlobClient _blobClient;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AzureBlobStorage"/> class.
@@ -87,6 +91,18 @@ namespace Microsoft.Bot.Builder.Azure
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="AzureBlobStorage"/> class.
+        /// </summary>
+        /// <param name="storageAccount">Azure CloudStorageAccount instance.</param>
+        /// <param name="containerName">Name of the Blob container where entities will be stored.</param>
+        /// <param name="blobClient">Custom implementation of CloudBlobClient.</param>
+        internal AzureBlobStorage(CloudStorageAccount storageAccount, string containerName, CloudBlobClient blobClient)
+            : this(storageAccount, containerName, JsonSerializer)
+        {
+            _blobClient = blobClient;
+        }
+
+        /// <summary>
         /// Deletes entity blobs from the configured container.
         /// </summary>
         /// <param name="keys">An array of entity keys.</param>
@@ -100,7 +116,7 @@ namespace Microsoft.Bot.Builder.Azure
                 throw new ArgumentNullException(nameof(keys));
             }
 
-            var blobClient = _storageAccount.CreateCloudBlobClient();
+            var blobClient = _blobClient ?? _storageAccount.CreateCloudBlobClient();
             var blobContainer = blobClient.GetContainerReference(_containerName);
             foreach (var key in keys)
             {
@@ -124,7 +140,7 @@ namespace Microsoft.Bot.Builder.Azure
                 throw new ArgumentNullException(nameof(keys));
             }
 
-            var blobClient = _storageAccount.CreateCloudBlobClient();
+            var blobClient = _blobClient ?? _storageAccount.CreateCloudBlobClient();
             var blobContainer = blobClient.GetContainerReference(_containerName);
 
             var items = new Dictionary<string, object>();
@@ -168,7 +184,7 @@ namespace Microsoft.Bot.Builder.Azure
                 throw new ArgumentNullException(nameof(changes));
             }
 
-            var blobClient = _storageAccount.CreateCloudBlobClient();
+            var blobClient = _blobClient ?? _storageAccount.CreateCloudBlobClient();
             var blobContainer = blobClient.GetContainerReference(_containerName);
 
             // this should only happen once - assuming this is a singleton


### PR DESCRIPTION
Addresses # 6292

## Description
This PR removes the existing Functional tests for the `AzureBlobStorage` class and replaces them with unit tests that don't require the use of the Azure Storage Emulator.

## Specific Changes
- Updates the `AzureBlobStorage` class, adding a new internal constructor that receives an instance of _CloudBlobClient_. This constructor is for the use of the tests only.
- Replaces the existing tests in the `AzureBlobStorageTests` class with unit tests for each method, constructor, method validations, etc, reaching 89% of code coverage.

## Testing
The following images show the new unit tests and the code coverage.
![image](https://user-images.githubusercontent.com/44245136/164520229-25c5ade0-a990-4a11-a6fc-c7f04c4f5596.png)
