### PR TITLE
[#6292] Add unit tests to cover AzureBlobTranscriptStore

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
@@ -8,11 +8,11 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Blob;
-using Microsoft.WindowsAzure.Storage.Blob.Protocol;
-using Microsoft.WindowsAzure.Storage.Core;
-using Microsoft.WindowsAzure.Storage.RetryPolicies;
+using Microsoft.Azure.Storage;
+using Microsoft.Azure.Storage.Blob;
+using Microsoft.Azure.Storage.Blob.Protocol;
+using Microsoft.Azure.Storage.Core;
+using Microsoft.Azure.Storage.RetryPolicies;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Azure

--- a/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
+++ b/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.15.1" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.13.1" />
-    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="9.4.2" />
+    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="10.0.3" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobStorageTests.cs
@@ -4,8 +4,10 @@
 using System;
 using System.Reflection;
 using System.Threading.Tasks;
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Blob;
+using Microsoft.Azure.Storage;
+using Microsoft.Azure.Storage.Auth;
+using Microsoft.Azure.Storage.Blob;
+using Microsoft.Azure.Storage.Core;
 using Newtonsoft.Json;
 using Xunit;
 using Xunit.Abstractions;

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobTranscriptStoreTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobTranscriptStoreTests.cs
@@ -2,116 +2,502 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Reflection;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Auth;
-using Microsoft.WindowsAzure.Storage.Blob;
+using Microsoft.Azure.Storage;
+using Microsoft.Azure.Storage.Auth;
+using Microsoft.Azure.Storage.Blob;
+using Microsoft.Bot.Schema;
+using Moq;
+using Newtonsoft.Json;
 using Xunit;
-using Xunit.Abstractions;
-using Xunit.Sdk;
 
-// These tests require Azure Storage Emulator v5.7
-// The emulator must be installed at this path C:\Program Files (x86)\Microsoft SDKs\Azure\Storage Emulator\AzureStorageEmulator.exe
-// More info: https://docs.microsoft.com/azure/storage/common/storage-use-emulator
 namespace Microsoft.Bot.Builder.Azure.Tests
 {
-    [Trait("TestCategory", "Storage")]
-    [Trait("TestCategory", "Storage - BlobTranscripts")]
-    public class AzureBlobTranscriptStoreTests : TranscriptStoreBaseTests, IAsyncLifetime
+    public class AzureBlobTranscriptStoreTests
     {
-        private readonly string _testName;
+        protected const string ConnectionString = @"UseDevelopmentStorage=true";
+        protected const string ContainerName = "containername";
 
-        public AzureBlobTranscriptStoreTests(ITestOutputHelper testOutputHelper)
-        {
-            var helper = (TestOutputHelper)testOutputHelper;
+        private Mock<CloudBlobStream> _stream;
+        private Mock<CloudBlockBlob> _mockBlockBlob;
+        private Mock<CloudBlobContainer> _mockContainer;
+        private Mock<CloudBlobClient> _mockBlobClient;
+        private Mock<CloudStorageAccount> _mockAccount;
+        private AzureBlobTranscriptStore _blobTranscript;
+        private BlobResultSegment _segment;
+        private Mock<CloudBlobDirectory> _mockDirectory;
+        private Activity _activity;
 
-            var test = (ITest)helper.GetType().GetField("test", BindingFlags.NonPublic | BindingFlags.Instance)
-                .GetValue(helper);
-
-            _testName = test.TestCase.TestMethod.Method.Name;
-
-            if (StorageEmulatorHelper.CheckEmulator())
-            {
-                CloudStorageAccount.Parse(BlobStorageEmulatorConnectionString)
-                    .CreateCloudBlobClient()
-                    .GetContainerReference(ContainerName)
-                    .DeleteIfExistsAsync().ConfigureAwait(false);
-            }
-        }
-
-        protected override string ContainerName => $"blobtranscript{_testName.ToLower()}";
-
-        protected override ITranscriptStore TranscriptStore => new AzureBlobTranscriptStore(BlobStorageEmulatorConnectionString, ContainerName);
-
-        public Task InitializeAsync()
-        {
-            return Task.CompletedTask;
-        }
-
-        public async Task DisposeAsync()
-        {
-            if (StorageEmulatorHelper.CheckEmulator())
-            {
-                await CloudStorageAccount.Parse(BlobStorageEmulatorConnectionString)
-                    .CreateCloudBlobClient()
-                    .GetContainerReference(ContainerName)
-                    .DeleteIfExistsAsync().ConfigureAwait(false);
-            }
-        }
-
-        // These tests require Azure Storage Emulator v5.7
         [Fact]
-        public async Task LongIdAddTest()
+        public void ConstructorValidation()
         {
-            if (StorageEmulatorHelper.CheckEmulator())
-            {
-                try
-                {
-                    var a = CreateActivity(0, 0, LongId);
+            var storageAccount = CloudStorageAccount.Parse(ConnectionString);
 
-                    await TranscriptStore.LogActivityAsync(a);
+            // Should work.
+            Assert.NotNull(new AzureBlobTranscriptStore(ConnectionString, ContainerName));
+            Assert.NotNull(new AzureBlobTranscriptStore(storageAccount, ContainerName));
 
-                    throw new XunitException("Should have thrown an error");
-                }
-                catch (StorageException)
-                {
-                    return;
-                }
-            }
+            // No storageAccount. Should throw.
+            Assert.Throws<ArgumentNullException>(() => new AzureBlobTranscriptStore(storageAccount: null, ContainerName));
+
+            // No containerName. Should throw.
+            Assert.Throws<ArgumentNullException>(() => new AzureBlobTranscriptStore(storageAccount, null));
+
+            // Wrong format. Should throw.
+            Assert.Throws<FormatException>(() => new AzureBlobTranscriptStore("123", ContainerName));
         }
 
-        // These tests require Azure Storage Emulator v5.7
         [Fact]
-        public void BlobTranscriptParamTest()
+        public async Task LogActivityAsyncNullActivityFailure()
         {
-            if (StorageEmulatorHelper.CheckEmulator())
-            {
-                Assert.Throws<FormatException>(() => new AzureBlobTranscriptStore("123", ContainerName));
+            var storageAccount = CloudStorageAccount.Parse(ConnectionString);
+            var blobTranscript = new AzureBlobTranscriptStore(storageAccount, ContainerName);
 
-                Assert.Throws<ArgumentNullException>(() => new AzureBlobTranscriptStore(new CloudStorageAccount(new StorageCredentials(), false), string.Empty));
-
-                Assert.Throws<ArgumentNullException>(() =>
-                    new AzureBlobTranscriptStore((CloudStorageAccount)null, ContainerName));
-
-                Assert.Throws<ArgumentNullException>(() =>
-                    new AzureBlobTranscriptStore((string)null, ContainerName));
-
-                Assert.Throws<ArgumentNullException>(() =>
-                    new AzureBlobTranscriptStore((CloudStorageAccount)null, null));
-
-                Assert.Throws<ArgumentNullException>(() => new AzureBlobTranscriptStore((string)null, null));
-            }
+            await Assert.ThrowsAsync<ArgumentNullException>(() => blobTranscript.LogActivityAsync(null));
         }
 
-        // These tests require Azure Storage Emulator v5.7
         [Fact]
-        public async void ListTranscriptsAsyncWithEmptyChannelIdShouldFail()
+        public async Task LogActivityAsyncDefault()
         {
-            if (StorageEmulatorHelper.CheckEmulator())
+            InitStorage();
+
+            _activity = new Activity
             {
-                await Assert.ThrowsAsync<ArgumentNullException>(() => TranscriptStore.ListTranscriptsAsync(string.Empty));
-            }
+                Type = ActivityTypes.Message,
+                Text = "Hello",
+                Id = "test-id",
+                ChannelId = "channel-id",
+                Conversation = new ConversationAccount() { Id = "conversation-id" },
+                Timestamp = new DateTimeOffset(),
+                From = new ChannelAccount() { Id = "account-1" },
+                Recipient = new ChannelAccount() { Id = "account-2" }
+            };
+
+            await _blobTranscript.LogActivityAsync(_activity);
+
+            _mockBlobClient.Verify(x => x.GetContainerReference(It.IsAny<string>()), Times.Once);
+            _mockContainer.Verify(x => x.GetBlockBlobReference(It.IsAny<string>()), Times.Once);
+            _mockBlockBlob.Verify(x => x.OpenWriteAsync(), Times.Once);
+            _mockBlockBlob.Verify(x => x.SetMetadataAsync(), Times.Once);
+        }
+
+        [Fact]
+        public async Task LogActivityAsyncMessageUpdate()
+        {
+            _activity = new Activity
+            {
+                Type = ActivityTypes.MessageUpdate,
+                Text = "Hello",
+                Id = "test-id",
+                ChannelId = "channel-id",
+                Conversation = new ConversationAccount { Id = "conversation-id" },
+                Timestamp = new DateTimeOffset(),
+                From = new ChannelAccount { Id = "account-1" },
+                Recipient = new ChannelAccount { Id = "account-2" }
+            };
+
+            InitStorage();
+
+            _mockBlockBlob.Setup(x => x.DownloadTextAsync()).Returns(Task.FromResult(JsonConvert.SerializeObject(_activity)));
+
+            await _blobTranscript.LogActivityAsync(_activity);
+
+            _mockBlobClient.Verify(x => x.GetContainerReference(It.IsAny<string>()), Times.Once);
+            _mockContainer.Verify(x => x.GetDirectoryReference(It.IsAny<string>()), Times.Once);
+            _mockBlockBlob.Verify(x => x.DownloadTextAsync(), Times.Exactly(2));
+            _mockBlockBlob.Verify(x => x.OpenWriteAsync(), Times.Once);
+            _mockBlockBlob.Verify(x => x.SetMetadataAsync(), Times.Exactly(2));
+            _mockDirectory.Verify(
+                x => x.ListBlobsSegmentedAsync(
+                    It.IsAny<bool>(),
+                    It.IsAny<BlobListingDetails>(),
+                    It.IsAny<int>(),
+                    It.IsAny<BlobContinuationToken>(),
+                    It.IsAny<BlobRequestOptions>(),
+                    It.IsAny<OperationContext>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task LogActivityAsyncMessageUpdateNullBlob()
+        {
+            _activity = new Activity
+            {
+                Type = ActivityTypes.MessageUpdate,
+                Text = "Hello",
+                Id = "test-id",
+                ChannelId = "channel-id",
+                Conversation = new ConversationAccount() { Id = "conversation-id" },
+                Timestamp = new DateTimeOffset(),
+                From = new ChannelAccount() { Id = "account-1" },
+                Recipient = new ChannelAccount() { Id = "account-2" }
+            };
+
+            InitStorage();
+
+            var segment = new BlobResultSegment(new List<CloudBlockBlob>(), null);
+
+            _mockDirectory.Setup(x => x.ListBlobsSegmentedAsync(
+                It.IsAny<bool>(),
+                It.IsAny<BlobListingDetails>(),
+                It.IsAny<int>(),
+                It.IsAny<BlobContinuationToken>(),
+                It.IsAny<BlobRequestOptions>(),
+                It.IsAny<OperationContext>())).Returns(Task.FromResult(segment));
+
+            _mockContainer.Setup(x => x.GetDirectoryReference(It.IsAny<string>())).Returns(_mockDirectory.Object);
+
+            await _blobTranscript.LogActivityAsync(_activity);
+
+            _mockBlobClient.Verify(x => x.GetContainerReference(It.IsAny<string>()), Times.Once);
+            _mockContainer.Verify(x => x.GetDirectoryReference(It.IsAny<string>()), Times.Once);
+            _mockContainer.Verify(x => x.GetBlockBlobReference(It.IsAny<string>()), Times.Once);
+            _mockBlockBlob.Verify(x => x.OpenWriteAsync(), Times.Once);
+            _mockBlockBlob.Verify(x => x.SetMetadataAsync(), Times.Once);
+            _mockDirectory.Verify(
+                x => x.ListBlobsSegmentedAsync(
+                    It.IsAny<bool>(),
+                    It.IsAny<BlobListingDetails>(),
+                    It.IsAny<int>(),
+                    It.IsAny<BlobContinuationToken>(),
+                    It.IsAny<BlobRequestOptions>(),
+                    It.IsAny<OperationContext>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task LogActivityAsyncMessageDelete()
+        {
+            _activity = new Activity
+            {
+                Type = ActivityTypes.MessageDelete,
+                Text = "Hello",
+                Id = "test-id",
+                ChannelId = "channel-id",
+                Conversation = new ConversationAccount { Id = "conversation-id" },
+                Timestamp = new DateTimeOffset(),
+                From = new ChannelAccount { Id = "account-1" },
+                Recipient = new ChannelAccount { Id = "account-2" }
+            };
+
+            InitStorage();
+
+            _mockBlockBlob.Setup(x => x.DownloadTextAsync()).Returns(Task.FromResult(JsonConvert.SerializeObject(_activity)));
+
+            await _blobTranscript.LogActivityAsync(_activity);
+
+            _mockBlobClient.Verify(x => x.GetContainerReference(It.IsAny<string>()), Times.Once);
+            _mockContainer.Verify(x => x.GetDirectoryReference(It.IsAny<string>()), Times.Once);
+            _mockBlockBlob.Verify(x => x.DownloadTextAsync(), Times.Exactly(2));
+            _mockBlockBlob.Verify(x => x.OpenWriteAsync(), Times.Once);
+            _mockBlockBlob.Verify(x => x.SetMetadataAsync(), Times.Exactly(2));
+            _mockDirectory.Verify(
+                x => x.ListBlobsSegmentedAsync(
+                    It.IsAny<bool>(),
+                    It.IsAny<BlobListingDetails>(),
+                    It.IsAny<int>(),
+                    It.IsAny<BlobContinuationToken>(),
+                    It.IsAny<BlobRequestOptions>(),
+                    It.IsAny<OperationContext>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetTranscriptActivitiesAsyncValidations()
+        {
+            var storageAccount = CloudStorageAccount.Parse(ConnectionString);
+            var blobTranscript = new AzureBlobTranscriptStore(storageAccount, ContainerName);
+
+            // No channel id. Should throw.
+            await Assert.ThrowsAsync<ArgumentNullException>(() => blobTranscript.GetTranscriptActivitiesAsync(null, "convo-id"));
+
+            // No conversation id. Should throw.
+            await Assert.ThrowsAsync<ArgumentNullException>(() => blobTranscript.GetTranscriptActivitiesAsync("channel-id", null));
+        }
+
+        [Fact]
+        public async Task GetTranscriptActivitiesAsync()
+        {
+            InitStorage();
+
+            _mockDirectory.Setup(x => x.ListBlobsSegmentedAsync(
+                It.IsAny<bool>(),
+                It.IsAny<BlobListingDetails>(),
+                null,
+                It.IsAny<BlobContinuationToken>(),
+                It.IsAny<BlobRequestOptions>(),
+                It.IsAny<OperationContext>())).Returns(Task.FromResult(_segment));
+
+            await _blobTranscript.GetTranscriptActivitiesAsync("channelId", "conversationId");
+
+            _mockBlobClient.Verify(x => x.GetContainerReference(It.IsAny<string>()), Times.Once);
+            _mockContainer.Verify(x => x.GetDirectoryReference(It.IsAny<string>()), Times.Once);
+            _mockDirectory.Verify(
+                x => x.ListBlobsSegmentedAsync(
+                    It.IsAny<bool>(),
+                    It.IsAny<BlobListingDetails>(),
+                    null,
+                    It.IsAny<BlobContinuationToken>(),
+                    It.IsAny<BlobRequestOptions>(),
+                    It.IsAny<OperationContext>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetTranscriptActivitiesAsyncWithMetadata()
+        {
+            InitStorage();
+
+            _mockBlockBlob.Object.Metadata["Timestamp"] = DateTime.Now.ToString(CultureInfo.InvariantCulture);
+
+            _mockDirectory.Setup(x => x.ListBlobsSegmentedAsync(
+                It.IsAny<bool>(),
+                It.IsAny<BlobListingDetails>(),
+                null,
+                It.IsAny<BlobContinuationToken>(),
+                It.IsAny<BlobRequestOptions>(),
+                It.IsAny<OperationContext>())).Returns(Task.FromResult(_segment));
+
+            await _blobTranscript.GetTranscriptActivitiesAsync("channelId", "conversationId");
+
+            _mockBlobClient.Verify(x => x.GetContainerReference(It.IsAny<string>()), Times.Once);
+            _mockContainer.Verify(x => x.GetDirectoryReference(It.IsAny<string>()), Times.Once);
+            _mockDirectory.Verify(
+                x => x.ListBlobsSegmentedAsync(
+                    It.IsAny<bool>(),
+                    It.IsAny<BlobListingDetails>(),
+                    null,
+                    It.IsAny<BlobContinuationToken>(),
+                    It.IsAny<BlobRequestOptions>(),
+                    It.IsAny<OperationContext>()), Times.Once);
+
+            _mockBlobClient.Verify(x => x.GetContainerReference(It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetTranscriptActivitiesAsyncContinuationToken()
+        {
+            InitStorage();
+
+            _mockBlockBlob.Object.Metadata["Timestamp"] = DateTime.Now.ToString(CultureInfo.InvariantCulture);
+            _mockBlockBlob.SetupGet(x => x.Name).Returns("token-name");
+
+            _mockDirectory.Setup(x => x.ListBlobsSegmentedAsync(
+                It.IsAny<bool>(),
+                It.IsAny<BlobListingDetails>(),
+                null,
+                It.IsAny<BlobContinuationToken>(),
+                It.IsAny<BlobRequestOptions>(),
+                It.IsAny<OperationContext>())).Returns(Task.FromResult(_segment));
+
+            await _blobTranscript.GetTranscriptActivitiesAsync("channelId", "conversationId", "token-name");
+
+            _mockBlobClient.Verify(x => x.GetContainerReference(It.IsAny<string>()), Times.Once);
+            _mockContainer.Verify(x => x.GetDirectoryReference(It.IsAny<string>()), Times.Once);
+            _mockDirectory.Verify(
+                x => x.ListBlobsSegmentedAsync(
+                    It.IsAny<bool>(),
+                    It.IsAny<BlobListingDetails>(),
+                    null,
+                    It.IsAny<BlobContinuationToken>(),
+                    It.IsAny<BlobRequestOptions>(),
+                    It.IsAny<OperationContext>()), Times.Once);
+
+            _mockBlobClient.Verify(x => x.GetContainerReference(It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetTranscriptActivitiesAsyncMultipleBlobs()
+        {
+            InitStorage();
+
+            var jsonString = JsonConvert.SerializeObject(new Activity());
+            _mockBlockBlob.Setup(x => x.DownloadTextAsync()).Returns(Task.FromResult(jsonString));
+            _mockBlockBlob.Object.Metadata["Timestamp"] = DateTime.Now.ToString(CultureInfo.InvariantCulture);
+            _mockBlockBlob.SetupGet(x => x.Name).Returns("token-name");
+
+            var segment = new BlobResultSegment(CreateSegment(21, _mockBlockBlob.Object).ToList(), null);
+
+            _mockDirectory.Setup(x => x.ListBlobsSegmentedAsync(
+                It.IsAny<bool>(),
+                It.IsAny<BlobListingDetails>(),
+                null,
+                It.IsAny<BlobContinuationToken>(),
+                It.IsAny<BlobRequestOptions>(),
+                It.IsAny<OperationContext>())).Returns(Task.FromResult(segment));
+
+            await _blobTranscript.GetTranscriptActivitiesAsync("channelId", "conversationId", "token-name");
+
+            _mockBlobClient.Verify(x => x.GetContainerReference(It.IsAny<string>()), Times.Once);
+            _mockContainer.Verify(x => x.GetDirectoryReference(It.IsAny<string>()), Times.Once);
+            _mockDirectory.Verify(
+                x => x.ListBlobsSegmentedAsync(
+                    It.IsAny<bool>(),
+                    It.IsAny<BlobListingDetails>(),
+                    null,
+                    It.IsAny<BlobContinuationToken>(),
+                    It.IsAny<BlobRequestOptions>(),
+                    It.IsAny<OperationContext>()), Times.Once);
+
+            _mockBlobClient.Verify(x => x.GetContainerReference(It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task ListTranscriptAsyncValidations()
+        {
+            var storageAccount = CloudStorageAccount.Parse(ConnectionString);
+            var blobTranscript = new AzureBlobTranscriptStore(storageAccount, ContainerName);
+
+            // No channel id. Should throw.
+            await Assert.ThrowsAsync<ArgumentNullException>(() => blobTranscript.ListTranscriptsAsync(null));
+        }
+
+        [Fact]
+        public async Task ListTranscriptAsync()
+        {
+            InitStorage();
+
+            _mockDirectory.Setup(x => x.ListBlobsSegmentedAsync(
+                It.IsAny<bool>(),
+                It.IsAny<BlobListingDetails>(),
+                null,
+                It.IsAny<BlobContinuationToken>(),
+                It.IsAny<BlobRequestOptions>(),
+                It.IsAny<OperationContext>())).Returns(Task.FromResult(_segment));
+
+            _mockContainer.Setup(x => x.GetDirectoryReference(It.IsAny<string>())).Returns(_mockDirectory.Object);
+
+            await _blobTranscript.ListTranscriptsAsync("channelId", null);
+
+            _mockBlobClient.Verify(x => x.GetContainerReference(It.IsAny<string>()), Times.Once);
+            _mockContainer.Verify(x => x.GetDirectoryReference(It.IsAny<string>()), Times.Once);
+            _mockDirectory.Verify(
+                x => x.ListBlobsSegmentedAsync(
+                    It.IsAny<bool>(),
+                    It.IsAny<BlobListingDetails>(),
+                    null,
+                    It.IsAny<BlobContinuationToken>(),
+                    It.IsAny<BlobRequestOptions>(),
+                    It.IsAny<OperationContext>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task DeleteTranscriptAsyncValidations()
+        {
+            var storageAccount = CloudStorageAccount.Parse(ConnectionString);
+            var blobTranscript = new AzureBlobTranscriptStore(storageAccount, ContainerName);
+
+            // No channel id. Should throw.
+            await Assert.ThrowsAsync<ArgumentNullException>(() => blobTranscript.DeleteTranscriptAsync(null, "convo-id"));
+
+            // No conversation id. Should throw.
+            await Assert.ThrowsAsync<ArgumentNullException>(() => blobTranscript.DeleteTranscriptAsync("channel-id", null));
+        }
+
+        [Fact]
+        public async Task DeleteTranscriptAsync()
+        {
+            InitStorage();
+
+            _mockDirectory.Setup(x => x.ListBlobsSegmentedAsync(
+                It.IsAny<bool>(),
+                It.IsAny<BlobListingDetails>(),
+                null,
+                It.IsAny<BlobContinuationToken>(),
+                It.IsAny<BlobRequestOptions>(),
+                It.IsAny<OperationContext>())).Returns(Task.FromResult(_segment));
+
+            await _blobTranscript.DeleteTranscriptAsync("channelId", "convo-id");
+
+            _mockBlobClient.Verify(x => x.GetContainerReference(It.IsAny<string>()), Times.Once);
+            _mockContainer.Verify(x => x.GetDirectoryReference(It.IsAny<string>()), Times.Once);
+            _mockDirectory.Verify(
+                x => x.ListBlobsSegmentedAsync(
+                    It.IsAny<bool>(),
+                    It.IsAny<BlobListingDetails>(),
+                    null,
+                    It.IsAny<BlobContinuationToken>(),
+                    It.IsAny<BlobRequestOptions>(),
+                    It.IsAny<OperationContext>()), Times.Once);
+            _mockBlockBlob.Verify(x => x.DeleteIfExistsAsync(), Times.Once);
+        }
+
+        [Fact]
+        public async Task LogActivityAsyncInternalFindActivityBlobAsync()
+        {
+            _activity = new Activity
+            {
+                Type = ActivityTypes.MessageUpdate,
+                Text = "Hello",
+                Id = "test-id",
+                ChannelId = "channel-id",
+                Conversation = new ConversationAccount { Id = "conversation-id" },
+                Timestamp = new DateTimeOffset(),
+                From = new ChannelAccount { Id = "account-1" },
+                Recipient = new ChannelAccount { Id = "account-2" }
+            };
+
+            InitStorage();
+
+            _mockBlockBlob.Object.Metadata["Id"] = "test-id";
+            _mockBlockBlob.Setup(x => x.DownloadTextAsync()).Returns(Task.FromResult(JsonConvert.SerializeObject(_activity)));
+
+            await _blobTranscript.LogActivityAsync(_activity);
+
+            _mockBlobClient.Verify(x => x.GetContainerReference(It.IsAny<string>()), Times.Once);
+            _mockContainer.Verify(x => x.GetDirectoryReference(It.IsAny<string>()), Times.Once);
+
+            _mockBlockBlob.Verify(x => x.OpenWriteAsync(), Times.Once);
+
+            _mockDirectory.Verify(
+                x => x.ListBlobsSegmentedAsync(
+                    It.IsAny<bool>(),
+                    It.IsAny<BlobListingDetails>(),
+                    It.IsAny<int>(),
+                    It.IsAny<BlobContinuationToken>(),
+                    It.IsAny<BlobRequestOptions>(),
+                    It.IsAny<OperationContext>()), Times.Once);
+        }
+
+        private static IEnumerable<CloudBlockBlob> CreateSegment(int count, CloudBlockBlob blob)
+        {
+            return Enumerable.Range(0, count).Select(x => blob);
+        }
+
+        private void InitStorage()
+        {
+            var jsonString = JsonConvert.SerializeObject(new Activity());
+
+            _stream = new Mock<CloudBlobStream>();
+            _stream.SetupGet(x => x.CanWrite).Returns(true);
+
+            _mockBlockBlob = new Mock<CloudBlockBlob>(new Uri("http://test/myaccount/blob"));
+            _mockBlockBlob.Setup(x => x.OpenWriteAsync()).Returns(Task.FromResult(_stream.Object));
+            _mockBlockBlob.Setup(x => x.SetMetadataAsync());
+            _mockBlockBlob.Setup(x => x.DownloadTextAsync()).Returns(Task.FromResult(JsonConvert.SerializeObject(_activity)));
+            _mockBlockBlob.Setup(x => x.DownloadTextAsync()).Returns(Task.FromResult(jsonString));
+
+            _segment = new BlobResultSegment(new List<CloudBlockBlob> { _mockBlockBlob.Object }, null);
+
+            _mockDirectory = new Mock<CloudBlobDirectory>();
+            _mockDirectory.Setup(x => x.ListBlobsSegmentedAsync(
+                It.IsAny<bool>(),
+                It.IsAny<BlobListingDetails>(),
+                It.IsAny<int>(),
+                It.IsAny<BlobContinuationToken>(),
+                It.IsAny<BlobRequestOptions>(),
+                It.IsAny<OperationContext>())).Returns(Task.FromResult(_segment));
+
+            _mockContainer = new Mock<CloudBlobContainer>(new Uri("https://testuri.com"));
+            _mockContainer.Setup(x => x.GetBlockBlobReference(It.IsAny<string>())).Returns(_mockBlockBlob.Object);
+            _mockContainer.Setup(x => x.CreateIfNotExistsAsync());
+            _mockContainer.Setup(x => x.GetDirectoryReference(It.IsAny<string>())).Returns(_mockDirectory.Object);
+
+            _mockBlobClient = new Mock<CloudBlobClient>(new Uri("https://testuri.com"), null);
+            _mockBlobClient.Setup(x => x.GetContainerReference(It.IsAny<string>())).Returns(_mockContainer.Object);
+
+            _mockAccount = new Mock<CloudStorageAccount>(new StorageCredentials("accountName", "S2V5VmFsdWU=", "key"), false);
+
+            _blobTranscript = new AzureBlobTranscriptStore(_mockAccount.Object, ContainerName, _mockBlobClient.Object);
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobTranscriptStoreTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobTranscriptStoreTests.cs
@@ -16,6 +16,8 @@ using Xunit;
 
 namespace Microsoft.Bot.Builder.Azure.Tests
 {
+    [Trait("TestCategory", "Storage")]
+    [Trait("TestCategory", "Storage - BlobTranscripts")]
     public class AzureBlobTranscriptStoreTests
     {
         protected const string ConnectionString = @"UseDevelopmentStorage=true";

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobTranscriptStoreTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobTranscriptStoreTests.cs
@@ -31,7 +31,18 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         private AzureBlobTranscriptStore _blobTranscript;
         private BlobResultSegment _segment;
         private Mock<CloudBlobDirectory> _mockDirectory;
-        private Activity _activity;
+
+        private Activity _activity = new Activity
+        {
+            Type = ActivityTypes.Message,
+            Text = "Hello",
+            Id = "test-id",
+            ChannelId = "channel-id",
+            Conversation = new ConversationAccount() { Id = "conversation-id" },
+            Timestamp = new DateTimeOffset(),
+            From = new ChannelAccount() { Id = "account-1" },
+            Recipient = new ChannelAccount() { Id = "account-2" }
+        };
 
         [Fact]
         public void ConstructorValidation()
@@ -66,17 +77,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         {
             InitStorage();
 
-            _activity = new Activity
-            {
-                Type = ActivityTypes.Message,
-                Text = "Hello",
-                Id = "test-id",
-                ChannelId = "channel-id",
-                Conversation = new ConversationAccount() { Id = "conversation-id" },
-                Timestamp = new DateTimeOffset(),
-                From = new ChannelAccount() { Id = "account-1" },
-                Recipient = new ChannelAccount() { Id = "account-2" }
-            };
+            _activity.Type = ActivityTypes.Message;
 
             await _blobTranscript.LogActivityAsync(_activity);
 
@@ -89,17 +90,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         [Fact]
         public async Task LogActivityAsyncMessageUpdate()
         {
-            _activity = new Activity
-            {
-                Type = ActivityTypes.MessageUpdate,
-                Text = "Hello",
-                Id = "test-id",
-                ChannelId = "channel-id",
-                Conversation = new ConversationAccount { Id = "conversation-id" },
-                Timestamp = new DateTimeOffset(),
-                From = new ChannelAccount { Id = "account-1" },
-                Recipient = new ChannelAccount { Id = "account-2" }
-            };
+            _activity.Type = ActivityTypes.MessageUpdate;
 
             InitStorage();
 
@@ -125,17 +116,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         [Fact]
         public async Task LogActivityAsyncMessageUpdateNullBlob()
         {
-            _activity = new Activity
-            {
-                Type = ActivityTypes.MessageUpdate,
-                Text = "Hello",
-                Id = "test-id",
-                ChannelId = "channel-id",
-                Conversation = new ConversationAccount() { Id = "conversation-id" },
-                Timestamp = new DateTimeOffset(),
-                From = new ChannelAccount() { Id = "account-1" },
-                Recipient = new ChannelAccount() { Id = "account-2" }
-            };
+            _activity.Type = ActivityTypes.MessageUpdate;
 
             InitStorage();
 
@@ -171,17 +152,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         [Fact]
         public async Task LogActivityAsyncMessageDelete()
         {
-            _activity = new Activity
-            {
-                Type = ActivityTypes.MessageDelete,
-                Text = "Hello",
-                Id = "test-id",
-                ChannelId = "channel-id",
-                Conversation = new ConversationAccount { Id = "conversation-id" },
-                Timestamp = new DateTimeOffset(),
-                From = new ChannelAccount { Id = "account-1" },
-                Recipient = new ChannelAccount { Id = "account-2" }
-            };
+            _activity.Type = ActivityTypes.MessageDelete;
 
             InitStorage();
 
@@ -207,17 +178,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         [Fact]
         public async Task LogActivityAsyncInternalFindActivityBlobAsync()
         {
-            _activity = new Activity
-            {
-                Type = ActivityTypes.MessageUpdate,
-                Text = "Hello",
-                Id = "test-id",
-                ChannelId = "channel-id",
-                Conversation = new ConversationAccount { Id = "conversation-id" },
-                Timestamp = new DateTimeOffset(),
-                From = new ChannelAccount { Id = "account-1" },
-                Recipient = new ChannelAccount { Id = "account-2" }
-            };
+            _activity.Type = ActivityTypes.MessageUpdate;
 
             InitStorage();
 


### PR DESCRIPTION
Addresses # 6292
#minor

## Description
This PR adds unit tests for the AzureBlobTranscriptStore class.

## Specific Changes

- Adds unit tests for the AzureBlobTranscriptStore class
- Adds a new internal constructor that receives a CloudBlobClient to be able to pass a mocked instance of this class, allowing to test without the use of emulators.
- Updates the Microsoft.Azure.Storage.Blob package to version 10.3.0 to be able to use the public constructor of CloudBlobDirectory introduced in this version and mock this class.

## Testing
This image shows the unit tests passing
<img width="357" alt="image" src="https://user-images.githubusercontent.com/64815358/165150064-0ca8436c-abd3-4e26-a4ed-997111a38574.png">