### PR TITLE
[#6229] Add descriptions to ARM template parameters files (updated)

### DIFF
--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/DeploymentTemplates/README.md
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/DeploymentTemplates/README.md
@@ -1,0 +1,44 @@
+# ARM Template Parameters
+
+These are the parameters needed to deploy a bot to Azure using ARM templates. They can be set in line when running `az deployment create` command or in the parameters.json file.
+<br/>
+<br/>
+
+## Common
+
+
+| Parameters                               | Description                                                                                                                                                                            |
+| :--------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| appId                                    | Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings                                                       |
+| appSecret                                | Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"                |
+| appType                                  | Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\" |
+| botId                                    | The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable                                                                          |
+| botSku                                   | The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1                                                                                                      |
+| newAppServicePlanName                    | The name of the new App Service Plan                                                                                                                                                   |
+| newAppServicePlanSku                     | The SKU of the App Service Plan. Defaults to Standard values                                                                                                                           |
+| existingAppServicePlan                   | Name of the existing App Service Plan used to create the Web App for the bot                                                                                                           |
+| newWebAppName                            | The globally unique name of the Web App. Defaults to the value passed in for \"botId\"                                                                                                 |
+| tenantId                                 | The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"                    |
+| existingUserAssignedMSIName              | The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"                                                                                        |
+| existingUserAssignedMSIResourceGroupName | The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"                                                                                  |
+
+<br/>
+
+## New resource group (new-rg-parameters.json)
+
+
+| Parameters                | Description                                  |
+| :------------------------ | :------------------------------------------- |
+| groupLocation             | Specifies the location of the Resource Group |
+| groupName                 | Specifies the name of the Resource Group     |
+| newAppServicePlanLocation | The location of the App Service Plan         |
+
+<br/>
+
+## Existing resource group (preexisting-rg-parameters.json)
+
+
+| Parameters             | Description                                  |
+| :--------------------- | :------------------------------------------- |
+| appServicePlanLocation | Specifies the location of the Resource Group |
+                                                                                 

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/DeploymentTemplates/README.md
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/DeploymentTemplates/README.md
@@ -1,0 +1,44 @@
+# ARM Template Parameters
+
+These are the parameters needed to deploy a bot to Azure using ARM templates. They can be set in line when running `az deployment create` command or in the parameters.json file.
+<br/>
+<br/>
+
+## Common
+
+
+| Parameters                               | Description                                                                                                                                                                            |
+| :--------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| appId                                    | Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings                                                       |
+| appSecret                                | Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"                |
+| appType                                  | Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\" |
+| botId                                    | The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable                                                                          |
+| botSku                                   | The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1                                                                                                      |
+| newAppServicePlanName                    | The name of the new App Service Plan                                                                                                                                                   |
+| newAppServicePlanSku                     | The SKU of the App Service Plan. Defaults to Standard values                                                                                                                           |
+| existingAppServicePlan                   | Name of the existing App Service Plan used to create the Web App for the bot                                                                                                           |
+| newWebAppName                            | The globally unique name of the Web App. Defaults to the value passed in for \"botId\"                                                                                                 |
+| tenantId                                 | The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"                    |
+| existingUserAssignedMSIName              | The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"                                                                                        |
+| existingUserAssignedMSIResourceGroupName | The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"                                                                                  |
+
+<br/>
+
+## New resource group (new-rg-parameters.json)
+
+
+| Parameters                | Description                                  |
+| :------------------------ | :------------------------------------------- |
+| groupLocation             | Specifies the location of the Resource Group |
+| groupName                 | Specifies the name of the Resource Group     |
+| newAppServicePlanLocation | The location of the App Service Plan         |
+
+<br/>
+
+## Existing resource group (preexisting-rg-parameters.json)
+
+
+| Parameters             | Description                                  |
+| :--------------------- | :------------------------------------------- |
+| appServicePlanLocation | Specifies the location of the Resource Group |
+                                                                                 

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/DeploymentTemplates/README.md
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/DeploymentTemplates/README.md
@@ -1,0 +1,44 @@
+# ARM Template Parameters
+
+These are the parameters needed to deploy a bot to Azure using ARM templates. They can be set in line when running `az deployment create` command or in the parameters.json file.
+<br/>
+<br/>
+
+## Common
+
+
+| Parameters                               | Description                                                                                                                                                                            |
+| :--------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| appId                                    | Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings                                                       |
+| appSecret                                | Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"                |
+| appType                                  | Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\" |
+| botId                                    | The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable                                                                          |
+| botSku                                   | The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1                                                                                                      |
+| newAppServicePlanName                    | The name of the new App Service Plan                                                                                                                                                   |
+| newAppServicePlanSku                     | The SKU of the App Service Plan. Defaults to Standard values                                                                                                                           |
+| existingAppServicePlan                   | Name of the existing App Service Plan used to create the Web App for the bot                                                                                                           |
+| newWebAppName                            | The globally unique name of the Web App. Defaults to the value passed in for \"botId\"                                                                                                 |
+| tenantId                                 | The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"                    |
+| existingUserAssignedMSIName              | The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"                                                                                        |
+| existingUserAssignedMSIResourceGroupName | The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"                                                                                  |
+
+<br/>
+
+## New resource group (new-rg-parameters.json)
+
+
+| Parameters                | Description                                  |
+| :------------------------ | :------------------------------------------- |
+| groupLocation             | Specifies the location of the Resource Group |
+| groupName                 | Specifies the name of the Resource Group     |
+| newAppServicePlanLocation | The location of the App Service Plan         |
+
+<br/>
+
+## Existing resource group (preexisting-rg-parameters.json)
+
+
+| Parameters             | Description                                  |
+| :--------------------- | :------------------------------------------- |
+| appServicePlanLocation | Specifies the location of the Resource Group |
+                                                                                 

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/DeploymentTemplates/README.md
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/DeploymentTemplates/README.md
@@ -1,0 +1,44 @@
+# ARM Template Parameters
+
+These are the parameters needed to deploy a bot to Azure using ARM templates. They can be set in line when running `az deployment create` command or in the parameters.json file.
+<br/>
+<br/>
+
+## Common
+
+
+| Parameters                               | Description                                                                                                                                                                            |
+| :--------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| appId                                    | Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings                                                       |
+| appSecret                                | Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"                |
+| appType                                  | Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\" |
+| botId                                    | The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable                                                                          |
+| botSku                                   | The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1                                                                                                      |
+| newAppServicePlanName                    | The name of the new App Service Plan                                                                                                                                                   |
+| newAppServicePlanSku                     | The SKU of the App Service Plan. Defaults to Standard values                                                                                                                           |
+| existingAppServicePlan                   | Name of the existing App Service Plan used to create the Web App for the bot                                                                                                           |
+| newWebAppName                            | The globally unique name of the Web App. Defaults to the value passed in for \"botId\"                                                                                                 |
+| tenantId                                 | The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"                    |
+| existingUserAssignedMSIName              | The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"                                                                                        |
+| existingUserAssignedMSIResourceGroupName | The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"                                                                                  |
+
+<br/>
+
+## New resource group (new-rg-parameters.json)
+
+
+| Parameters                | Description                                  |
+| :------------------------ | :------------------------------------------- |
+| groupLocation             | Specifies the location of the Resource Group |
+| groupName                 | Specifies the name of the Resource Group     |
+| newAppServicePlanLocation | The location of the App Service Plan         |
+
+<br/>
+
+## Existing resource group (preexisting-rg-parameters.json)
+
+
+| Parameters             | Description                                  |
+| :--------------------- | :------------------------------------------- |
+| appServicePlanLocation | Specifies the location of the Resource Group |
+                                                                                 

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/DeploymentTemplates/README.md
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/DeploymentTemplates/README.md
@@ -1,0 +1,44 @@
+# ARM Template Parameters
+
+These are the parameters needed to deploy a bot to Azure using ARM templates. They can be set in line when running `az deployment create` command or in the parameters.json file.
+<br/>
+<br/>
+
+## Common
+
+
+| Parameters                               | Description                                                                                                                                                                            |
+| :--------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| appId                                    | Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings                                                       |
+| appSecret                                | Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"                |
+| appType                                  | Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\" |
+| botId                                    | The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable                                                                          |
+| botSku                                   | The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1                                                                                                      |
+| newAppServicePlanName                    | The name of the new App Service Plan                                                                                                                                                   |
+| newAppServicePlanSku                     | The SKU of the App Service Plan. Defaults to Standard values                                                                                                                           |
+| existingAppServicePlan                   | Name of the existing App Service Plan used to create the Web App for the bot                                                                                                           |
+| newWebAppName                            | The globally unique name of the Web App. Defaults to the value passed in for \"botId\"                                                                                                 |
+| tenantId                                 | The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"                    |
+| existingUserAssignedMSIName              | The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"                                                                                        |
+| existingUserAssignedMSIResourceGroupName | The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"                                                                                  |
+
+<br/>
+
+## New resource group (new-rg-parameters.json)
+
+
+| Parameters                | Description                                  |
+| :------------------------ | :------------------------------------------- |
+| groupLocation             | Specifies the location of the Resource Group |
+| groupName                 | Specifies the name of the Resource Group     |
+| newAppServicePlanLocation | The location of the App Service Plan         |
+
+<br/>
+
+## Existing resource group (preexisting-rg-parameters.json)
+
+
+| Parameters             | Description                                  |
+| :--------------------- | :------------------------------------------- |
+| appServicePlanLocation | Specifies the location of the Resource Group |
+                                                                                 

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/DeploymentTemplates/README.md
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/DeploymentTemplates/README.md
@@ -1,0 +1,44 @@
+# ARM Template Parameters
+
+These are the parameters needed to deploy a bot to Azure using ARM templates. They can be set in line when running `az deployment create` command or in the parameters.json file.
+<br/>
+<br/>
+
+## Common
+
+
+| Parameters                               | Description                                                                                                                                                                            |
+| :--------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| appId                                    | Active Directory App ID or User-Assigned Managed Identity Client ID, set as MicrosoftAppId in the Web App's Application Settings                                                       |
+| appSecret                                | Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Required for MultiTenant and SingleTenant app types. Defaults to \"\"                |
+| appType                                  | Type of Bot Authentication. set as MicrosoftAppType in the Web App's Application Settings. Allowed values are: MultiTenant, SingleTenant, UserAssignedMSI. Defaults to \"MultiTenant\" |
+| botId                                    | The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable                                                                          |
+| botSku                                   | The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1                                                                                                      |
+| newAppServicePlanName                    | The name of the new App Service Plan                                                                                                                                                   |
+| newAppServicePlanSku                     | The SKU of the App Service Plan. Defaults to Standard values                                                                                                                           |
+| existingAppServicePlan                   | Name of the existing App Service Plan used to create the Web App for the bot                                                                                                           |
+| newWebAppName                            | The globally unique name of the Web App. Defaults to the value passed in for \"botId\"                                                                                                 |
+| tenantId                                 | The Azure AD Tenant ID to use as part of the Bot's Authentication. Only used for SingleTenant and UserAssignedMSI app types. Defaults to \"Subscription Tenant ID\"                    |
+| existingUserAssignedMSIName              | The User-Assigned Managed Identity Resource used for the Bot's Authentication. Defaults to \"\"                                                                                        |
+| existingUserAssignedMSIResourceGroupName | The User-Assigned Managed Identity Resource Group used for the Bot's Authentication. Defaults to \"\"                                                                                  |
+
+<br/>
+
+## New resource group (new-rg-parameters.json)
+
+
+| Parameters                | Description                                  |
+| :------------------------ | :------------------------------------------- |
+| groupLocation             | Specifies the location of the Resource Group |
+| groupName                 | Specifies the name of the Resource Group     |
+| newAppServicePlanLocation | The location of the App Service Plan         |
+
+<br/>
+
+## Existing resource group (preexisting-rg-parameters.json)
+
+
+| Parameters             | Description                                  |
+| :--------------------- | :------------------------------------------- |
+| appServicePlanLocation | Specifies the location of the Resource Group |
+                                                                                 


### PR DESCRIPTION
Addresses # 6229
#minor

## Description
This PR adds description to ARM template parameters files for each bot template.

## Specific Changes

- Adds description property to ARM template parameters in dotnet-templates.
- Adds description property to ARM template parameters in vsix-vs-win templates.

## Testing

README.md view from GitHub
<img width="736" alt="image" src="https://user-images.githubusercontent.com/64815358/165791938-eaa88e74-39cd-49be-90ca-7cc45ce0f482.png">
