### PR TITLE
[#5977] Update projects to .Net 6 - test bots

### DIFF
--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>594af4a1-e396-4609-8198-d665eb0c1f78</UserSecretsId>
   </PropertyGroup>
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.SecondaryTestBot/Bots/SecondaryBot.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.SecondaryTestBot/Bots/SecondaryBot.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.SecondaryTestBot.Bots
             {
                 var metadata = ((FacebookThreadControl)turnContext.Activity.Value).Metadata;
 
-                if (metadata.Equals(HandoverConstants.MetadataPassThreadControl))
+                if (metadata.Equals(HandoverConstants.MetadataPassThreadControl, System.StringComparison.Ordinal))
                 {
                     var activity = MessageFactory.Text("Hello, I'm the secondary bot. How can I help you?");
                     await turnContext.SendActivityAsync(activity, cancellationToken);

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.SecondaryTestBot/Microsoft.Bot.Builder.Adapters.Facebook.SecondaryTestBot.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.SecondaryTestBot/Microsoft.Bot.Builder.Adapters.Facebook.SecondaryTestBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>dae2bae8-b3c8-4b83-8b3c-4022669c7a20</UserSecretsId>
   </PropertyGroup>
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.TestBot/Microsoft.Bot.Builder.Adapters.Slack.TestBot.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.TestBot/Microsoft.Bot.Builder.Adapters.Slack.TestBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <!-- The SlackAPI package isn't signed, so supress the warning. There seems to not be a way to supress this for ONLY SlackAPI. -->
     <NoWarn>$(NoWarn),CS8002</NoWarn>
     <UserSecretsId>3c783a33-e2a5-4acd-99dd-581d563d47e3</UserSecretsId>

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.TestBot/Microsoft.Bot.Builder.Adapters.Twilio.TestBot.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.TestBot/Microsoft.Bot.Builder.Adapters.Twilio.TestBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.TestBot/Microsoft.Bot.Builder.Adapters.Webex.TestBot.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.TestBot/Microsoft.Bot.Builder.Adapters.Webex.TestBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <!-- The WebExTeams package isn't signed, so supress the warning. -->
     <NoWarn>$(NoWarn),CS8002</NoWarn>
     <UserSecretsId>63730bc1-f7d4-4b32-8efe-ce03907b3e0a</UserSecretsId>

--- a/tests/Auth/bot-authentication/AuthenticationBot.csproj
+++ b/tests/Auth/bot-authentication/AuthenticationBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/Microsoft.Bot.Builder.TestBot.Json.csproj
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/Microsoft.Bot.Builder.TestBot.Json.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>TestBot</UserSecretsId>
     <Configurations>Debug;Release</Configurations>
     <!-- The Jurrasic package isn't signed, so supress the warning. -->

--- a/tests/Microsoft.Bot.Builder.TestBot/Microsoft.Bot.Builder.TestBot.csproj
+++ b/tests/Microsoft.Bot.Builder.TestBot/Microsoft.Bot.Builder.TestBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>f277272c-9113-411f-addd-a4acfa9701a2</UserSecretsId>
     <RootNamespace>Microsoft.BotBuilderSamples</RootNamespace>
   </PropertyGroup>

--- a/tests/Microsoft.Bot.Builder.TestBot/wwwroot/default.htm
+++ b/tests/Microsoft.Bot.Builder.TestBot/wwwroot/default.htm
@@ -5,7 +5,7 @@
     <meta charset="utf-8" />
 </head>
 <body style="font-family:'Segoe UI'">
-    <h1>TestBot using ASP.Net Core 2</h1>
+    <h1>TestBot using ASP.Net 6</h1>
     <p>Describe your bot here and your terms of use etc.</p>
     <p>To debug your bot using the Bot Framework Emulator, paste this URL into the Emulator window:</p>
     <div style="padding-left: 50px;" id="botBaseUrl"></div>

--- a/tests/Skills/Bot1/Bot1.csproj
+++ b/tests/Skills/Bot1/Bot1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Skills/Bot2/Bot2.csproj
+++ b/tests/Skills/Bot2/Bot2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Skills/Bot3/Bot3.csproj
+++ b/tests/Skills/Bot3/Bot3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Skills/Child/Child.csproj
+++ b/tests/Skills/Child/Child.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>f277272c-9113-411f-addd-a4acfa9701a2</UserSecretsId>
     <RootNamespace>Microsoft.BotBuilderSamples</RootNamespace>
   </PropertyGroup>

--- a/tests/Skills/Parent/Parent.csproj
+++ b/tests/Skills/Parent/Parent.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>f277272c-9113-411f-addd-a4acfa9701a2</UserSecretsId>
     <RootNamespace>Microsoft.BotBuilderSamples</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
Addresses # 5977
#minor

## Description
This PR updates the test bots in the repository to target .NET6

## Specific Changes
- Updated the following bots to target .NET6
  - Microsoft.Bot.Builder.TestBot
  - Microsoft.Bot.Builder.TestBot.Json  
  - Adapters/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot
  - Adapters/Microsoft.Bot.Builder.Adapters.Facebook.SecondaryTestBot
  - Adapters/Microsoft.Bot.Builder.Adapters.Slack.TestBot
  - Adapters/Microsoft.Bot.Builder.Adapters.Twilio.TestBot
  - Adapters/Microsoft.Bot.Builder.Adapters.Webex.TestBot
  - Auth/AuthenticationBot
  - Skills/Bot1
  - Skills/Bot2
  - Skills/Bot3
  - Skills/Child/Child
  - Skills/Parent
- Fixed analyzers issue with StringComparison.

## Testing
These images show some of the updated bots working as expected.
![image](https://user-images.githubusercontent.com/44245136/167473690-0948e5e0-e89b-4698-98f9-6a84a513cafb.png)
