### PR TITLE
[#6392] Bump Newtonsoft.Json from 12.0.3 to 13.0.1 - Set MaxDepth property (3/4)

### DIFF
--- a/libraries/Microsoft.Bot.Configuration/BotConfiguration.cs
+++ b/libraries/Microsoft.Bot.Configuration/BotConfiguration.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Bot.Configuration
                 json = await stream.ReadToEndAsync().ConfigureAwait(false);
             }
 
-            var bot = JsonConvert.DeserializeObject<BotConfiguration>(json);
+            var bot = JsonConvert.DeserializeObject<BotConfiguration>(json, new JsonSerializerSettings { MaxDepth = null });
             bot.Location = file;
             bot.MigrateData();
 
@@ -227,7 +227,7 @@ namespace Microsoft.Bot.Configuration
             {
                 using (var textWriter = new StreamWriter(file))
                 {
-                    await textWriter.WriteLineAsync(JsonConvert.SerializeObject(this, Formatting.Indented)).ConfigureAwait(false);
+                    await textWriter.WriteLineAsync(JsonConvert.SerializeObject(this, Formatting.Indented, new JsonSerializerSettings { MaxDepth = null })).ConfigureAwait(false);
                 }
             }
 

--- a/libraries/Microsoft.Bot.Connector.Streaming/Transport/TransportHandler.cs
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Transport/TransportHandler.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Bot.Connector.Streaming.Transport
         private readonly SemaphoreSlim _writeLock = new SemaphoreSlim(1);
         private readonly TimeSpan _semaphoreTimeout = TimeSpan.FromSeconds(10);
         private readonly byte[] _sendHeaderBuffer = new byte[TransportConstants.MaxHeaderLength];
+        private readonly JsonSerializerSettings _settings = new JsonSerializerSettings { MaxDepth = null };
 
         private IObserver<(Header, ReadOnlySequence<byte>)> _observer;
         private bool _disposedValue;
@@ -154,7 +155,7 @@ namespace Microsoft.Bot.Connector.Streaming.Transport
                 throw new ArgumentNullException(nameof(response));
             }
 
-            var responseBytes = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(response));
+            var responseBytes = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(response, _settings));
 
             var responseHeader = new Header()
             {
@@ -176,7 +177,7 @@ namespace Microsoft.Bot.Connector.Streaming.Transport
                 throw new ArgumentNullException(nameof(request));
             }
 
-            var requestBytes = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(request));
+            var requestBytes = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(request, _settings));
 
             var requestHeader = new Header()
             {

--- a/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkClientImpl.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkClientImpl.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Bot.Connector.Authentication
         private readonly HttpClient _httpClient;
         private readonly string _loginEndpoint;
         private readonly ILogger _logger;
+        private readonly JsonSerializerSettings _settings = new JsonSerializerSettings { MaxDepth = null };
         private bool _disposed;
 
         public BotFrameworkClientImpl(
@@ -50,7 +51,7 @@ namespace Microsoft.Bot.Connector.Authentication
             var credentials = await _credentialsFactory.CreateCredentialsAsync(fromBotId, toBotId, _loginEndpoint, true, cancellationToken).ConfigureAwait(false);
 
             // Clone the activity so we can modify it before sending without impacting the original object.
-            var activityClone = JsonConvert.DeserializeObject<Activity>(JsonConvert.SerializeObject(activity));
+            var activityClone = JsonConvert.DeserializeObject<Activity>(JsonConvert.SerializeObject(activity, _settings), _settings);
 
             // Apply the appropriate addressing to the newly created Activity.
             activityClone.RelatesTo = new ConversationReference
@@ -77,7 +78,7 @@ namespace Microsoft.Bot.Connector.Authentication
             activityClone.Recipient.Role = RoleTypes.Skill;
 
             // Create the HTTP request from the cloned Activity and send it to the Skill.
-            using (var jsonContent = new StringContent(JsonConvert.SerializeObject(activityClone, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }), Encoding.UTF8, "application/json"))
+            using (var jsonContent = new StringContent(JsonConvert.SerializeObject(activityClone, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null }), Encoding.UTF8, "application/json"))
             {
                 using (var httpRequestMessage = new HttpRequestMessage())
                 {
@@ -100,7 +101,7 @@ namespace Microsoft.Bot.Connector.Authentication
                             return new InvokeResponse<T>
                             {
                                 Status = (int)httpResponseMessage.StatusCode,
-                                Body = content?.Length > 0 ? JsonConvert.DeserializeObject<T>(content) : default
+                                Body = content?.Length > 0 ? JsonConvert.DeserializeObject<T>(content, _settings) : default
                             };
                         }
                         else

--- a/libraries/Microsoft.Bot.Connector/Authentication/UserTokenClient.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/UserTokenClient.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 RelatesTo = activity.RelatesTo,
                 MsAppId = appId,
             };
