### PR TITLE
[#6433] Error in AdaptiveDialog.ContinueActionAsync with native dialog SDK

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BaseInvokeDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BaseInvokeDialog.cs
@@ -102,9 +102,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             if (dialog == null)
             {
                 var resourceExplorer = dc.Context.TurnState.Get<ResourceExplorer>();
-                if (resourceExplorer != null)
+                var resourceId = $"{dialogId}.dialog";
+                var foundResource = resourceExplorer?.TryGetResource(resourceId, out _) ?? false;
+                if (foundResource)
                 {
-                    dialog = resourceExplorer.LoadType<AdaptiveDialog>($"{dialogId}.dialog");
+                    dialog = resourceExplorer.LoadType<AdaptiveDialog>(resourceId);
                     dc.Dialogs.Add(dialog);
                 }
             }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
@@ -686,9 +686,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                     if (dialog == null)
                     {
                         var resourceExplorer = actionDC.Context.TurnState.Get<ResourceExplorer>();
-                        if (resourceExplorer != null)
+                        var resourceId = $"{actionDC.ActiveDialog.Id}.dialog";
+                        var foundResource = resourceExplorer?.TryGetResource(resourceId, out _) ?? false;
+                        if (foundResource)
                         {
-                            dialog = resourceExplorer.LoadType<AdaptiveDialog>($"{actionDC.ActiveDialog.Id}.dialog");
+                            dialog = resourceExplorer.LoadType<AdaptiveDialog>(resourceId);
                             actionDC.Dialogs.Add(dialog);
                         }
                     }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AdaptiveDialogTests/AdaptiveDialog_LoadDialogFromProperty.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AdaptiveDialogTests/AdaptiveDialog_LoadDialogFromProperty.test.dialog
@@ -5,13 +5,42 @@
         "$kind": "Microsoft.AdaptiveDialog",
         "id": "outer",
         "autoEndDialog": false,
+        "recognizer": {
+            "$kind": "Microsoft.RegexRecognizer",
+            "intents": [
+                {
+                    "intent": "TellJokeDialog",
+                    "pattern": "joke"
+                },
+                {
+                    "intent": "UnknownDialog",
+                    "pattern": "unknown"
+                }
+            ]
+        },
         "triggers": [
             {
-                "$kind": "Microsoft.OnBeginDialog",
+                "$kind": "Microsoft.OnIntent",
+                "intent": "TellJokeDialog",
                 "actions": [
                     {
                         "$kind": "Microsoft.SetProperty",
                         "value": "TellJokeDialog",
+                        "property": "turn.dialogToStart"
+                    },
+                    {
+                        "$kind": "Microsoft.BeginDialog",
+                        "dialog": "=turn.dialogToStart"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnIntent",
+                "intent": "UnknownDialog",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SetProperty",
+                        "value": "UnknownDialog",
                         "property": "turn.dialogToStart"
                     },
                     {
@@ -25,11 +54,19 @@
     "script": [
         {
             "$kind": "Microsoft.Test.UserSays",
-            "text": "hi"
+            "text": "joke"
         },
         {
             "$kind": "Microsoft.Test.AssertReply",
             "text": "Why did the chicken cross the road?"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "unknown"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Object reference not set to an instance of an object."
         }
     ]
 }


### PR DESCRIPTION
Fixes # 6433

## Description
This PR fixes an issue where the `ComponentDialog` cannot be found in the `Dialogs stack` and in the `ResourceExplorer` when using `AdaptiveDialogs`, adding a condition evaluating the resource existence before trying to load it into the dialogs stack.

## Specific Changes
- Adds a pre-condition before trying to load the dialog from the `ResourceExplorer` in `BaseInvokeDialog` and `AdaptiveDialog` classes.
- Added a unit test validating the new condition when using `ComponentDialogs` with `AdaptiveDialogs`.
- Updated the `AdaptiveDialog_LoadDialogFromProperty.test.dialog` unit test, validating the new condition.

## Testing
The following image shows the new unit tests passing.
![image](https://user-images.githubusercontent.com/62260472/185213265-af00ff83-b852-4715-86bd-d20ae307d626.png)