### PR TITLE
[#6392] Bump Newtonsoft.Json from 12.0.3 to 13.0.1 - Set MaxDepth property (1/4)

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookAdapter.cs
@@ -252,7 +252,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
 
             FacebookResponseEvent facebookResponseEvent = null;
 
-            facebookResponseEvent = JsonConvert.DeserializeObject<FacebookResponseEvent>(stringifiedBody);
+            facebookResponseEvent = JsonConvert.DeserializeObject<FacebookResponseEvent>(stringifiedBody, new JsonSerializerSettings { MaxDepth = null });
 
             foreach (var entry in facebookResponseEvent.Entry)
             {

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookClientWrapper.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
         /// An instance of the FacebookClientWrapperOptions class.
         /// </summary>
         private readonly FacebookClientWrapperOptions _options;
+        
+        private readonly JsonSerializerSettings _settings = new JsonSerializerSettings { MaxDepth = null };
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FacebookClientWrapper"/> class.
@@ -74,6 +76,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
                     new JsonSerializerSettings
                     {
                         NullValueHandling = NullValueHandling.Ignore,
+                        MaxDepth = null
                     });
                 request.Content = new StringContent(json, Encoding.UTF8, "application/json");
 
@@ -84,7 +87,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
                     if (res.IsSuccessStatusCode)
                     {
                         var responseBody = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                        var stringResponse = JsonConvert.DeserializeObject<FacebookResponseOk>(responseBody);
+                        var stringResponse = JsonConvert.DeserializeObject<FacebookResponseOk>(responseBody, _settings);
                         return stringResponse.MessageId;
                     }
                     else
@@ -231,7 +234,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
             }
 
             var content = new { recipient = new { id = userId }, metadata = message };
-            return await PostToFacebookApiAsync($"/me/{HandoverConstants.RequestThreadControl}", JsonConvert.SerializeObject(content), cancellationToken).ConfigureAwait(false);
+            return await PostToFacebookApiAsync($"/me/{HandoverConstants.RequestThreadControl}", JsonConvert.SerializeObject(content, _settings), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -251,7 +254,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
             }
 
             var content = new { recipient = new { id = userId }, metadata = message };
-            return await PostToFacebookApiAsync($"/me/{HandoverConstants.TakeThreadControl}", JsonConvert.SerializeObject(content), cancellationToken).ConfigureAwait(false);
+            return await PostToFacebookApiAsync($"/me/{HandoverConstants.TakeThreadControl}", JsonConvert.SerializeObject(content, _settings), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -277,7 +280,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
             }
 
             var content = new { recipient = new { id = userId }, target_app_id = targetAppId, metadata = message };
