### PR TITLE
Fix cast issue in SendHandoffActivity action

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SendHandoffActivity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SendHandoffActivity.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var handoffContext = HandoffContext?.GetValue(dc.State);
-            var context = (JObject)handoffContext;
+            var context = JObject.FromObject(handoffContext);
             var contextResult = ((ValueExpression)context).EvaluateExpression(dc.State);
             var transcript = Transcript?.GetValue(dc.State);
             var eventActivity = EventFactory.CreateHandoffInitiation(dc.Context, contextResult, transcript);


### PR DESCRIPTION
#minor

## Description
This PR fixes the casting error found in the [Telephony unit tests](https://github.com/microsoft/botframework-components/blob/main/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/CallTransferTests.cs) when the _handoff context_ is an object.

## Specific Changes
- Updated _BeginDialogAsync_ method in _SendHandoffActivity_ class replacing the _JObject_ cast with the _JObject.FromObject_ parse method.

## Testing
These images show the _Telephony_ tests working after the fix and the _Dialogs.Adaptive_ tests passing:
![image](https://user-images.githubusercontent.com/44245136/212379997-633adfd6-fcdb-47dc-b270-04027f020e40.png)
![image](https://user-images.githubusercontent.com/44245136/212380118-0b21f787-4a94-42ab-b56e-be26379fddfd.png)
