### PR TITLE
[#6438] It's not possible to send binary data with the HttpSend activity

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/HttpRequest.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/HttpRequest.cs
@@ -297,16 +297,16 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                         {
                             if (instanceBody.GetType() == typeof(byte[]))
                             {
-                                using var postContent = new ByteArrayContent((byte[])instanceBody);
-                                request.Content = postContent;
+                                using var bodyContent = new ByteArrayContent((byte[])instanceBody);
+                                request.Content = bodyContent;
                                 traceInfo.request.content = JsonConvert.SerializeObject(instanceBody);
                                 traceInfo.request.headers = JObject.FromObject(request.Content.Headers.ToDictionary(t => t.Key, t => (object)t.Value?.FirstOrDefault()));
                                 response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
                             }
                             else
                             {
-                                using var postContent = new StringContent(instanceBody.ToString(), Encoding.UTF8, contentType);
-                                request.Content = postContent;
+                                using var bodyContent = new StringContent(instanceBody.ToString(), Encoding.UTF8, contentType);
+                                request.Content = bodyContent;
                                 traceInfo.request.content = instanceBody.ToString();
                                 traceInfo.request.headers = JObject.FromObject(request.Content.Headers.ToDictionary(t => t.Key, t => (object)t.Value?.FirstOrDefault()));
                                 response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/HttpRequest.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/HttpRequest.cs
@@ -282,42 +282,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                 traceInfo.request.url = instanceUrl;
 
                 HttpResponseMessage response = null;
-                string contentType = ContentType?.GetValue(dc.State) ?? "application/json";
+                var contentType = ContentType?.GetValue(dc.State) ?? "application/json";
 
                 switch (Method)
                 {
                     case HttpMethod.POST:
-                        if (instanceBody == null)
-                        {
-                            response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
-                        }
-                        else
-                        {
-                            using var postContent = new StringContent(instanceBody.ToString(), Encoding.UTF8, contentType);
-                            traceInfo.request.content = instanceBody.ToString();
-                            request.Content = postContent;
-                            traceInfo.request.headers = JObject.FromObject(request.Content.Headers.ToDictionary(t => t.Key, t => (object)t.Value?.FirstOrDefault()));
-                            response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
-                        }
-
-                        break;
-
                     case HttpMethod.PATCH:
-                        if (instanceBody == null)
-                        {
-                            response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
-                        }
-                        else
-                        {
-                            using var patchContent = new StringContent(instanceBody.ToString(), Encoding.UTF8, contentType);
-                            request.Content = patchContent;
-                            traceInfo.request.content = instanceBody.ToString();
-                            traceInfo.request.headers = JObject.FromObject(request.Content.Headers.ToDictionary(t => t.Key, t => (object)t.Value?.FirstOrDefault()));
-                            response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
-                        }
-
-                        break;
-
                     case HttpMethod.PUT:
                         if (instanceBody == null)
                         {
@@ -325,19 +295,27 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                         }
                         else
                         {
-                            using var putContent = new StringContent(instanceBody.ToString(), Encoding.UTF8, contentType);
-                            traceInfo.request.content = instanceBody.ToString();
-                            request.Content = putContent;
-                            traceInfo.request.headers = JObject.FromObject(request.Content.Headers.ToDictionary(t => t.Key, t => (object)t.Value?.FirstOrDefault()));
-                            response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                            if (instanceBody.GetType() == typeof(byte[]))
+                            {
+                                using var postContent = new ByteArrayContent((byte[])instanceBody);
+                                request.Content = postContent;
+                                traceInfo.request.content = JsonConvert.SerializeObject(instanceBody);
+                                traceInfo.request.headers = JObject.FromObject(request.Content.Headers.ToDictionary(t => t.Key, t => (object)t.Value?.FirstOrDefault()));
+                                response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                            }
+                            else
+                            {
+                                using var postContent = new StringContent(instanceBody.ToString(), Encoding.UTF8, contentType);
+                                request.Content = postContent;
+                                traceInfo.request.content = instanceBody.ToString();
+                                traceInfo.request.headers = JObject.FromObject(request.Content.Headers.ToDictionary(t => t.Key, t => (object)t.Value?.FirstOrDefault()));
+                                response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                            }
                         }
 
                         break;
 
                     case HttpMethod.DELETE:
-                        response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
-                        break;
-
                     case HttpMethod.GET:
                         response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
                         break;

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
@@ -585,6 +585,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                 .Respond("plain/text", "array");
 
             handler
+                .When(HttpMethod.Post, "http://foo.com/upload")
+                .Respond("plain/text", "data received");
+
+            handler
                 .When(HttpMethod.Put, "http://foo.com/")
                 .WithContent("Joe is 52")
                 .Respond("plain/text", "put:string");
@@ -705,6 +709,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                             new SendActivity("${turn.lastresult.content}"),
                             new HttpRequest()
                             {
+                                Url = "http://foo.com/upload",
+                                Method = HttpRequest.HttpMethod.POST,
+                                Body = "=base64ToBinary(base64('Hello'))"
+                            },
+                            new SendActivity("${turn.lastresult.content}"),
+                            new HttpRequest()
+                            {
                                 Url = "http://foo.com/",
                                 Method = HttpRequest.HttpMethod.PUT,
                                 ContentType = "plain/text",
@@ -790,6 +801,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                     .AssertReply("string")
                     .AssertReply("object")
                     .AssertReply("array")
+                    .AssertReply("data received")
                     .AssertReply("put:string")
                     .AssertReply("put:object")
                     .AssertReply("put:array")


### PR DESCRIPTION
Fixes # 6438
#minor

## Description
This PR updates the _**HttpRequest**_ class in _Dialogs.Adaptive_ to handle binary data in the request's body. 
Also, it updates the **_Action_HttpRequest_** test to cover this scenario.

## Specific Changes
  - Updated the **_BeginDialogAsync_** method in the _**HttpRequest**_ class to handle the case of binary data in the request's body using _ByteArrayContent_ to provide the HTTP content instead of _StringContent_.
  - Refactored the switch case to remove duplicated code.
  - Updated the **_Action_HttpRequest_** test in _Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests_ class adding a new _HttpRequest_ trigger to cover this scenario.

## Testing
These images show a request with binary data sent using the HttpRequest action before and after the changes.
![image](https://user-images.githubusercontent.com/44245136/188935007-e7a53fcd-fe85-444c-8482-0e821464d684.png)