-            return await PostToFacebookApiAsync($"/me/{HandoverConstants.PassThreadControl}", JsonConvert.SerializeObject(content), cancellationToken).ConfigureAwait(false);
+            return await PostToFacebookApiAsync($"/me/{HandoverConstants.PassThreadControl}", JsonConvert.SerializeObject(content, _settings), cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookHelper.cs
@@ -63,13 +63,16 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
 
             if (activity.Attachments != null && activity.Attachments.Count > 0 && facebookMessage.Message != null)
             {
-                var payload = JsonConvert.DeserializeObject<AttachmentPayload>(JsonConvert.SerializeObject(
-                    activity.Attachments[0].Content,
-                    Formatting.None,
-                    new JsonSerializerSettings
-                    {
-                        NullValueHandling = NullValueHandling.Ignore,
-                    }));
+                var payload = JsonConvert.DeserializeObject<AttachmentPayload>(
+                    JsonConvert.SerializeObject(
+                        activity.Attachments[0].Content,
+                        Formatting.None,
+                        new JsonSerializerSettings
+                        {
+                            NullValueHandling = NullValueHandling.Ignore,
+                            MaxDepth = null
+                        }),
+                    new JsonSerializerSettings { MaxDepth = null });
 
                 var facebookAttachment = new FacebookAttachment
                 {

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapter.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         private readonly SlackClientWrapper _slackClient;
         private readonly ILogger _logger;
         private readonly SlackAdapterOptions _options;
+        private readonly JsonSerializerSettings _settings = new JsonSerializerSettings { MaxDepth = null };
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SlackAdapter"/> class using configuration settings.
@@ -295,13 +296,13 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
 
                 if (postValues.ContainsKey("payload"))
                 {
-                    var payload = JsonConvert.DeserializeObject<InteractionPayload>(postValues["payload"]);
+                    var payload = JsonConvert.DeserializeObject<InteractionPayload>(postValues["payload"], _settings);
                     activity = SlackHelper.PayloadToActivity(payload);
                 }
                 else if (postValues.ContainsKey("command"))
                 {
-                    var serializedPayload = JsonConvert.SerializeObject(postValues);
-                    var payload = JsonConvert.DeserializeObject<CommandPayload>(serializedPayload);
+                    var serializedPayload = JsonConvert.SerializeObject(postValues, _settings);
+                    var payload = JsonConvert.DeserializeObject<CommandPayload>(serializedPayload, _settings);
                     activity = SlackHelper.CommandToActivity(payload, _slackClient);
                 }
             }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackClientWrapper.cs
@@ -180,6 +180,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                 data["blocks"] = JsonConvert.SerializeObject(message.Blocks, new JsonSerializerSettings()
                 {
                     NullValueHandling = NullValueHandling.Ignore,
+                    MaxDepth = null
                 });
             }
 
@@ -193,7 +194,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                 response = await client.UploadValuesTaskAsync(url, "POST", data).ConfigureAwait(false);
             }
 
-            return JsonConvert.DeserializeObject<SlackResponse>(Encoding.UTF8.GetString(response));
+            return JsonConvert.DeserializeObject<SlackResponse>(Encoding.UTF8.GetString(response), new JsonSerializerSettings { MaxDepth = null });
         }
 
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioHelper.cs
@@ -110,7 +110,8 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
                 throw new ArgumentNullException(nameof(payload));
             }
 
