### PR TITLE
[#6563] Expired JWT token exception not being handled

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenExtractor.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenExtractor.cs
@@ -297,6 +297,11 @@ namespace Microsoft.Bot.Connector.Authentication
 
                 return principal;
             }
+            catch (SecurityTokenExpiredException err)
+            {
+                Trace.TraceError(err.Message);
+                throw new UnauthorizedAccessException($"The token has expired");
+            }
             catch (SecurityTokenSignatureKeyNotFoundException)
             {
                 var keys = string.Join(", ", (config?.SigningKeys ?? Enumerable.Empty<SecurityKey>()).Select(t => t.KeyId));


### PR DESCRIPTION
Fixes # 6563
#minor

## Description
This PR catches the SecurityTokenExpiredException when a JWT token is expired.

## Specific Changes
- Added catch block on the ValidateTokenAsync method of the JwtTokenExtractor class.
- Added unit test for the JwtTokenExtractor class.
- Added unit test for the CloudAdapter class.

## Testing
These images show the new unit tests passing.
![image](https://user-images.githubusercontent.com/64815358/207942149-a04db60d-246f-4feb-819c-c591e13d4ea0.png)
