### PR TITLE
[#6392] Bump Newtonsoft.Json from 12.0.3 to 13.0.1

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Microsoft.Bot.Builder.Adapters.Slack.csproj
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Microsoft.Bot.Builder.Adapters.Slack.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
     
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="SlackAPI" Version="1.1.12" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Condition=" '$(ReleasePackageVersion)' != '' " Version="$(ReleasePackageVersion)" />

--- a/libraries/AdaptiveExpressions/AdaptiveExpressions.csproj
+++ b/libraries/AdaptiveExpressions/AdaptiveExpressions.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Antlr4.Runtime.Standard" Version="4.8.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.3.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/Microsoft.Bot.Builder.AI.Luis.csproj
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/Microsoft.Bot.Builder.AI.Luis.csproj
@@ -33,7 +33,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.22" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.22" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language.LUIS.Runtime" Version="2.1.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Condition=" '$(ReleasePackageVersion)' != '' " Version="$(ReleasePackageVersion)" />

--- a/libraries/Microsoft.Bot.Builder.Azure.Blobs/Microsoft.Bot.Builder.Azure.Blobs.csproj
+++ b/libraries/Microsoft.Bot.Builder.Azure.Blobs/Microsoft.Bot.Builder.Azure.Blobs.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.8.0" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(ReleasePackageVersion)' != '' " Version="$(ReleasePackageVersion)" />

--- a/libraries/Microsoft.Bot.Builder.Azure.Queues/Microsoft.Bot.Builder.Azure.Queues.csproj
+++ b/libraries/Microsoft.Bot.Builder.Azure.Queues/Microsoft.Bot.Builder.Azure.Queues.csproj
@@ -33,7 +33,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.3.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PreviewPackageVersion)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PreviewPackageVersion)' != '' " Version="$(PreviewPackageVersion)" />

--- a/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
+++ b/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.15.1" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.13.1" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="9.4.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(ReleasePackageVersion)' != '' " Version="$(ReleasePackageVersion)" />

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Microsoft.Bot.Builder.Dialogs.Debugging.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Microsoft.Bot.Builder.Dialogs.Debugging.csproj
@@ -30,7 +30,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Condition=" '$(ReleasePackageVersion)' != '' " Version="$(ReleasePackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Microsoft.Bot.Builder.Dialogs.Declarative.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Microsoft.Bot.Builder.Dialogs.Declarative.csproj
@@ -37,7 +37,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.22" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NuGet.Packaging" Version="5.5.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Condition=" '$(ReleasePackageVersion)' != '' " Version="$(ReleasePackageVersion)" />

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Microsoft.Bot.Builder.LanguageGeneration.csproj
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Microsoft.Bot.Builder.LanguageGeneration.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="Antlr4.Runtime.Standard" Version="4.8.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="AdaptiveExpressions" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="AdaptiveExpressions" Condition=" '$(ReleasePackageVersion)' != '' " Version="$(ReleasePackageVersion)" />
   </ItemGroup>

--- a/libraries/Microsoft.Bot.Configuration/Microsoft.Bot.Configuration.csproj
+++ b/libraries/Microsoft.Bot.Configuration/Microsoft.Bot.Configuration.csproj
@@ -20,11 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 </Project>

--- a/libraries/Microsoft.Bot.Configuration/Microsoft.Bot.Configuration.csproj
+++ b/libraries/Microsoft.Bot.Configuration/Microsoft.Bot.Configuration.csproj
@@ -25,6 +25,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 </Project>

--- a/libraries/Microsoft.Bot.Connector.Streaming/Microsoft.Bot.Connector.Streaming.csproj
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Microsoft.Bot.Connector.Streaming.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.IO.Pipelines" Version="5.0.1" />
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
     <!-- Force System.Text.Encodings.Web to a safe version. -->

--- a/libraries/Microsoft.Bot.Connector/Microsoft.Bot.Connector.csproj
+++ b/libraries/Microsoft.Bot.Connector/Microsoft.Bot.Connector.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.4" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.6.0" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Microsoft.Bot.Schema" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Schema" Condition=" '$(ReleasePackageVersion)' != '' " Version="$(ReleasePackageVersion)" />
   </ItemGroup>

--- a/libraries/Microsoft.Bot.Schema/Microsoft.Bot.Schema.csproj
+++ b/libraries/Microsoft.Bot.Schema/Microsoft.Bot.Schema.csproj
@@ -25,6 +25,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 </Project>

--- a/libraries/Microsoft.Bot.Streaming/Microsoft.Bot.Streaming.csproj
+++ b/libraries/Microsoft.Bot.Streaming/Microsoft.Bot.Streaming.csproj
@@ -29,6 +29,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 </Project>

