### PR TITLE
[#6354] isMatch adaptive expression returns error when value is null or empty string

### DIFF
--- a/libraries/AdaptiveExpressions/BuiltinFunctions/IsMatch.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/IsMatch.cs
@@ -21,22 +21,11 @@ namespace AdaptiveExpressions.BuiltinFunctions
             return FunctionUtils.ApplyWithError(
                         args =>
                         {
-                            var value = false;
-                            string error = null;
+                            var regex = CommonRegex.CreateRegex(args[1].ToString());
+                            var inputString = args[0]?.ToString() ?? string.Empty;
+                            var value = regex.IsMatch(inputString);
 
-                            string inputString = args[0]?.ToString();
-                            if (string.IsNullOrEmpty(inputString))
-                            {
-                                value = false;
-                                error = "regular expression is empty.";
-                            }
-                            else
-                            {
-                                var regex = CommonRegex.CreateRegex(args[1].ToString());
-                                value = regex.IsMatch(inputString);
-                            }
-
-                            return (value, error);
+                            return (value, null);
                         }, FunctionUtils.VerifyStringOrNull);
         }
 

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -1150,6 +1150,8 @@ namespace AdaptiveExpressions.Tests
             Test(@"isMatch('1', '\\d{1}')", true), // "\d" (match [0-9])
             Test(@"isMatch('12.5', '[0-9]+(\\.5)')", true), // "\." (match .)
             Test(@"isMatch('12x5', '[0-9]+(\\.5)')", false), // "\." (match .)
+            Test("isMatch('', '([0-9])')", false), // empty string
+            Test("isMatch(nullObj, '([0-9])')", false), // null object
             #endregion
 
             #region type checking


### PR DESCRIPTION
Fixes # 6354

## Description
This PR fixes the issue where the `isMatch` adaptive expression built-in function returns the error message `regular expression is empty` when the value is null or an empty string to just being processed by the evaluator instead.

## Specific Changes
- Updates the `IsMatch` built-in function to handle empty strings and null values by the evaluator.
- Adds new unit tests to handle empty string and null values for the `IsMatch` function.

## Testing
The following image shows the tests passing successfully.
![image](https://user-images.githubusercontent.com/62260472/180838966-7c192a25-433a-4e58-bba1-51c52329e5fa.png)