-            var twilioMessage = JsonConvert.DeserializeObject<TwilioMessage>(JsonConvert.SerializeObject(payload));
+            var serializerSettings = new JsonSerializerSettings { MaxDepth = null };
+            var twilioMessage = JsonConvert.DeserializeObject<TwilioMessage>(JsonConvert.SerializeObject(payload, serializerSettings), serializerSettings);
 
             return new Activity()
             {

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         private readonly WebexClientWrapper _webexClient;
         private readonly ILogger _logger;
         private readonly WebexAdapterOptions _options;
+        private readonly JsonSerializerSettings _settings = new JsonSerializerSettings { MaxDepth = null };
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WebexAdapter"/> class using configuration settings.
@@ -255,7 +256,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
             using (var bodyStream = new StreamReader(request.Body))
             {
                 json = await bodyStream.ReadToEndAsync().ConfigureAwait(false);
-                payload = JsonConvert.DeserializeObject<WebhookEventData>(json);
+                payload = JsonConvert.DeserializeObject<WebhookEventData>(json, _settings);
             }
 
             if (_options.ValidateIncomingRequests && !_webexClient.ValidateSignature(request, json))
@@ -274,9 +275,9 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
             {
                 var extraData = payload.GetResourceData<TeamsData>();
 
-                var data = JsonConvert.SerializeObject(extraData);
+                var data = JsonConvert.SerializeObject(extraData, _settings);
 
-                var jsonData = JsonConvert.DeserializeObject<AttachmentActionData>(data);
+                var jsonData = JsonConvert.DeserializeObject<AttachmentActionData>(data, _settings);
 
                 var decryptedMessage = await _webexClient.GetAttachmentActionAsync(jsonData.Id, cancellationToken).ConfigureAwait(false);
 

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexClientWrapper.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         private const string SparkSignature = "x-spark-signature";
 
         private readonly TeamsAPIClient _api;
+        private readonly JsonSerializerSettings _settings = new JsonSerializerSettings { MaxDepth = null };
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WebexClientWrapper"/> class.
@@ -144,7 +145,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
             http.ContentType = "application/json";
             http.Method = "POST";
 
-            var parsedContent = JsonConvert.SerializeObject(request);
+            var parsedContent = JsonConvert.SerializeObject(request, _settings);
             var encoding = new ASCIIEncoding();
             var bytes = encoding.GetBytes(parsedContent);
 
@@ -161,7 +162,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
             using (var sr = new StreamReader(stream))
             {
                 var content = await sr.ReadToEndAsync().ConfigureAwait(false);
-                result = JsonConvert.DeserializeObject<Message>(content);
+                result = JsonConvert.DeserializeObject<Message>(content, _settings);
             }
 
             return result.Id;
@@ -191,7 +192,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
             using (var sr = new StreamReader(stream))
             {
                 var content = await sr.ReadToEndAsync().ConfigureAwait(false);
-                result = JsonConvert.DeserializeObject<Message>(content);
+                result = JsonConvert.DeserializeObject<Message>(content, _settings);
             }
 
             return result;

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexHelper.cs
@@ -176,9 +176,10 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
                 return null;
             }
 
-            var data = JsonConvert.SerializeObject(decryptedMessage);
+            var serializerSettings = new JsonSerializerSettings { MaxDepth = null };
+            var data = JsonConvert.SerializeObject(decryptedMessage, serializerSettings);
 
-            var messageExtraData = JsonConvert.DeserializeObject<AttachmentActionData>(data);
+            var messageExtraData = JsonConvert.DeserializeObject<AttachmentActionData>(data, serializerSettings);
 
             var activity = new Activity
             {

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Json.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Json.cs
@@ -31,7 +31,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
                             string error = null;
                             using (var textReader = new StringReader(args[0].ToString()))
                             {
-                                using (var jsonReader = new JsonTextReader(textReader) { DateParseHandling = DateParseHandling.None })
+                                using (var jsonReader = new JsonTextReader(textReader) { DateParseHandling = DateParseHandling.None, MaxDepth = null })
                                 {
                                     try
                                     {

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/JsonStringify.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/JsonStringify.cs
@@ -24,7 +24,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
             return FunctionUtils.Apply(
                 (args) =>
                 {
-                    var result = JsonConvert.SerializeObject(args[0]);
+                    var result = JsonConvert.SerializeObject(args[0], new JsonSerializerSettings { MaxDepth = null });
                     return result;
                 });
         }

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/String.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/String.cs
@@ -59,7 +59,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
                         }
                         else
                         {
-                            result = JsonConvert.SerializeObject(args[0]).TrimStart('"').TrimEnd('"');
+                            result = JsonConvert.SerializeObject(args[0], new JsonSerializerSettings { MaxDepth = null }).TrimStart('"').TrimEnd('"');
                         }
                     }
 

--- a/libraries/AdaptiveExpressions/Expression.cs
+++ b/libraries/AdaptiveExpressions/Expression.cs
@@ -630,7 +630,8 @@ namespace AdaptiveExpressions
                     return (default(T), error);
                 }
 
-                return (JsonConvert.DeserializeObject<T>(JsonConvert.SerializeObject(result)), null);
+                var serializerSettings = new JsonSerializerSettings { MaxDepth = null };
+                return (JsonConvert.DeserializeObject<T>(JsonConvert.SerializeObject(result, serializerSettings), serializerSettings), null);
             }
 #pragma warning disable CA1031 // Do not catch general exception types (just return an error)
             catch

--- a/libraries/AdaptiveExpressions/ExpressionProperties/ExpressionProperty.cs
+++ b/libraries/AdaptiveExpressions/ExpressionProperties/ExpressionProperty.cs
@@ -111,7 +111,7 @@ namespace AdaptiveExpressions.Properties
             }
 
             // return expression for json object
