### PR TITLE
[#6355] ContinueDialog fails to find dynamically loaded dialog after bot restart

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
@@ -16,6 +16,7 @@ using Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Selectors;
 using Microsoft.Bot.Builder.Dialogs.Debugging;
+using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Bot.Schema;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -677,6 +678,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             var actionDC = CreateChildContext(actionContext);
             while (actionDC != null)
             {
+                if (actionDC.ActiveDialog != null)
+                {
+                    var dialog = FindDialog(actionDC.ActiveDialog.Id);
+                    if (dialog == null)
+                    {
+                        var resourceExplorer = actionDC.Context.TurnState.Get<ResourceExplorer>();
+                        if (resourceExplorer != null)
+                        {
+                            dialog = resourceExplorer.LoadType<AdaptiveDialog>($"{actionDC.ActiveDialog.Id}.dialog");
+                            actionDC.Dialogs.Add(dialog);
+                        }
+                    }
+                }
+
                 // DEBUG: To debug step execution set a breakpoint on line below and add a watch 
                 //        statement for actionContext.Actions.
                 DialogTurnResult result;


### PR DESCRIPTION
Fixes # 6355
#minor

## Description
This PR adds the ability to load dynamically dialogs when the bot is restarted during a conversation.

## Specific Changes
- Adds a step to gather the dialog resource when isn't found in the dialogs stack from the `ResourceExplorer` to be loaded automatically into the dialogs stack.

## Testing
The following image shows the dialog working from a Composer bot and the new unit test passing.
![image](https://user-images.githubusercontent.com/62260472/169308038-9f8c6ada-7577-4a24-aced-745252c9c878.png)