### PR TITLE
Fix CodeQL alert SM03926: Security sensitive JsonWebTokenHandler validations are disabled

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Authentication/ChannelValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ChannelValidation.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 ValidIssuers = new[] { AuthenticationConstants.ToBotFromChannelTokenIssuer },
 
                 // Audience validation takes place in JwtTokenExtractor
-                ValidateAudience = false,
+                ValidateAudience = false, // lgtm[cs/web/missing-token-validation]
                 ValidateLifetime = true,
                 ClockSkew = TimeSpan.FromMinutes(5),
                 RequireSignedTokens = true,

--- a/libraries/Microsoft.Bot.Connector/Authentication/EmulatorValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/EmulatorValidation.cs
@@ -35,7 +35,9 @@ namespace Microsoft.Bot.Connector.Authentication
                     "https://login.microsoftonline.us/f8cdef31-a31e-4b4a-93e4-5f571e91255a/",           // Auth for US Gov, 1.0 token
                     "https://login.microsoftonline.us/f8cdef31-a31e-4b4a-93e4-5f571e91255a/v2.0",       // Auth for US Gov, 2.0 token
                 },
-                ValidateAudience = false,   // Audience validation takes place manually in code.
+
+                // Audience validation takes place manually in code.
+                ValidateAudience = false, // lgtm[cs/web/missing-token-validation]
                 ValidateLifetime = true,
                 ClockSkew = TimeSpan.FromMinutes(5),
                 RequireSignedTokens = true,

--- a/libraries/Microsoft.Bot.Connector/Authentication/EnterpriseChannelValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/EnterpriseChannelValidation.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 ValidIssuers = new[] { AuthenticationConstants.ToBotFromChannelTokenIssuer },
 
                 // Audience validation takes place in JwtTokenExtractor
-                ValidateAudience = false,
+                ValidateAudience = false, // lgtm[cs/web/missing-token-validation]
                 ValidateLifetime = true,
                 ClockSkew = TimeSpan.FromMinutes(5),
                 RequireSignedTokens = true,

--- a/libraries/Microsoft.Bot.Connector/Authentication/GovernmentChannelValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/GovernmentChannelValidation.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 ValidIssuers = new[] { GovernmentAuthenticationConstants.ToBotFromChannelTokenIssuer },
 
                 // Audience validation takes place in JwtTokenExtractor
-                ValidateAudience = false,
+                ValidateAudience = false, // lgtm[cs/web/missing-token-validation]
                 ValidateLifetime = true,
                 ClockSkew = TimeSpan.FromMinutes(5),
                 RequireSignedTokens = true,

--- a/libraries/Microsoft.Bot.Connector/Authentication/ParameterizedBotFrameworkAuthentication.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ParameterizedBotFrameworkAuthentication.cs
@@ -204,7 +204,9 @@ namespace Microsoft.Bot.Connector.Authentication
                     "https://sts.windows.net/cab8a31a-1906-4287-a0d8-4eef66b95f6e/", // Auth for US Gov, 1.0 token
                     "https://login.microsoftonline.us/cab8a31a-1906-4287-a0d8-4eef66b95f6e/v2.0" // Auth for US Gov, 2.0 token
                     },
-                    ValidateAudience = false, // Audience validation takes place manually in code.
+
+                    // Audience validation takes place manually in code.
+                    ValidateAudience = true, // lgtm[cs/web/missing-token-validation]
                     ValidateLifetime = true,
                     ClockSkew = TimeSpan.FromMinutes(5),
                     RequireSignedTokens = true
@@ -406,7 +408,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 ValidIssuers = new[] { _toBotFromChannelTokenIssuer },
 
                 // Audience validation takes place in JwtTokenExtractor
-                ValidateAudience = false,
+                ValidateAudience = false, // lgtm[cs/web/missing-token-validation]
                 ValidateLifetime = true,
                 ClockSkew = TimeSpan.FromMinutes(5),
                 RequireSignedTokens = true,

--- a/libraries/Microsoft.Bot.Connector/Authentication/SkillValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/SkillValidation.cs
@@ -135,7 +135,9 @@ namespace Microsoft.Bot.Connector.Authentication
                     "https://login.microsoftonline.us/f8cdef31-a31e-4b4a-93e4-5f571e91255a/", // Auth for US Gov, 1.0 token
                     "https://login.microsoftonline.us/f8cdef31-a31e-4b4a-93e4-5f571e91255a/v2.0", // Auth for US Gov, 2.0 token
                 },
-                ValidateAudience = false, // Audience validation takes place manually in code.
+
+                // Audience validation takes place manually in code.
+                ValidateAudience = false, // lgtm[cs/web/missing-token-validation]
                 ValidateLifetime = true,
                 ClockSkew = TimeSpan.FromMinutes(5),
                 RequireSignedTokens = true


### PR DESCRIPTION
#minor
Fixes #
6513
6507
6505
6504
6503
6502
6501

## Description
This PR suppresses the CodeQL SM03926 alerts related to disabled **_ValidateAudience_** properties in **_TokenValidationParameters_** class.
The alert can't be fixed because the validations take place manually in the code.

## Specific Changes
- Added comment to suppress SM03926 alerts in the following classes:
   - ChannelValidation
   - EmulatorValidation
   - EnterpriseChannelValidation
   - GovernmentChannelValidation
   - ParameterizedBotFrameworkAuthentication
   - SkillValidation

## Testing
The unit tests passed after the changes.
![image](https://user-images.githubusercontent.com/44245136/201423032-69df39df-7834-4dd0-8d58-762be2ce75bf.png)