-            _expression = Expression.Parse($"json({JsonConvert.SerializeObject(this.Value)})");
+            _expression = Expression.Parse($"json({JsonConvert.SerializeObject(this.Value, new JsonSerializerSettings { MaxDepth = null })})");
             return _expression;
         }
 

--- a/libraries/AdaptiveExpressions/Memory/SimpleObjectMemory.cs
+++ b/libraries/AdaptiveExpressions/Memory/SimpleObjectMemory.cs
@@ -193,7 +193,8 @@ namespace AdaptiveExpressions.Memory
         {
             return JsonConvert.SerializeObject(_memory, new JsonSerializerSettings
             {
-                ReferenceLoopHandling = ReferenceLoopHandling.Ignore
+                ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+                MaxDepth = null
             });
         }
 

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizerOptionsV3.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizerOptionsV3.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Bot.Builder.AI.Luis
 
             content.Add("options", queryOptions);
 
-            var settings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore };
+            var settings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null };
             if (options.DynamicLists != null)
             {
                 foreach (var list in options.DynamicLists)
@@ -137,7 +137,7 @@ namespace Microsoft.Bot.Builder.AI.Luis
                     list.Validate();
                 }
 
-                content.Add("dynamicLists", (JArray)JsonConvert.DeserializeObject(JsonConvert.SerializeObject(options.DynamicLists, settings)));
+                content.Add("dynamicLists", (JArray)JsonConvert.DeserializeObject(JsonConvert.SerializeObject(options.DynamicLists, settings),  new JsonSerializerSettings { MaxDepth = null }));
             }
 
             if (options.ExternalEntities != null)
@@ -147,7 +147,7 @@ namespace Microsoft.Bot.Builder.AI.Luis
                     entity.Validate();
                 }
 
-                content.Add("externalEntities", (JArray)JsonConvert.DeserializeObject(JsonConvert.SerializeObject(options.ExternalEntities, settings)));
+                content.Add("externalEntities", (JArray)JsonConvert.DeserializeObject(JsonConvert.SerializeObject(options.ExternalEntities, settings),  new JsonSerializerSettings { MaxDepth = null }));
             }
 
             return content;
@@ -216,7 +216,7 @@ namespace Microsoft.Bot.Builder.AI.Luis
             var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
 
-            return (JObject)JsonConvert.DeserializeObject(await response.Content.ReadAsStringAsync().ConfigureAwait(false));
+            return (JObject)JsonConvert.DeserializeObject(await response.Content.ReadAsStringAsync().ConfigureAwait(false),  new JsonSerializerSettings { MaxDepth = null });
         }
 
         private RecognizerResult BuildRecognizerResultFromLuisResponse(JObject luisResponse, string utterance)

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/V3/LuisRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/V3/LuisRecognizer.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Bot.Builder.AI.LuisV3
 
         private readonly LuisApplication _application;
         private readonly LuisPredictionOptions _predictionOptions;
+        private readonly JsonSerializerSettings _settings = new JsonSerializerSettings { MaxDepth = null };
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LuisRecognizer"/> class.
@@ -374,7 +375,7 @@ namespace Microsoft.Bot.Builder.AI.LuisV3
                 };
                 content.Add("options", queryOptions);
 
-                var settings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore };
+                var settings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null };
                 if (options.DynamicLists != null)
                 {
                     foreach (var list in options.DynamicLists)
@@ -382,7 +383,7 @@ namespace Microsoft.Bot.Builder.AI.LuisV3
                         list.Validate();
                     }
 
-                    content.Add("dynamicLists", (JArray)JsonConvert.DeserializeObject(JsonConvert.SerializeObject(options.DynamicLists, settings)));
+                    content.Add("dynamicLists", (JArray)JsonConvert.DeserializeObject(JsonConvert.SerializeObject(options.DynamicLists, settings), _settings));
                 }
 
                 if (options.ExternalEntities != null)
@@ -392,7 +393,7 @@ namespace Microsoft.Bot.Builder.AI.LuisV3
                         entity.Validate();
                     }
 
