### PR TITLE
Fix AzureBlobTranscriptStore tests - The specified blob does not exist

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobTranscriptStore.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobTranscriptStore.cs
@@ -348,14 +348,16 @@ namespace Microsoft.Bot.Builder.Azure
             blobReference.Metadata["FromId"] = activity.From.Id;
             blobReference.Metadata["RecipientId"] = activity.Recipient.Id;
             blobReference.Metadata["Timestamp"] = activity.Timestamp.Value.ToString("O", CultureInfo.InvariantCulture);
-            
-            using var blobStream = await blobReference.OpenWriteAsync().ConfigureAwait(false);
-            using var streamWriter = new StreamWriter(blobStream);
-            using var jsonWriter = new JsonTextWriter(streamWriter);
-            
-            _jsonSerializer.Serialize(jsonWriter, activity);
 
-            await streamWriter.FlushAsync().ConfigureAwait(false);
+            using (var blobStream = await blobReference.OpenWriteAsync().ConfigureAwait(false))
+            {
+                using var streamWriter = new StreamWriter(blobStream);
+                using var jsonWriter = new JsonTextWriter(streamWriter);
+
+                _jsonSerializer.Serialize(jsonWriter, activity);
+
+                await streamWriter.FlushAsync().ConfigureAwait(false);
+            }
 
             await blobReference.SetMetadataAsync().ConfigureAwait(false);
         }


### PR DESCRIPTION
#minor

## Description
This PR fixes the using blocks in the _LogActivityAsync_ method of _AzureBlobTranscriptStore_ class that was causing the Functional Tests to fail with the `The specified blob does not exist` error. 

## Specific Changes
- Updated _LogActivityAsync_ method to leave the _SetMetadaAsync_ outside the _blobStream_'s using scope.

## Testing
This image shows the functional tests (BotFramework-FunctionalTests) and the unit tests passing after the change.
![image](https://user-images.githubusercontent.com/44245136/173654990-11c6c447-e98e-4d57-9c6c-b4d4cfa2f072.png)
