### PR TITLE
[#5678] Channels "enumeration" is out of date

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Channels.cs
+++ b/libraries/Microsoft.Bot.Connector/Channels.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+
 namespace Microsoft.Bot.Connector
 {
     /// <summary>
@@ -110,6 +112,7 @@ namespace Microsoft.Bot.Connector
         /// <summary>
         /// Twilio channel.
         /// </summary>
+        [Obsolete("This channel is deprecated. Use Sms instead.")]
         public const string Twilio = "twilio-sms";
 
         /// <summary>
@@ -121,5 +124,10 @@ namespace Microsoft.Bot.Connector
         /// Omni channel.
         /// </summary>
         public const string Omni = "omnichannel";
+
+        /// <summary>
+        /// Outlook channel.
+        /// </summary>
+        public const string Outlook = "outlook";
     }
 }


### PR DESCRIPTION
Fixes # 5678
#minor

## Description
This PR updates the Channels enum adding Outlook and marking Twilio as obsolete.

## Specific Changes
- Added new channel Outlook.
- Marked Twilio as obsolete.

## Testing
This image shows the tests passing after the changes.
![image](https://user-images.githubusercontent.com/44245136/165777909-f76e9025-e220-4c2a-ade5-9f0b72a7dd1e.png)
