### PR TITLE
[#6430] Adaptive ForEachElement does not exit when child action CancelAllDialogs is called

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ForEachElement.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ForEachElement.cs
@@ -263,6 +263,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 
         private bool ShouldEndDialog(DialogTurnResult turnResult, out DialogTurnResult finalTurnResult)
         {
+            DialogTurnStatus[] endedDialog = { DialogTurnStatus.Complete, DialogTurnStatus.Cancelled };
             finalTurnResult = null;
 
             // Insure BreakLoop ends the dialog
@@ -279,12 +280,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             // the result will be nested.
             while (finalTurnResult.Result != null
                 && finalTurnResult.Result is DialogTurnResult dtr
-                && dtr.ParentEnded && dtr.Status == DialogTurnStatus.Complete)
+                && dtr.ParentEnded && endedDialog.Contains(dtr.Status))
             {
                 finalTurnResult = dtr;
             }
 
-            return finalTurnResult.ParentEnded && finalTurnResult.Status == DialogTurnStatus.Complete;
+            return finalTurnResult.ParentEnded && endedDialog.Contains(finalTurnResult.Status);
         }
 
         private void UpdateActionScopeState(DialogContext dc, DialogState state)

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
@@ -297,6 +297,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
         }
 
         [Fact]
+        public async Task Action_Foreach_Nested_WithCancel()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
+
+        [Fact]
         public async Task Action_Foreach_Object()
         {
             await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_Foreach_Nested_WithCancel.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_Foreach_Nested_WithCancel.test.dialog
@@ -1,0 +1,67 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "root",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnBeginDialog",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SetProperty",
+                        "property": "dialog.todo",
+                        "value": "=['1', '2', '3']"
+                    },
+                    {
+                        "$kind": "Microsoft.Foreach",
+                        "itemsProperty": "dialog.todo",
+                        "actions": [
+                            {
+                                "$kind": "Microsoft.SendActivity",
+                                "activity": "I'm the Parent loop - index is: ${dialog.foreach.index}"
+                            },
+                            {
+                                "$kind": "Microsoft.Foreach",
+                                "itemsProperty": "dialog.todo",
+                                "actions": [
+                                    {
+                                        "$kind": "Microsoft.SendActivity",
+                                        "activity": "I'm the child loop and I will cancel all dialogs"
+                                    },
+                                    {
+                                        "$kind": "Microsoft.CancelAllDialogs"
+                                    },
+                                    {
+                                        "$kind": "Microsoft.SendActivity",
+                                        "activity": "This shouldn't be sent"
+                                    }
+                                ]
+                            },
+                            {
+                                "$kind": "Microsoft.SendActivity",
+                                "activity": "This shouldn't be sent either"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "autoEndDialog": true,
+        "defaultResultProperty": "dialog.result"
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hi"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "I'm the Parent loop - index is: 0"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "I'm the child loop and I will cancel all dialogs"
+        }
+    ]
+}


### PR DESCRIPTION
Fixes # 6430
#minor

## Description
This PR fixes the issue in the `ForEachElement` action that wasn't exiting the loop after a call to the _CancelAllDialogs_ action.
The fix also considers the nested _ForEachElement_ loops scenario.

## Specific Changes
  - Updated the `ShouldEndDialog` method of the _ForEachElement_ class to consider also _Cancelled_ status as well as _Complete_ to end the dialogs.
  - Added a unit test in the `ActionTests` class to cover the nested ForEachElement's loops with a _CancelAllDialogs_ call scenario.
  - Added the `Action_Foreach_Nested_WithCancel.test.dialog` test script.
 
## Testing
These images show the issue fixed after the changes.
![image](https://user-images.githubusercontent.com/44245136/186512169-e59f5505-912c-4314-8943-5edacb4b5e22.png)