-            var json = JsonConvert.SerializeObject(tokenExchangeState);
+            var json = JsonConvert.SerializeObject(tokenExchangeState, new JsonSerializerSettings { MaxDepth = null });
             return Convert.ToBase64String(Encoding.UTF8.GetBytes(json));
         }
 

--- a/libraries/Microsoft.Bot.Connector/ConnectorClient.cs
+++ b/libraries/Microsoft.Bot.Connector/ConnectorClient.cs
@@ -351,7 +351,8 @@ namespace Microsoft.Bot.Connector
                 Converters = new List<JsonConverter>
                     {
                         new Iso8601TimeSpanConverter()
-                    }
+                    },
+                MaxDepth = null
             };
             DeserializationSettings = new JsonSerializerSettings
             {
@@ -363,7 +364,8 @@ namespace Microsoft.Bot.Connector
                 Converters = new List<JsonConverter>
                     {
                         new Iso8601TimeSpanConverter()
-                    }
+                    },
+                MaxDepth = null
             };
             CustomInitialize();
         }

--- a/libraries/Microsoft.Bot.Connector/OAuthClientOld.cs
+++ b/libraries/Microsoft.Bot.Connector/OAuthClientOld.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Bot.Connector
 #pragma warning disable CA1801 // Review unused parameters (this class is deprecated, we won't fix FxCop issues)
         private readonly ConnectorClient _client;
         private readonly string _uri;
+        private readonly JsonSerializerSettings _settings = new JsonSerializerSettings { MaxDepth = null };
 
         /// <summary>
         /// Initializes a new instance of the <see cref="OAuthClientOld"/> class.
@@ -143,7 +144,7 @@ namespace Microsoft.Bot.Connector
                 string responseContent = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    var tokenResponse = Rest.Serialization.SafeJsonConvert.DeserializeObject<TokenResponse>(responseContent);
+                    var tokenResponse = Rest.Serialization.SafeJsonConvert.DeserializeObject<TokenResponse>(responseContent, _settings);
                     return tokenResponse;
                 }
                 catch (JsonException)
@@ -389,7 +390,7 @@ namespace Microsoft.Bot.Connector
                 string responseContent = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    var statuses = Rest.Serialization.SafeJsonConvert.DeserializeObject<TokenStatus[]>(responseContent);
+                    var statuses = Rest.Serialization.SafeJsonConvert.DeserializeObject<TokenStatus[]>(responseContent, _settings);
                     return statuses;
                 }
                 catch (JsonException)
