### PR TITLE
[#6582, #6584] Incorrect serialization of state when using Blob or CosmosDB storage in v4.19.x

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsStorage.cs
@@ -33,7 +33,6 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
         private static readonly AllowedTypesSerializationBinder _allowedTypesBinder = new AllowedTypesSerializationBinder(
             new List<Type>
             {
-                typeof(IStoreItem),
                 typeof(Dictionary<string, object>)
             });
 
@@ -232,7 +231,7 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
                     var json = JToken.FromObject(newValue, _jsonSerializer);
                     if (json.Type == JTokenType.Object || json.Type == JTokenType.Array)
                     {
-                        (_jsonSerializer.SerializationBinder as AllowedTypesSerializationBinder)?.CleanupTypes((JContainer)json);
+                        (_jsonSerializer.SerializationBinder as AllowedTypesSerializationBinder)?.Verify();
                         await json.WriteToAsync(jsonWriter).ConfigureAwait(false);
                     }
                     else
@@ -278,6 +277,7 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
                         using (var jsonReader = new JsonTextReader(new StreamReader(download.Content)) { MaxDepth = null })
                         {
                             var obj = _jsonSerializer.Deserialize(jsonReader);
+                            (_jsonSerializer.SerializationBinder as AllowedTypesSerializationBinder)?.Verify();
 
                             if (obj is IStoreItem storeItem)
                             {

--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
@@ -38,7 +38,6 @@ namespace Microsoft.Bot.Builder.Azure
             SerializationBinder = new AllowedTypesSerializationBinder(
                 new List<Type>
                 {
-                    typeof(IStoreItem),
                     typeof(Dictionary<string, object>)
                 }),
             MaxDepth = null,
@@ -229,7 +228,7 @@ namespace Microsoft.Bot.Builder.Azure
                         var json = JToken.FromObject(newValue, _jsonSerializer);
                         if (json.Type == JTokenType.Object || json.Type == JTokenType.Array)
                         {
-                            (_jsonSerializer.SerializationBinder as AllowedTypesSerializationBinder)?.CleanupTypes((JContainer)json);
+                            (_jsonSerializer.SerializationBinder as AllowedTypesSerializationBinder)?.Verify();
                             await json.WriteToAsync(jsonWriter).ConfigureAwait(false);
                         }
                         else
@@ -280,6 +279,7 @@ namespace Microsoft.Bot.Builder.Azure
                     using (var jsonReader = new JsonTextReader(new StreamReader(blobStream)) { MaxDepth = null })
                     {
                         var obj = _jsonSerializer.Deserialize(jsonReader);
+                        (_jsonSerializer.SerializationBinder as AllowedTypesSerializationBinder)?.Verify();
 
                         if (obj is IStoreItem storeItem)
                         {

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
@@ -28,7 +28,6 @@ namespace Microsoft.Bot.Builder.Azure
             SerializationBinder = new AllowedTypesSerializationBinder(
                 new List<Type>
                 {
-                    typeof(IStoreItem),
                     typeof(Dictionary<string, object>)
                 }),
             MaxDepth = null
@@ -172,6 +171,7 @@ namespace Microsoft.Bot.Builder.Azure
 
                     var documentStoreItem = readItemResponse.Resource;
                     var item = documentStoreItem.Document.ToObject(typeof(object), _jsonSerializer);
+                    (_jsonSerializer.SerializationBinder as AllowedTypesSerializationBinder)?.Verify();
 
                     if (item is IStoreItem storeItem)
                     {
@@ -227,7 +227,7 @@ namespace Microsoft.Bot.Builder.Azure
             foreach (var change in changes)
             {
                 var json = JObject.FromObject(change.Value, _jsonSerializer);
-                (_jsonSerializer.SerializationBinder as AllowedTypesSerializationBinder)?.CleanupTypes(json);
+                (_jsonSerializer.SerializationBinder as AllowedTypesSerializationBinder)?.Verify();
 
                 // Remove etag from JSON object that was copied from IStoreItem.
                 // The ETag information is updated as an _etag attribute in the document metadata.

--- a/libraries/Microsoft.Bot.Builder/AllowedTypesSerializationBinder.cs
+++ b/libraries/Microsoft.Bot.Builder/AllowedTypesSerializationBinder.cs
@@ -16,8 +16,8 @@ namespace Microsoft.Bot.Builder
     /// capable of allowing only desired <see cref="Type"/>s to be serialized and deserialized.
     /// </summary>
     /// <remarks>
-    /// Internally loads types dynamically, allowing all the exported types from BotBuilder and 
-    /// the project who is using it to be taken into account in the verification process.
+    /// Dynamically loads types allowing all the exported types from BotBuilder and 
+    /// the project that is using it, to be considered in the verification process.
     /// </remarks>
     public class AllowedTypesSerializationBinder : DefaultSerializationBinder
     {


### PR DESCRIPTION
Fixes # 6582
Fixes # 6584

## Description
This PR refactors the `AllowedTypesSerializationBinder` class to allow custom types to be loaded dynamically, this includes types from BotBuilder and the project who is using it (e.g. a bot sample).
Also, the process verifies the serialized and deserialized types are allowed or valid, otherwise it will fail with the following message sample:
![image](https://user-images.githubusercontent.com/62260472/201351262-2b76cae3-9b0b-4462-a772-9dde452731c9.png)

## Specific Changes
- Adds the `LoadTypes` method to dynamically load types from external projects (e.g. a bot sample), internal libraries (BotBuilder, with its nested related types).
- Adds `Verify` method, that validates after serializing and deserializing an object, it has all valid or allowed types, otherwise it will fail.
- Removed `CleanupTypes` method, since all types are now saved equally into the Storage, and validated when read or write.
- Removed, updated and added new unit tests to validate the new implementation.

## Testing
The following image shows the changes working with Blobs Storage and CosmosDB.
![image](https://user-images.githubusercontent.com/62260472/216446073-5ced5d3c-94be-4917-acf8-da40936a089c.png)