### PR TITLE
[#6432] TeamsInfo.GetMemberAsync(...) doesn't work properly in Skill Bot scenario, it returns http 405 error.

### DIFF
--- a/libraries/Microsoft.Bot.Builder/ChannelServiceHandlerBase.cs
+++ b/libraries/Microsoft.Bot.Builder/ChannelServiceHandlerBase.cs
@@ -130,6 +130,20 @@ namespace Microsoft.Bot.Builder
         }
 
         /// <summary>
+        /// Gets the account of a single conversation member.
+        /// </summary>
+        /// <param name="authHeader">The authentication header.</param>
+        /// <param name="userId">The user id.</param>
+        /// <param name="conversationId">The conversation Id.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
+        public async Task<ChannelAccount> HandleGetConversationMemberAsync(string authHeader, string userId, string conversationId, CancellationToken cancellationToken = default)
+        {
+            var claimsIdentity = await AuthenticateAsync(authHeader, cancellationToken).ConfigureAwait(false);
+            return await OnGetConversationMemberAsync(claimsIdentity, userId, conversationId, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Enumerates the members of a conversation one page at a time.
         /// </summary>
         /// <param name="authHeader">The authentication header.</param>
@@ -388,6 +402,25 @@ namespace Microsoft.Bot.Builder
         /// <param name='cancellationToken'>The cancellation token.</param>
         /// <returns>task for a response.</returns>
         protected virtual Task<IList<ChannelAccount>> OnGetConversationMembersAsync(ClaimsIdentity claimsIdentity, string conversationId, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// GetConversationMember() API for Skill.
+        /// </summary>
+        /// <remarks>
+        /// Override this method to get the account of a single conversation member.
+        ///
+        /// This REST API takes a ConversationId and UserId and returns the ChannelAccount
+        /// objects representing the member of the conversation.
+        /// </remarks>
+        /// <param name="claimsIdentity">claimsIdentity for the bot, should have AudienceClaim, AppIdClaim and ServiceUrlClaim.</param>
+        /// <param name="userId">User ID.</param>
+        /// <param name='conversationId'>Conversation ID.</param>
+        /// <param name='cancellationToken'>The cancellation token.</param>
+        /// <returns>task for a response.</returns>
+        protected virtual Task<ChannelAccount> OnGetConversationMemberAsync(ClaimsIdentity claimsIdentity, string userId, string conversationId, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }

--- a/libraries/Microsoft.Bot.Builder/Skills/CloudSkillHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/Skills/CloudSkillHandler.cs
@@ -132,5 +132,11 @@ namespace Microsoft.Bot.Builder.Skills
         {
             return await _inner.OnUpdateActivityAsync(claimsIdentity, conversationId, activityId, activity, cancellationToken).ConfigureAwait(false);
         }
+
+        /// <inheritdoc/>
+        protected override async Task<ChannelAccount> OnGetConversationMemberAsync(ClaimsIdentity claimsIdentity, string userId, string conversationId, CancellationToken cancellationToken = default)
+        {
+            return await _inner.OnGetMemberAsync(claimsIdentity, userId, conversationId, cancellationToken).ConfigureAwait(false);
+        }
     }
 }

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ChannelServiceController.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ChannelServiceController.cs
@@ -131,6 +131,19 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
         }
 
         /// <summary>
+        /// GetConversationMember.
+        /// </summary>
+        /// <param name="userId">User ID.</param>
+        /// <param name="conversationId">Conversation ID.</param>
+        /// <returns>The ChannelAccount of the conversation member.</returns>
+        [HttpGet("v3/conversations/{conversationId}/members/{userId}")]
+        public virtual async Task<IActionResult> GetConversationMemberAsync(string userId, string conversationId)
+        {
+            var result = await _handler.HandleGetConversationMemberAsync(HttpContext.Request.Headers["Authorization"], userId, conversationId).ConfigureAwait(false);
+            return new JsonResult(result, HttpHelper.BotMessageSerializerSettings);
+        }
+
+        /// <summary>
         /// GetConversationPagedMembers.
         /// </summary>
         /// <param name="conversationId">Conversation ID.</param>


### PR DESCRIPTION
Fixes # 6432
#minor

## Description
This PR fixes the error thrown when executing the **_TeamsInfo.GetMemberAsync_** from a skill bot implementing the method in the **_CloudSkillHandler_** class.

## Specific Changes
  - Added the _HandleGetConversationMemberAsync_ and _OnGetConversationMemberAsync_ methods in `ChannelServiceHandlerBase`.
  - Added the _OnGetConversationMemberAsync_ method in the `CloudSkillHandler` class.
  - Added the implementation of the _OnGetMemberAsync_ method in the `SkillHandlerImpl` class.
  - Added the _GetConversationMemberAsync_ method in the `ChannelServiceController` class.
  - Added unit test in `CloudSkillHandlerTests`.

## Testing
These images show the skill bot retrieving the member's information successfully and the new unit test passing.
![image](https://user-images.githubusercontent.com/44245136/184358972-505c9b98-d688-4fdc-aa52-3c302acb532e.png)
![image](https://user-images.githubusercontent.com/44245136/184358997-e12a2d83-4e71-47cd-9f99-c7bd83596779.png)