-                    content.Add("externalEntities", (JArray)JsonConvert.DeserializeObject(JsonConvert.SerializeObject(options.ExternalEntities, settings)));
+                    content.Add("externalEntities", (JArray)JsonConvert.DeserializeObject(JsonConvert.SerializeObject(options.ExternalEntities, settings), _settings));
                 }
 
                 if (options.Version == null)
@@ -406,7 +407,7 @@ namespace Microsoft.Bot.Builder.AI.LuisV3
 
                 var response = await DefaultHttpClient.PostAsync(uri.Uri, new StringContent(content.ToString(), System.Text.Encoding.UTF8, "application/json")).ConfigureAwait(false);
                 response.EnsureSuccessStatusCode();
-                luisResponse = (JObject)JsonConvert.DeserializeObject(await response.Content.ReadAsStringAsync().ConfigureAwait(false));
+                luisResponse = (JObject)JsonConvert.DeserializeObject(await response.Content.ReadAsStringAsync().ConfigureAwait(false), _settings);
                 var prediction = (JObject)luisResponse["prediction"];
                 recognizerResult = new RecognizerResult
                 {

--- a/libraries/Microsoft.Bot.Builder.AI.Orchestrator/OrchestratorRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.Orchestrator/OrchestratorRecognizer.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Bot.Builder.AI.Orchestrator
         private OrchestratorDictionaryEntry _orchestrator = null;
         private ILabelResolver _resolver = null;
         private bool _isResolverMockup = false;
+        private readonly JsonSerializerSettings _settings = new JsonSerializerSettings { MaxDepth = null };
 
         /// <summary>
         /// Initializes a new instance of the <see cref="OrchestratorRecognizer"/> class.
@@ -269,9 +270,9 @@ namespace Microsoft.Bot.Builder.AI.Orchestrator
                 { "TopIntentScore", recognizerResult.Intents.Any() ? orderedIntents.First().Value?.Score?.ToString("N1", CultureInfo.InvariantCulture) : null },
                 { "NextIntent", recognizerResult.Intents.Count > 1 ? orderedIntents.ElementAtOrDefault(1).Key : null },
                 { "NextIntentScore", recognizerResult.Intents.Count > 1 ? orderedIntents.ElementAtOrDefault(1).Value?.Score?.ToString("N1", CultureInfo.InvariantCulture) : null },
-                { "Intents", recognizerResult.Intents.Any() ? JsonConvert.SerializeObject(recognizerResult.Intents) : null },
+                { "Intents", recognizerResult.Intents.Any() ? JsonConvert.SerializeObject(recognizerResult.Intents, _settings) : null },
                 { "Entities", recognizerResult.Entities?.ToString() },
-                { "AdditionalProperties", recognizerResult.Properties.Any() ? JsonConvert.SerializeObject(recognizerResult.Properties) : null },
+                { "AdditionalProperties", recognizerResult.Properties.Any() ? JsonConvert.SerializeObject(recognizerResult.Properties, _settings) : null },
             };
 
             var (logPersonalInfo, error) = LogPersonalInformation.TryGetValue(dialogContext.State);

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/CustomQuestionAnswering.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/CustomQuestionAnswering.cs
@@ -229,7 +229,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
             if (queryResults.Length > 0)
             {
                 var queryResult = queryResults[0];
-                properties.Add(QnATelemetryConstants.MatchedQuestionProperty, JsonConvert.SerializeObject(queryResult.Questions));
+                properties.Add(QnATelemetryConstants.MatchedQuestionProperty, JsonConvert.SerializeObject(queryResult.Questions, new JsonSerializerSettings { MaxDepth = null }));
                 properties.Add(QnATelemetryConstants.QuestionIdProperty, queryResult.Id.ToString(CultureInfo.InvariantCulture));
                 properties.Add(QnATelemetryConstants.AnswerProperty, queryResult.Answer);
                 metrics.Add(QnATelemetryConstants.ScoreProperty, queryResult.Score);

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMaker.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMaker.cs
@@ -309,7 +309,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
             if (queryResults.Length > 0)
             {
                 var queryResult = queryResults[0];
-                properties.Add(QnATelemetryConstants.MatchedQuestionProperty, JsonConvert.SerializeObject(queryResult.Questions));
+                properties.Add(QnATelemetryConstants.MatchedQuestionProperty, JsonConvert.SerializeObject(queryResult.Questions, new JsonSerializerSettings { MaxDepth = null }));
                 properties.Add(QnATelemetryConstants.QuestionIdProperty, queryResult.Id.ToString(CultureInfo.InvariantCulture));
                 properties.Add(QnATelemetryConstants.AnswerProperty, queryResult.Answer);
                 metrics.Add(QnATelemetryConstants.ScoreProperty, queryResult.Score);

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMakerRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMakerRecognizer.cs
@@ -35,6 +35,8 @@ namespace Microsoft.Bot.Builder.AI.QnA.Recognizers
 
         private const string IntentPrefix = "intent=";
 
+        private readonly JsonSerializerSettings _settings = new JsonSerializerSettings { MaxDepth = null };
+
         /// <summary>
         /// Initializes a new instance of the <see cref="QnAMakerRecognizer"/> class.
         /// </summary>
@@ -319,9 +321,9 @@ namespace Microsoft.Bot.Builder.AI.QnA.Recognizers
             {
                 { "TopIntent", recognizerResult.Intents.Any() ? recognizerResult.Intents.First().Key : null },
                 { "TopIntentScore", recognizerResult.Intents.Any() ? recognizerResult.Intents.First().Value?.Score?.ToString("N1", CultureInfo.InvariantCulture) : null },
-                { "Intents", recognizerResult.Intents.Any() ? JsonConvert.SerializeObject(recognizerResult.Intents) : null },
+                { "Intents", recognizerResult.Intents.Any() ? JsonConvert.SerializeObject(recognizerResult.Intents, _settings) : null },
                 { "Entities", recognizerResult.Entities?.ToString() },
-                { "AdditionalProperties", recognizerResult.Properties.Any() ? JsonConvert.SerializeObject(recognizerResult.Properties) : null },
+                { "AdditionalProperties", recognizerResult.Properties.Any() ? JsonConvert.SerializeObject(recognizerResult.Properties, _settings) : null },
             };
 
             var (logPersonalInfo, error) = LogPersonalInformation.TryGetValue(dialogContext.State);

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/GenerateAnswerUtils.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/GenerateAnswerUtils.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
         private readonly HttpClient _httpClient;
         private readonly IBotTelemetryClient _telemetryClient;
         private readonly QnAMakerEndpoint _endpoint;
+        private readonly JsonSerializerSettings _settings = new JsonSerializerSettings { MaxDepth = null };
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GenerateAnswerUtils"/> class.
@@ -97,7 +98,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
         {
             var jsonResponse = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
-            var results = JsonConvert.DeserializeObject<QueryResults>(jsonResponse);
+            var results = JsonConvert.DeserializeObject<QueryResults>(jsonResponse, new JsonSerializerSettings { MaxDepth = null });
 
             foreach (var answer in results.Answers)
             {
@@ -159,7 +160,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
         /// <returns>Return modified options for the QnA Maker knowledge base.</returns>
         private QnAMakerOptions HydrateOptions(QnAMakerOptions queryOptions)
         {
-            var hydratedOptions = JsonConvert.DeserializeObject<QnAMakerOptions>(JsonConvert.SerializeObject(Options));
+            var hydratedOptions = JsonConvert.DeserializeObject<QnAMakerOptions>(JsonConvert.SerializeObject(Options, _settings), _settings);
 
             if (queryOptions != null)
             {
@@ -209,7 +210,8 @@ namespace Microsoft.Bot.Builder.AI.QnA
                     isTest = options.IsTest,
                     rankerType = options.RankerType,
                     StrictFiltersCompoundOperationType = Enum.TryParse(options.Filters?.MetadataFilter?.LogicalOperation, out JoinOperator operation) ? operation : JoinOperator.AND,
-                }, Formatting.None);
+                }, Formatting.None,
+                _settings);
 
             var httpRequestHelper = new HttpRequestUtils(_httpClient);
             var response = await httpRequestHelper.ExecuteHttpRequestAsync(requestUrl, jsonRequest, _endpoint).ConfigureAwait(false);

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/LanguageServiceUtils.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/LanguageServiceUtils.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Utils
         private readonly HttpClient _httpClient;
         private readonly QnAMakerOptions _options;
         private readonly QnAMakerEndpoint _endpoint;
+        private readonly JsonSerializerSettings _settings = new JsonSerializerSettings { MaxDepth = null };
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LanguageServiceUtils"/> class.
@@ -170,7 +171,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Utils
         {
             var jsonResponse = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
-            var results = JsonConvert.DeserializeObject<KnowledgeBaseAnswers>(jsonResponse);
+            var results = JsonConvert.DeserializeObject<KnowledgeBaseAnswers>(jsonResponse, _settings);
 
             return new QueryResults
             {
@@ -197,7 +198,8 @@ namespace Microsoft.Bot.Builder.AI.QnA.Utils
                     rankerType = options.RankerType,
                     answerSpanRequest = new { enable = options.EnablePreciseAnswer },
                     includeUnstructuredSources = options.IncludeUnstructuredSources
-                }, Formatting.None);
+                }, Formatting.None,
+                _settings);
             var httpRequestHelper = new HttpRequestUtils(_httpClient);
             var response = await httpRequestHelper.ExecuteHttpRequestAsync(requestUrl, jsonRequest, _endpoint).ConfigureAwait(false);
 
