### PR TITLE
[#6392] Bump Newtonsoft.Json from 12.0.3 to 13.0.1 - Set MaxDepth property (4/4)

### DIFF
--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/Bots/DialogAndWelcomeBot.cs
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/Bots/DialogAndWelcomeBot.cs
@@ -52,7 +52,7 @@ namespace CoreBot.Bots
                     return new Attachment()
                     {
                         ContentType = "application/vnd.microsoft.card.adaptive",
-                        Content = JsonConvert.DeserializeObject(adaptiveCard),
+                        Content = JsonConvert.DeserializeObject(adaptiveCard, new JsonSerializerSettings { MaxDepth = null }),
                     };
                 }
             }

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/CognitiveModels/FlightBooking.cs
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/CognitiveModels/FlightBooking.cs
@@ -75,7 +75,7 @@ namespace CoreBot
 
         public void Convert(dynamic result)
         {
-            var app = JsonConvert.DeserializeObject<FlightBooking>(JsonConvert.SerializeObject(result, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
+            var app = JsonConvert.DeserializeObject<FlightBooking>(JsonConvert.SerializeObject(result, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null }));
             Text = app.Text;
             AlteredText = app.AlteredText;
             Intents = app.Intents;

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/Bots/DialogAndWelcomeBot.cs
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/Bots/DialogAndWelcomeBot.cs
@@ -53,7 +53,7 @@ namespace $safeprojectname$.Bots
                     return new Attachment()
                     {
                         ContentType = "application/vnd.microsoft.card.adaptive",
-                        Content = JsonConvert.DeserializeObject(adaptiveCard),
+                        Content = JsonConvert.DeserializeObject(adaptiveCard, new JsonSerializerSettings { MaxDepth = null }),
                     };
                 }
             }

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/CognitiveModels/FlightBooking.cs
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/CognitiveModels/FlightBooking.cs
@@ -75,7 +75,7 @@ namespace $safeprojectname$.CognitiveModels
 
         public void Convert(dynamic result)
         {
-            var app = JsonConvert.DeserializeObject<FlightBooking>(JsonConvert.SerializeObject(result, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
+            var app = JsonConvert.DeserializeObject<FlightBooking>(JsonConvert.SerializeObject(result, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null }));
             Text = app.Text;
             AlteredText = app.AlteredText;
             Intents = app.Intents;

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot/Bots/DialogAndWelcomeBot.cs
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot/Bots/DialogAndWelcomeBot.cs
@@ -53,7 +53,7 @@ namespace $ext_safeprojectname$.Bots
                     return new Attachment()
                     {
                         ContentType = "application/vnd.microsoft.card.adaptive",
-                        Content = JsonConvert.DeserializeObject(adaptiveCard),
+                        Content = JsonConvert.DeserializeObject(adaptiveCard, new JsonSerializerSettings { MaxDepth = null }),
                     };
                 }
             }

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot/CognitiveModels/FlightBooking.cs
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot/CognitiveModels/FlightBooking.cs
@@ -75,7 +75,7 @@ namespace $ext_safeprojectname$.CognitiveModels
 
         public void Convert(dynamic result)
         {
-            var app = JsonConvert.DeserializeObject<FlightBooking>(JsonConvert.SerializeObject(result, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
+            var app = JsonConvert.DeserializeObject<FlightBooking>(JsonConvert.SerializeObject(result, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null }));
             Text = app.Text;
             AlteredText = app.AlteredText;
             Intents = app.Intents;


### PR DESCRIPTION
Fixes # 6392
#minor

## Description
This PR adds the setting of the `MaxDepth` property in all the JSON Serialize/Deserialize operations.

## Specific Changes
- Set MaxDepth = null in **_JsonConvert.SerializeObject_**, **_JsonConvert.DeserializeObject_**, and **_JsonTextReader_** instances in the generators/Core bot templates

## Testing
This image shows the CoreBot working as expected after the changes:
![image](https://user-images.githubusercontent.com/44245136/176908187-803c150c-c538-48af-a190-961df849a45c.png)