### PR TITLE
[#6306] NamedPipe could not reconnect correctly when disconnected unexpectedly

### DIFF
--- a/libraries/Microsoft.Bot.Connector.Streaming/Transport/NamedPipeTransport.cs
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Transport/NamedPipeTransport.cs
@@ -60,6 +60,11 @@ namespace Microsoft.Bot.Connector.Streaming.Transport
 
                 await ProcessAsync(cancellationToken).ConfigureAwait(false);
             }
+            catch (Exception)
+            {
+                Log.NamedPipeClosed(Logger);
+                throw;
+            }
             finally
             {
                 Log.NamedPipeClosed(Logger);

--- a/libraries/Microsoft.Bot.Connector.Streaming/Transport/StreamingTransport.cs
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Transport/StreamingTransport.cs
@@ -47,6 +47,11 @@ namespace Microsoft.Bot.Connector.Streaming.Transport
             // Wait for send or receive to complete
             var trigger = await Task.WhenAny(receiving, sending).ConfigureAwait(false);
 
+            if (trigger.Exception != null)
+            {
+                throw trigger.Exception;
+            }
+
             if (trigger == receiving)
             {
                 Log.WaitingForSend(Logger);
@@ -191,6 +196,8 @@ namespace Microsoft.Bot.Connector.Streaming.Transport
                     await _application.Output.CompleteAsync(ex).ConfigureAwait(false);
                     Log.TransportError(Logger, ex);
                 }
+
+                throw;
             }
             finally
             {

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/CloudAdapterTests.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/CloudAdapterTests.cs
@@ -149,33 +149,27 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             // Arrange
             var headerDictionaryMock = new Mock<IHeaderDictionary>();
             headerDictionaryMock.Setup(h => h[It.Is<string>(v => v == "Authorization")]).Returns<string>(null);
-
+            
+            var validContent = new StringContent(JsonConvert.SerializeObject(new Activity()), Encoding.UTF8, "application/json");
             var webSocketReceiveResult = new Mock<WebSocketReceiveResult>(MockBehavior.Strict, new object[] { 1, WebSocketMessageType.Binary, false });
-
-            var webSocketMock = new Mock<WebSocket>();
-            webSocketMock.Setup(ws => ws.State).Returns(WebSocketState.Open);
-            webSocketMock.Setup(ws => ws.ReceiveAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(webSocketReceiveResult.Object));
-            webSocketMock.Setup(ws => ws.SendAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<WebSocketMessageType>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-            webSocketMock.Setup(ws => ws.CloseAsync(It.IsAny<WebSocketCloseStatus>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-            webSocketMock.Setup(ws => ws.Dispose());
-
-            var webSocketManagerMock = new Mock<WebSocketManager>();
-            webSocketManagerMock.Setup(w => w.IsWebSocketRequest).Returns(true);
-            webSocketManagerMock.Setup(w => w.AcceptWebSocketAsync()).Returns(Task.FromResult(webSocketMock.Object));
-            var httpContextMock = new Mock<HttpContext>();
-            httpContextMock.Setup(c => c.WebSockets).Returns(webSocketManagerMock.Object);
-            var httpRequestMock = new Mock<HttpRequest>();
-            httpRequestMock.Setup(r => r.Method).Returns("GET");
-            httpRequestMock.Setup(r => r.Body).Returns(CreateMessageActivityStream());
-            httpRequestMock.Setup(r => r.Headers).Returns(headerDictionaryMock.Object);
-            httpRequestMock.Setup(r => r.HttpContext).Returns(httpContextMock.Object);
-
             var httpResponseMock = new Mock<HttpResponse>().SetupAllProperties();
-
             var authenticateRequestResult = new AuthenticateRequestResult
             {
                 Audience = "audience",
             };
+
+            var webSocket = new ClientWebSocket();
+            var webSocketManagerMock = new Mock<WebSocketManager>();
+            webSocketManagerMock.Setup(m => m.IsWebSocketRequest).Returns(true);
+            webSocketManagerMock.Setup(m => m.AcceptWebSocketAsync()).Returns(Task.FromResult<WebSocket>(webSocket));
+            
+            var httpContextMock = new Mock<HttpContext>();
+            httpContextMock.Setup(c => c.WebSockets).Returns(webSocketManagerMock.Object);
+            
+            var httpRequestMock = new Mock<HttpRequest>();
+            httpRequestMock.Setup(r => r.Method).Returns("GET");
+            httpRequestMock.Setup(r => r.HttpContext).Returns(httpContextMock.Object);
+            httpRequestMock.Setup(r => r.Headers).Returns(headerDictionaryMock.Object);
 
             var botFrameworkAuthenticationMock = new Mock<BotFrameworkAuthentication>();
             botFrameworkAuthenticationMock.Setup(
@@ -184,9 +178,31 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
 
             var bot = new MessageBot();
 
+            var streamingConnectionMock = new Mock<StreamingConnection>(null);
+            streamingConnectionMock
+                .Setup(c => c.ListenAsync(It.IsAny<RequestHandler>(), It.IsAny<CancellationToken>()))
+                .Returns<RequestHandler, CancellationToken>((handler, cancellationToken) => handler.ProcessRequestAsync(
+                    new ReceiveRequest
+                    {
+                        Verb = "POST",
+                        Path = "/api/messages",
+                        Streams = new List<IContentStream>
+                        {
+                            new TestContentStream
+                            {
+                                Id = Guid.NewGuid(),
+                                ContentType = "application/json",
+                                Length = (int?)validContent.Headers.ContentLength,
+                                Stream = validContent.ReadAsStreamAsync().GetAwaiter().GetResult()
+                            }
+                        }
+                    },
+                    null,
+                    cancellationToken: cancellationToken));
+
             // Act
-            var adapter = new CloudAdapter(botFrameworkAuthenticationMock.Object);
-            await adapter.ProcessAsync(httpRequestMock.Object, httpResponseMock.Object, bot);
+            var adapter = new StreamingTestCloudAdapter(botFrameworkAuthenticationMock.Object, new Dictionary<WebSocket, StreamingConnection> { { webSocket, streamingConnectionMock.Object } });
+            await adapter.ProcessAsync(httpRequestMock.Object, httpResponseMock.Object, bot, CancellationToken.None);
 
             // Assert
             botFrameworkAuthenticationMock.Verify(x => x.AuthenticateStreamingRequestAsync(It.Is<string>(v => true), It.Is<string>(v => true), It.Is<CancellationToken>(ct => true)), Times.Once());


### PR DESCRIPTION
Fixes # 6306
#minor

## Description
This PR adds the **_reconnect_** logic in CloudAdapter's **_ConnectNamedPipeAsync_** so the server can recover and keep receiving new connections after an exception.
It also fixes a unit test that was working by ignoring an exception now being thrown. 

## Specific Changes
- Updated `ConnectNamedPipeAsync` method to catch exceptions and reconnect.
- Catch and throw possible exceptions in `ConnectAsync` and `ProcessAsync` methods.
- Mock connection and other necessary classes in `WebSocketRequestShouldCallAuthenticateStreamingRequestAsync` test for it to work.

## Testing
Here we have two Webchat clients connecting with an echo bot through DL-ASE. 
The second client is able to connect with the server after it failed on the first client and reconnected.
![image](https://user-images.githubusercontent.com/44245136/178754707-6b22a0e3-c8db-4a53-acd4-ab29c966fe4e.png)