### PR TITLE
[#6339] Mark deprecated channels as obsolete in Channels enum

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Channels.cs
+++ b/libraries/Microsoft.Bot.Connector/Channels.cs
@@ -22,11 +22,13 @@ namespace Microsoft.Bot.Connector
         /// <summary>
         /// Console channel.
         /// </summary>
+        [Obsolete("This channel is deprecated.")]
         public const string Console = "console";
 
         /// <summary>
         /// Cortana channel.
         /// </summary>
+        [Obsolete("This channel is deprecated.")]
         public const string Cortana = "cortana";
 
         /// <summary>
@@ -62,6 +64,7 @@ namespace Microsoft.Bot.Connector
         /// <summary>
         /// Kik channel.
         /// </summary>
+        [Obsolete("This channel is deprecated.")]
         public const string Kik = "kik";
 
         /// <summary>
@@ -82,6 +85,7 @@ namespace Microsoft.Bot.Connector
         /// <summary>
         /// Skype for Business channel.
         /// </summary>
+        [Obsolete("This channel is deprecated.")]
         public const string Skypeforbusiness = "skypeforbusiness";
 
         /// <summary>
@@ -118,6 +122,7 @@ namespace Microsoft.Bot.Connector
         /// <summary>
         /// Telephony channel.
         /// </summary>
+        [Obsolete("This channel is deprecated.")]
         public const string Telephony = "telephony";
 
         /// <summary>


### PR DESCRIPTION
Addresses # 6339
#minor

## Description
This PR marks the unsupported channels as deprecated.
Unsupported channels:
- Console
- Cortana
- Kik
- SkypeForBusiness
- Telephony

## Specific Changes
- Unsupported channels marked as deprecated in Microsoft.Bot.Connector/Channels.cs

## Testing
This screenshot shows the unit tests passing
<img width="498" alt="image" src="https://user-images.githubusercontent.com/64815358/169897665-377b3037-e0ad-4742-8ce5-7dbd25167427.png">
