### PR TITLE
Fix CodeQL alert SM01507: Client-side URL redirect

### DIFF
--- a/build/AnalyzeDeps/InterdependencyGraph.html
+++ b/build/AnalyzeDeps/InterdependencyGraph.html
@@ -343,7 +343,9 @@
   const params = new URLSearchParams(window.location.search);
   const src = params.get("data") || "data.js";
   const script = document.createElement("script");
-  script.src = src;
+  const url = window.location.href.split('?')[0];
+  const path = url.substr(0, url.lastIndexOf('/'));
+  script.src = path.concat('/', src);
   script.async = false;
   script.addEventListener("load", () => renderGraph(data));
   script.addEventListener("error", e => {


### PR DESCRIPTION
#minor
Fixes #
6537
6521
6514
6500
6499
6498
6497
6496
6495
6494
6493
6492
6491
6490
6489
6488
6486

## Description
This PR fixes de CodeQL SM01507 alert related to open redirects by implementing a fixed domain for the script's _src_ param.

## Specific Changes
- Updated `build/AnalyzeDeps/InterdependencyGraph.html` to append the domain URL to the _data_ param.

## Testing
We tested the changes locally rendering the HTML with and without the _data_ query parameter.
![image](https://user-images.githubusercontent.com/44245136/199581129-93ea8a8e-1b21-464f-a8b8-a2ea56f1fc5a.png)
