### PR TITLE
[#6542] Applying BotMessageSerializerSettings.MaxDepth doesn't seem to work

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsStorage.cs
@@ -78,6 +78,7 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
             _jsonSerializer = jsonSerializer ?? JsonSerializer.Create(new JsonSerializerSettings
                                                 {
                                                     TypeNameHandling = TypeNameHandling.All,
+                                                    MaxDepth = null,
                                                 });
 
             // Triggers a check for the existence of the container
@@ -102,6 +103,7 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
             _jsonSerializer = jsonSerializer ?? JsonSerializer.Create(new JsonSerializerSettings
             {
                 TypeNameHandling = TypeNameHandling.All,
+                MaxDepth = null,
             });
 
             // Triggers a check for the existence of the container

--- a/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsTranscriptStore.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsTranscriptStore.cs
@@ -77,10 +77,11 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
             _storageTransferOptions = storageTransferOptions;
 
             _jsonSerializer = jsonSerializer ?? JsonSerializer.Create(new JsonSerializerSettings
-                                                {            
+                                                {
                                                     NullValueHandling = NullValueHandling.Ignore,
                                                     Formatting = Formatting.Indented,
                                                     TypeNameHandling = TypeNameHandling.None,
+                                                    MaxDepth = null,
                                                 });
 
             // Triggers a check for the existance of the container
@@ -115,6 +116,7 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
             _jsonSerializer = jsonSerializer ?? JsonSerializer.Create(new JsonSerializerSettings
             {
                 TypeNameHandling = TypeNameHandling.All,
+                MaxDepth = null,
             });
         }
 

--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Bot.Builder.Azure
         {
             // we use All so that we get typed roundtrip out of storage, but we don't use validation because we don't know what types are valid
             TypeNameHandling = TypeNameHandling.All,
+            MaxDepth = null,
         });
 
         // If a JsonSerializer is not provided during construction, this will be the default static JsonSerializer.

--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobTranscriptStore.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobTranscriptStore.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Bot.Builder.Azure
         {
             NullValueHandling = NullValueHandling.Ignore,
             Formatting = Formatting.Indented,
+            MaxDepth = null,
         });
 
         private static HashSet<string> _checkedContainers = new HashSet<string>();

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/TextEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/TextEntityRecognizer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
     /// </summary>
     public abstract class TextEntityRecognizer : EntityRecognizer
     {
-        private static JsonSerializer serializer = new JsonSerializer() { ContractResolver = new CamelCasePropertyNamesContractResolver() };
+        private static JsonSerializer serializer = new JsonSerializer() { ContractResolver = new CamelCasePropertyNamesContractResolver(), MaxDepth = null };
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TextEntityRecognizer"/> class.

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Protocol/ProtocolMessage.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Protocol/ProtocolMessage.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging.Protocol
         private static readonly JsonSerializer Serializer = new JsonSerializer
         {
             NullValueHandling = NullValueHandling.Include,
+            MaxDepth = null,
             ContractResolver = new CamelCasePropertyNamesContractResolver()
         };
 

--- a/libraries/Microsoft.Bot.Builder/MemoryStorage.cs
+++ b/libraries/Microsoft.Bot.Builder/MemoryStorage.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Bot.Builder
         {
             TypeNameHandling = TypeNameHandling.All,
             ReferenceLoopHandling = ReferenceLoopHandling.Error,
+            MaxDepth = null
         };
 
         // If a JsonSerializer is not provided during construction, this will be the default static JsonSerializer.

--- a/libraries/Microsoft.Bot.Connector/OAuthClient.cs
+++ b/libraries/Microsoft.Bot.Connector/OAuthClient.cs
@@ -723,7 +723,8 @@ namespace Microsoft.Bot.Connector
                 Converters = new List<JsonConverter>
                     {
                         new Iso8601TimeSpanConverter()
-                    }
+                    },
+                MaxDepth = null
             };
             DeserializationSettings = new JsonSerializerSettings
             {
@@ -735,7 +736,8 @@ namespace Microsoft.Bot.Connector
                 Converters = new List<JsonConverter>
                     {
                         new Iso8601TimeSpanConverter()
-                    }
+                    },
+                MaxDepth = null
             };
             CustomInitialize();
         }


### PR DESCRIPTION
Fixes # 6542
#minor

## Description
This PR sets the **_MaxDepth_** property as null in the _MemoryStorage_ class' JsonSerializer to avoid the "_The reader’s MaxDepth of 64 has been exceeded_" error.
It also sets the property in other classes, with a similar implementation, that were skipped in the original issue.

## Specific Changes
- Set **_MaxDepth_** property to null in the serializer used in the following classes:
- MemoryStorage
- BlobStorage
- BlobTranscriptStore
- AzureBlobStorage
- AzureBlobTranscriptStore
- TextEntityRecognizer
- ProtocolMessage
- OAuthClient

## Testing
Here we can see a bot with a dialogs loop failing in loop 10 and after the fix, working as expected in loop 11.
![image](https://user-images.githubusercontent.com/44245136/200914678-5ec4c853-4470-491e-b2d0-ea60669a8c89.png)