--- a/libraries/Parsers/Microsoft.Bot.Builder.Parsers.LU/Microsoft.Bot.Builder.Parsers.LU.csproj
+++ b/libraries/Parsers/Microsoft.Bot.Builder.Parsers.LU/Microsoft.Bot.Builder.Parsers.LU.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="Antlr4.Runtime.Standard" Version="4.8.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
 </Project>

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
@@ -48,7 +48,7 @@
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(ReleasePackageVersion)' != '' " Version="$(ReleasePackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Configuration" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Configuration" Condition=" '$(ReleasePackageVersion)' != '' " Version="$(ReleasePackageVersion)" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Bot.Builder.AI.Luis.TestUtils/Microsoft.Bot.Builder.AI.Luis.TestUtils.csproj
+++ b/tests/Microsoft.Bot.Builder.AI.Luis.TestUtils/Microsoft.Bot.Builder.AI.Luis.TestUtils.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
 </Project>

--- a/tests/Microsoft.Bot.Builder.TemplateManager/Microsoft.Bot.Builder.TemplateManager.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.TemplateManager/Microsoft.Bot.Builder.TemplateManager.Tests.csproj
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/Microsoft.Bot.Builder.TestBot.WebApi/Microsoft.Bot.Builder.TestBot.WebApi.csproj
+++ b/tests/Microsoft.Bot.Builder.TestBot.WebApi/Microsoft.Bot.Builder.TestBot.WebApi.csproj
@@ -116,7 +116,7 @@
       <Version>1.2.3</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>10.0.3</Version>
+      <Version>13.0.1</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/Microsoft.Bot.Connector.Tests/Microsoft.Bot.Connector.Tests.csproj
+++ b/tests/Microsoft.Bot.Connector.Tests/Microsoft.Bot.Connector.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.TestFramework" Version="1.7.7" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.6.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/Microsoft.Bot.Schema.Tests/Microsoft.Bot.Schema.Tests.csproj
+++ b/tests/Microsoft.Bot.Schema.Tests/Microsoft.Bot.Schema.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
     <ItemGroup>
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
-      <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
       <PackageReference Include="xunit" Version="2.4.1" />
       <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
         <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Addresses # 6392
#minor

**_Note: The setting of the MaxDepth property for the rest of the json serialization/deserialization ([comment](https://github.com/microsoft/botbuilder-dotnet/issues/6392#issuecomment-1167583077)) will be addressed in another PR._**

## Description
This PR updates the version of the Newtonsoft.Json dependency to 13.0.1.
It also adds a custom CosmosDB Serializer and sets the MaxDepth property to fix the error `The reader's MaxDepth of 64 has been exceeded.` in some unit tests and integration tests.

## Specific Changes
Updated the following projects:
- libraries:
   - Microsoft.Bot.Builder.Adapters.Slack
   - AdaptiveExpressions
   - Microsoft.Bot.Builder.AI.Luis
   - Microsoft.Bot.Builder.Azure.Blobs
   - Microsoft.Bot.Builder.Azure.Queues
   - Microsoft.Bot.Builder.Azure
   - Microsoft.Bot.Builder.Dialogs.Debugging
   - Microsoft.Bot.Builder.Dialogs.Declarative
   - Microsoft.Bot.Builder.LanguageGeneration
   - Microsoft.Bot.Configuration
   - Microsoft.Bot.Connector.Streaming
   - Microsoft.Bot.Connector
   - Microsoft.Bot.Schema
   - Microsoft.Bot.Streaming
   - Microsoft.Bot.Builder.Parsers.LU
   - Microsoft.Bot.Builder.Integration.AspNet.Core
- tests:
   - Microsoft.Bot.Builder.AI.Luis.TestUtils
   - Microsoft.Bot.Builder.TemplateManager.Tests
   - Microsoft.Bot.Builder.TestBot.WebApi
   - Microsoft.Bot.Connector.Tests
   - Microsoft.Bot.Schema.Tests
  
Updated `CosmosDbPartitionedStorage` class:
- Set MaxDepth property for JsonSerializers
- Added a custom Cosmos Serializer to be able to set the MaxDepth as the [default serializer](https://github.com/Azure/azure-cosmos-dotnet-v3/blob/master/Microsoft.Azure.Cosmos/src/Serializer/CosmosJsonDotNetSerializer.cs) has the limit of 64 causing some of the integration tests to fail.

## Testing
These images show the unit tests and the [integration tests](https://github.com/microsoft/BotFramework-FunctionalTests/tree/main/Tests/Integration/DotNet) passing after the changes.
![image](https://user-images.githubusercontent.com/44245136/176527085-84b903d0-9cff-4827-a6b4-23b33704f3a3.png)