@@ -510,7 +511,7 @@ namespace Microsoft.Bot.Connector
                     string responseContent = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                     try
                     {
-                        var tokens = Rest.Serialization.SafeJsonConvert.DeserializeObject<Dictionary<string, TokenResponse>>(responseContent);
+                        var tokens = Rest.Serialization.SafeJsonConvert.DeserializeObject<Dictionary<string, TokenResponse>>(responseContent, _settings);
                         return tokens;
                     }
                     catch (JsonException)

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsConnectorClient.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsConnectorClient.cs
@@ -298,7 +298,8 @@ namespace Microsoft.Bot.Connector.Teams
                 Converters = new List<JsonConverter>
                     {
                         new Iso8601TimeSpanConverter()
-                    }
+                    },
+                MaxDepth = null
             };
             DeserializationSettings = new JsonSerializerSettings
             {
@@ -310,7 +311,8 @@ namespace Microsoft.Bot.Connector.Teams
                 Converters = new List<JsonConverter>
                     {
                         new Iso8601TimeSpanConverter()
-                    }
+                    },
+                MaxDepth = null
             };
             CustomInitialize();
         }

--- a/libraries/Microsoft.Bot.Schema/Entity.cs
+++ b/libraries/Microsoft.Bot.Schema/Entity.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Bot.Schema
     /// </summary>
     public class Entity
     {
+        private readonly JsonSerializerSettings _settings = new JsonSerializerSettings { MaxDepth = null };
+
         /// <summary>Initializes a new instance of the <see cref="Entity"/> class.</summary>
         public Entity()
         {
@@ -51,7 +53,7 @@ namespace Microsoft.Bot.Schema
         /// <returns>T as T.</returns>
         public T GetAs<T>()
         {
-            return JsonConvert.DeserializeObject<T>(JsonConvert.SerializeObject(this));
+            return JsonConvert.DeserializeObject<T>(JsonConvert.SerializeObject(this, _settings), _settings);
         }
 
         /// <summary>
@@ -61,7 +63,7 @@ namespace Microsoft.Bot.Schema
         /// <param name="obj">obj.</param>
         public void SetAs<T>(T obj)
         {
-            var entity = JsonConvert.DeserializeObject<Entity>(JsonConvert.SerializeObject(obj));
+            var entity = JsonConvert.DeserializeObject<Entity>(JsonConvert.SerializeObject(obj, _settings), _settings);
             Type = entity.Type;
             Properties = entity.Properties;
         }
@@ -78,7 +80,7 @@ namespace Microsoft.Bot.Schema
                 return false;
             }
 
-            return JsonConvert.SerializeObject(this).Equals(JsonConvert.SerializeObject(other), StringComparison.Ordinal);
+            return JsonConvert.SerializeObject(this, _settings).Equals(JsonConvert.SerializeObject(other, _settings), StringComparison.Ordinal);
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Streaming/Payloads/Assemblers/ReceiveRequestAssembler.cs
+++ b/libraries/Microsoft.Bot.Streaming/Payloads/Assemblers/ReceiveRequestAssembler.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Bot.Streaming.Payloads
         {
             using (var textReader = new StreamReader(stream))
             {
-                using (var jsonReader = new JsonTextReader(textReader))
+                using (var jsonReader = new JsonTextReader(textReader) { MaxDepth = null })
                 {
                     var requestPayload = Serializer.Deserialize<RequestPayload>(jsonReader);
 

--- a/libraries/Microsoft.Bot.Streaming/Payloads/Assemblers/ReceiveResponseAssembler.cs
+++ b/libraries/Microsoft.Bot.Streaming/Payloads/Assemblers/ReceiveResponseAssembler.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Bot.Streaming.Payloads
         {
             using (var textReader = new StreamReader(stream))
             {
-                using (var jsonReader = new JsonTextReader(textReader))
+                using (var jsonReader = new JsonTextReader(textReader) { MaxDepth = null })
                 {
                     var responsePayload = Serializer.Deserialize<ResponsePayload>(jsonReader);
 

--- a/libraries/Microsoft.Bot.Streaming/ReceiveResponseExtensions.cs
+++ b/libraries/Microsoft.Bot.Streaming/ReceiveResponseExtensions.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Bot.Streaming
 
             using (var reader = new StreamReader(contentStream.Stream, Encoding.UTF8))
             {
-                using (var jsonReader = new JsonTextReader(reader))
+                using (var jsonReader = new JsonTextReader(reader) { MaxDepth = null })
                 {
                     var serializer = JsonSerializer.Create(SerializationSettings.DefaultDeserializationSettings);
                     return serializer.Deserialize<T>(jsonReader);

--- a/libraries/Microsoft.Bot.Streaming/SerializationSettings.cs
+++ b/libraries/Microsoft.Bot.Streaming/SerializationSettings.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Bot.Streaming
             NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore,
             ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Serialize,
             ContractResolver = new CamelCasePropertyNamesContractResolver(),
+            MaxDepth = null,
         };
 
         /// <summary>
@@ -40,6 +41,7 @@ namespace Microsoft.Bot.Streaming
             DateTimeZoneHandling = Newtonsoft.Json.DateTimeZoneHandling.Utc,
             NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore,
             ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Serialize,
+            MaxDepth = null,
         };
 
         /// <summary>
@@ -51,6 +53,7 @@ namespace Microsoft.Bot.Streaming
             DateTimeZoneHandling = DateTimeZoneHandling.Utc,
             NullValueHandling = NullValueHandling.Ignore,
             ReferenceLoopHandling = ReferenceLoopHandling.Serialize,
+            MaxDepth = null,
         };
     }
 }

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot/Bots/PrimaryBot.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot/Bots/PrimaryBot.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot.Bots
             var templateAttachment = new Attachment()
             {
                 ContentType = "template",
-                Content = JsonConvert.DeserializeObject(templateAttachmentJson),
+                Content = JsonConvert.DeserializeObject(templateAttachmentJson, new JsonSerializerSettings { MaxDepth = null }),
             };
             return templateAttachment;
         }

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.TestBot/Bots/EchoBot.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.TestBot/Bots/EchoBot.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.TestBot.Bots
         private static Attachment CreateInteractiveMessage(string filePath)
         {
             var interactiveMessageJson = System.IO.File.ReadAllText(filePath);
-            var adaptiveCardAttachment = JsonConvert.DeserializeObject<Block[]>(interactiveMessageJson);
+            var adaptiveCardAttachment = JsonConvert.DeserializeObject<Block[]>(interactiveMessageJson, new JsonSerializerSettings { MaxDepth = null });
 
             var blockList = adaptiveCardAttachment.ToList();
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.TestBot/Bots/EchoBot.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.TestBot/Bots/EchoBot.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.TestBot.Bots
             var adaptiveCardAttachment = new Attachment()
             {
                 ContentType = "application/vnd.microsoft.card.adaptive",
-                Content = JsonConvert.DeserializeObject(adaptiveCardJson),
+                Content = JsonConvert.DeserializeObject(adaptiveCardJson, new JsonSerializerSettings { MaxDepth = null }),
             };
             return adaptiveCardAttachment;
         }

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/Contoso_App.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/Contoso_App.cs
@@ -260,7 +260,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
 
         public void Convert(dynamic result)
         {
-            var app = JsonConvert.DeserializeObject<Contoso_App>(JsonConvert.SerializeObject(result, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
+            var app = JsonConvert.DeserializeObject<Contoso_App>(JsonConvert.SerializeObject(result, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null }));
             Text = app.Text;
             AlteredText = app.AlteredText;
             Intents = app.Intents;

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/Contoso_App_V3.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/Contoso_App_V3.cs
@@ -261,7 +261,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
 
         public void Convert(dynamic result)
         {
-            var app = JsonConvert.DeserializeObject<Contoso_App_V3>(JsonConvert.SerializeObject(result, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
+            var app = JsonConvert.DeserializeObject<Contoso_App_V3>(JsonConvert.SerializeObject(result, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null }));
             Text = app.Text;
             AlteredText = app.AlteredText;
             Intents = app.Intents;

--- a/tests/Microsoft.Bot.Builder.Ai.LUISV3.tests/Contoso_App.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.LUISV3.tests/Contoso_App.cs
@@ -261,7 +261,7 @@ namespace Microsoft.Bot.Builder.AI.LuisV3.Tests
 
     public void Convert(dynamic result)
     {
-        var app = JsonConvert.DeserializeObject<Contoso_App>(JsonConvert.SerializeObject(result, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
+        var app = JsonConvert.DeserializeObject<Contoso_App>(JsonConvert.SerializeObject(result, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null }));
         Text = app.Text;
         AlteredText = app.AlteredText;
         Intents = app.Intents;

--- a/tests/Microsoft.Bot.Builder.TestBot.Shared/Bots/DialogAndWelcomeBot.cs
+++ b/tests/Microsoft.Bot.Builder.TestBot.Shared/Bots/DialogAndWelcomeBot.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Bot.Builder.TestBot.Shared.Bots
                     return new Attachment()
                     {
                         ContentType = "application/vnd.microsoft.card.adaptive",
-                        Content = JsonConvert.DeserializeObject(adaptiveCard),
+                        Content = JsonConvert.DeserializeObject(adaptiveCard, new JsonSerializerSettings { MaxDepth = null }),
                     };
                 }
             }

--- a/tests/Microsoft.Bot.Builder.TestBot.Shared/CognitiveModels/FlightBooking.cs
+++ b/tests/Microsoft.Bot.Builder.TestBot.Shared/CognitiveModels/FlightBooking.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Bot.Builder.TestBot.Shared.CognitiveModels
 
         public void Convert(dynamic result)
         {
-            var app = JsonConvert.DeserializeObject<FlightBooking>(JsonConvert.SerializeObject(result));
+            var app = JsonConvert.DeserializeObject<FlightBooking>(JsonConvert.SerializeObject(result, new JsonSerializerSettings { MaxDepth = null }));
             Text = app.Text;
             AlteredText = app.AlteredText;
             Intents = app.Intents;

--- a/tests/Microsoft.Bot.Builder.TestBot.Shared/HttpHelper.cs
+++ b/tests/Microsoft.Bot.Builder.TestBot.Shared/HttpHelper.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Bot.Builder.TestBot.Shared
             ReferenceLoopHandling = ReferenceLoopHandling.Serialize,
             ContractResolver = new ReadOnlyJsonContractResolver(),
             Converters = new List<JsonConverter> { new Iso8601TimeSpanConverter() },
+            MaxDepth = null
         });
 
         public static Activity ReadRequest(HttpRequest request)
@@ -35,7 +36,7 @@ namespace Microsoft.Bot.Builder.TestBot.Shared
 
             var activity = default(Activity);
 
-            using (var bodyReader = new JsonTextReader(new StreamReader(request.Body, Encoding.UTF8)))
+            using (var bodyReader = new JsonTextReader(new StreamReader(request.Body, Encoding.UTF8)) { MaxDepth = null })
             {
                 activity = BotMessageSerializer.Deserialize<Activity>(bodyReader);
             }

--- a/tests/Microsoft.Bot.Builder.TestBot.WebApi/Bots/DialogAndWelcomeBot.cs
+++ b/tests/Microsoft.Bot.Builder.TestBot.WebApi/Bots/DialogAndWelcomeBot.cs
@@ -55,7 +55,7 @@ namespace Microsoft.BotBuilderSamples
             return new Attachment()
             {
                 ContentType = "application/vnd.microsoft.card.adaptive",
-                Content = JsonConvert.DeserializeObject(adaptiveCard),
+                Content = JsonConvert.DeserializeObject(adaptiveCard, new JsonSerializerSettings { MaxDepth = null }),
             };
         }
     }

--- a/tests/Microsoft.Bot.Connector.Streaming.Tests.Client/Program.cs
+++ b/tests/Microsoft.Bot.Connector.Streaming.Tests.Client/Program.cs
@@ -179,7 +179,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests.Client
                 Text = text,
             };
 
-            var request = StreamingRequest.CreatePost("/api/messages", new StringContent(JsonConvert.SerializeObject(activity), Encoding.UTF8, "application/json"));
+            var request = StreamingRequest.CreatePost("/api/messages", new StringContent(JsonConvert.SerializeObject(activity, new JsonSerializerSettings { MaxDepth = null }), Encoding.UTF8, "application/json"));
 
             var stopwatch = Stopwatch.StartNew();
 

--- a/tests/Microsoft.Bot.Streaming.Tests/Utilities/MockBot.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/Utilities/MockBot.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Bot.Streaming.Tests.Utilities
 
             if (serverResponse.Status == (int)HttpStatusCode.OK)
             {
-                return JsonConvert.DeserializeObject<Schema.ResourceResponse>(serverResponse.Body.ToString());
+                return JsonConvert.DeserializeObject<Schema.ResourceResponse>(serverResponse.Body.ToString(), new JsonSerializerSettings { MaxDepth = null });
             }
 
             throw new Exception("SendActivityAsync failed");

--- a/tests/Skills/Bot1/Bot1.cs
+++ b/tests/Skills/Bot1/Bot1.cs
@@ -111,7 +111,7 @@ namespace Bot1
 
             if ((turnContext.Activity as Activity)?.Value != null)
             {
-                eocActivityMessage += $"\n\nValue: {JsonConvert.SerializeObject((turnContext.Activity as Activity)?.Value)}";
+                eocActivityMessage += $"\n\nValue: {JsonConvert.SerializeObject((turnContext.Activity as Activity)?.Value, new JsonSerializerSettings { MaxDepth = null })}";
             }
 
             await turnContext.SendActivityAsync(MessageFactory.Text(eocActivityMessage), cancellationToken);

--- a/tests/Skills/Bot2/Bot2.cs
+++ b/tests/Skills/Bot2/Bot2.cs
@@ -113,7 +113,7 @@ namespace Bot2
 
             if ((turnContext.Activity as Activity)?.Value != null)
             {
-                eocActivityMessage += $"\n\nValue: {JsonConvert.SerializeObject((turnContext.Activity as Activity)?.Value)}";
+                eocActivityMessage += $"\n\nValue: {JsonConvert.SerializeObject((turnContext.Activity as Activity)?.Value, new JsonSerializerSettings { MaxDepth = null })}";
             }
 
             await turnContext.SendActivityAsync(MessageFactory.Text(eocActivityMessage), cancellationToken);


### PR DESCRIPTION
Addresses # 6392
#minor

## Description
This PR adds the setting of the `MaxDepth` property in all the JSON Serialize/Deserialize operations.

## Specific Changes
- Set MaxDepth = null in **_JsonConvert.SerializeObject_**, **_JsonConvert.DeserializeObject_**, and **_JsonTextReader_** instances of the following projects:
   - libraries/Microsoft.Bot.Configuration/BotConfiguration.cs
   - libraries/Microsoft.Bot.Connector.Streaming/Transport/TransportHandler.cs
   - libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkClientImpl.cs
   - libraries/Microsoft.Bot.Schema/Entity.cs
   - libraries/Microsoft.Bot.Streaming/Payloads/Assemblers/ReceiveRequestAssembler.cs
 
- And in the test bots and apps of the following projects:
   - Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot
   - Microsoft.Bot.Builder.Adapters.Slack.TestBot
   - Microsoft.Bot.Builder.Adapters.Webex.TestBot
   - Microsoft.Bot.Builder.AI.LUIS.Tests
   - Microsoft.Bot.Builder.Ai.LUISV3.tests
   - Microsoft.Bot.Builder.TestBot.Shared
   - Microsoft.Bot.Builder.TestBot.WebApi
   - Microsoft.Bot.Connector.Streaming.Tests.Client
   - Microsoft.Bot.Streaming.Tests
   - Skills/Bot1
   - Skills/Bot2

## Testing
These images show the unit tests and the FunctionalTests pipeline successfully executed.
![image](https://user-images.githubusercontent.com/44245136/176904203-6f6809b5-c8bc-43d2-8525-7a08bfc678bc.png)