@@ -212,7 +214,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Utils
             var feedbackRecordsRequest = new FeedbackRecordsRequest();
             feedbackRecordsRequest.Records.AddRange(feedbackRecords.Records.ToList());
 
-            var jsonRequest = JsonConvert.SerializeObject(feedbackRecordsRequest);
+            var jsonRequest = JsonConvert.SerializeObject(feedbackRecordsRequest, _settings);
 
             var httpRequestHelper = new HttpRequestUtils(_httpClient);
             await httpRequestHelper.ExecuteHttpRequestAsync(requestUrl, jsonRequest, _endpoint).ConfigureAwait(false);
@@ -225,7 +227,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Utils
         /// <returns>Return modified options for the Custom Question Answering Knowledge Base.</returns>
         private QnAMakerOptions HydrateOptions(QnAMakerOptions queryOptions)
         {
-            var hydratedOptions = JsonConvert.DeserializeObject<QnAMakerOptions>(JsonConvert.SerializeObject(_options));
+            var hydratedOptions = JsonConvert.DeserializeObject<QnAMakerOptions>(JsonConvert.SerializeObject(_options, _settings), _settings);
 
             if (queryOptions != null)
             {

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/TrainUtils.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/TrainUtils.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
         private async Task QueryTrainAsync(FeedbackRecords feedbackRecords)
         {
             var requestUrl = $"{_endpoint.Host}/knowledgebases/{_endpoint.KnowledgeBaseId}/train";
-            var jsonRequest = JsonConvert.SerializeObject(feedbackRecords, Formatting.None);
+            var jsonRequest = JsonConvert.SerializeObject(feedbackRecords, Formatting.None, new JsonSerializerSettings { MaxDepth = null });
 
             var httpRequestHelper = new HttpRequestUtils(_httpClient);
             var response = await httpRequestHelper.ExecuteHttpRequestAsync(requestUrl, jsonRequest, _endpoint).ConfigureAwait(false);

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpClient.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpClient.cs
@@ -30,6 +30,8 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
     [Obsolete("Use `BotFrameworkAuthentication.CreateBotFrameworkClient()` to obtain a client and perform the operations that were accomplished through `BotFrameworkHttpClient`.", false)]
     public class BotFrameworkHttpClient : BotFrameworkClient
     {
+        private readonly JsonSerializerSettings _settings = new JsonSerializerSettings { MaxDepth = null };
+
         /// <summary>
         /// Initializes a new instance of the <see cref="BotFrameworkHttpClient"/> class.
         /// </summary>
@@ -132,7 +134,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
             var token = appCredentials == MicrosoftAppCredentials.Empty ? null : await appCredentials.GetTokenAsync().ConfigureAwait(false);
 
             // Clone the activity so we can modify it before sending without impacting the original object.
-            var activityClone = JsonConvert.DeserializeObject<Activity>(JsonConvert.SerializeObject(activity));
+            var activityClone = JsonConvert.DeserializeObject<Activity>(JsonConvert.SerializeObject(activity, _settings), _settings);
             activityClone.RelatesTo = new ConversationReference
             {
                 ServiceUrl = activityClone.ServiceUrl,
@@ -215,7 +217,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
         {
             try
             {
-                return JsonConvert.DeserializeObject<T>(content);
+                return JsonConvert.DeserializeObject<T>(content, new JsonSerializerSettings { MaxDepth = null });
             }
             catch (JsonException)
             {
@@ -226,7 +228,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
 
         private async Task<InvokeResponse<T>> SecurePostActivityAsync<T>(Uri toUrl, Activity activity, string token, CancellationToken cancellationToken)
         {
-            using (var jsonContent = new StringContent(JsonConvert.SerializeObject(activity, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }), Encoding.UTF8, "application/json"))
+            using (var jsonContent = new StringContent(JsonConvert.SerializeObject(activity, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null }), Encoding.UTF8, "application/json"))
             {
                 using (var httpRequestMessage = new HttpRequestMessage())
                 {

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotMessageHandler.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotMessageHandler.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Handlers
 
                 // Get the request body and deserialize to the Activity object.
                 // NOTE: We explicitly leave the stream open here so others can still access it (in case buffering was enabled); ASP.NET runtime will always dispose of it anyway
-                using (var bodyReader = new JsonTextReader(new StreamReader(memoryStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: true)))
+                using (var bodyReader = new JsonTextReader(new StreamReader(memoryStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: true)) { MaxDepth = null })
                 {
                     activity = BotMessageSerializer.Deserialize<Activity>(bodyReader);
                 }

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/HttpHelper.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/HttpHelper.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                 {
                     await request.Body.CopyToAsync(memoryStream).ConfigureAwait(false);
                     memoryStream.Seek(0, SeekOrigin.Begin);
-                    using (var bodyReader = new JsonTextReader(new StreamReader(memoryStream, Encoding.UTF8)))
+                    using (var bodyReader = new JsonTextReader(new StreamReader(memoryStream, Encoding.UTF8)) { MaxDepth = null })
                     {
                         return BotMessageSerializer.Deserialize<T>(bodyReader);
                     }


### PR DESCRIPTION
Addresses # 6392
#minor

## Description
This PR adds the setting of the `MaxDepth` property in all the JSON Serialize/Deserialize operations.

## Specific Changes
- Set MaxDepth = null in **_JsonConvert.SerializeObject_**, **_JsonConvert.DeserializeObject_**, and **_JsonTextReader_** instances of the following projects:
   - Microsoft.Bot.Builder.Adapters.Facebook
   - Microsoft.Bot.Builder.Adapters.Slack
   - Microsoft.Bot.Builder.Adapters.Twilio
   - Microsoft.Bot.Builder.Adapters.Webex
   - AdaptiveExpressions
   - Microsoft.Bot.Builder.AI.LUIS
   - Microsoft.Bot.Builder.AI.Orchestrator
   - Microsoft.Bot.Builder.AI.QnA
   - Microsoft.Bot.Builder.Integration.AspNet.Core

## Testing
These images show the unit tests and the FunctionalTests pipeline successfully executed.
![image](https://user-images.githubusercontent.com/44245136/176904203-6f6809b5-c8bc-43d2-8525-7a08bfc678bc.png)
