### PR TITLE
[#6590] Error while saving bot state to azure blob storage

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsTranscriptStore.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsTranscriptStore.cs
@@ -114,6 +114,7 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
 
             _jsonSerializer = jsonSerializer ?? JsonSerializer.Create(new JsonSerializerSettings
             {
+                TypeNameHandling = TypeNameHandling.All, // lgtm [cs/unsafe-type-name-handling]
                 MaxDepth = null,
             });
         }

--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
@@ -14,7 +14,6 @@ using Microsoft.WindowsAzure.Storage.Blob.Protocol;
 using Microsoft.WindowsAzure.Storage.Core;
 using Microsoft.WindowsAzure.Storage.RetryPolicies;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder.Azure
 {
@@ -34,12 +33,8 @@ namespace Microsoft.Bot.Builder.Azure
     {
         private static readonly JsonSerializer JsonSerializer = JsonSerializer.Create(new JsonSerializerSettings
         {
-            TypeNameHandling = TypeNameHandling.Objects, // lgtm [cs/unsafe-type-name-handling]
-            SerializationBinder = new AllowedTypesSerializationBinder(
-                new List<Type>
-                {
-                    typeof(Dictionary<string, object>)
-                }),
+            // we use All so that we get typed roundtrip out of storage, but we don't use validation because we don't know what types are valid
+            TypeNameHandling = TypeNameHandling.All, // lgtm [cs/unsafe-type-name-handling]
             MaxDepth = null,
         });
 
@@ -59,7 +54,6 @@ namespace Microsoft.Bot.Builder.Azure
         /// <para>jsonSerializer.TypeNameHandling = TypeNameHandling.All.</para>
         /// <para>jsonSerializer.NullValueHandling = NullValueHandling.Include.</para>
         /// <para>jsonSerializer.ContractResolver = new DefaultContractResolver().</para>
-        /// <para>jsonSerializer.SerializationBinder = new AllowedTypesSerializationBinder().</para>
         /// </param>
         public AzureBlobStorage(CloudStorageAccount storageAccount, string containerName, JsonSerializer jsonSerializer)
         {
@@ -100,14 +94,8 @@ namespace Microsoft.Bot.Builder.Azure
         /// <param name="storageAccount">Azure CloudStorageAccount instance.</param>
         /// <param name="containerName">Name of the Blob container where entities will be stored.</param>
         /// <param name="blobClient">Custom implementation of CloudBlobClient.</param>
-        /// <param name="jsonSerializer">If passing in a custom JsonSerializer, we recommend the following settings:
-        /// <para>jsonSerializer.TypeNameHandling = TypeNameHandling.All.</para>
-        /// <para>jsonSerializer.NullValueHandling = NullValueHandling.Include.</para>
-        /// <para>jsonSerializer.ContractResolver = new DefaultContractResolver().</para>
-        /// <para>jsonSerializer.SerializationBinder = new AllowedTypesSerializationBinder().</para>
-        /// </param>
-        internal AzureBlobStorage(CloudStorageAccount storageAccount, string containerName, CloudBlobClient blobClient, JsonSerializer jsonSerializer = default)
-            : this(storageAccount, containerName, jsonSerializer ?? JsonSerializer)
+        internal AzureBlobStorage(CloudStorageAccount storageAccount, string containerName, CloudBlobClient blobClient)
+            : this(storageAccount, containerName, JsonSerializer)
         {
             _blobClient = blobClient;
         }
@@ -223,18 +211,8 @@ namespace Microsoft.Bot.Builder.Azure
                 {
                     using (var memoryStream = new MultiBufferMemoryStream(blobReference.ServiceClient.BufferManager))
                     using (var streamWriter = new StreamWriter(memoryStream))
-                    using (var jsonWriter = new JsonTextWriter(streamWriter))
                     {
-                        var json = JToken.FromObject(newValue, _jsonSerializer);
-                        if (json.Type == JTokenType.Object || json.Type == JTokenType.Array)
-                        {
-                            (_jsonSerializer.SerializationBinder as AllowedTypesSerializationBinder)?.Verify();
-                            await json.WriteToAsync(jsonWriter).ConfigureAwait(false);
-                        }
-                        else
-                        {
-                            _jsonSerializer.Serialize(streamWriter, newValue);
-                        }
+                        _jsonSerializer.Serialize(streamWriter, newValue);
 
                         await streamWriter.FlushAsync().ConfigureAwait(false);
 
@@ -279,7 +257,6 @@ namespace Microsoft.Bot.Builder.Azure
                     using (var jsonReader = new JsonTextReader(new StreamReader(blobStream)) { MaxDepth = null })
                     {
                         var obj = _jsonSerializer.Deserialize(jsonReader);
-                        (_jsonSerializer.SerializationBinder as AllowedTypesSerializationBinder)?.Verify();
 
                         if (obj is IStoreItem storeItem)
                         {

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
@@ -24,12 +24,7 @@ namespace Microsoft.Bot.Builder.Azure
 
         private readonly JsonSerializer _jsonSerializer = JsonSerializer.Create(new JsonSerializerSettings
         {
-            TypeNameHandling = TypeNameHandling.Objects, // lgtm [cs/unsafe-type-name-handling]
-            SerializationBinder = new AllowedTypesSerializationBinder(
-                new List<Type>
-                {
-                    typeof(Dictionary<string, object>)
-                }),
+            TypeNameHandling = TypeNameHandling.All, // lgtm [cs/unsafe-type-name-handling]
             MaxDepth = null
         });
 
@@ -171,7 +166,10 @@ namespace Microsoft.Bot.Builder.Azure
 
                     var documentStoreItem = readItemResponse.Resource;
                     var item = documentStoreItem.Document.ToObject(typeof(object), _jsonSerializer);
-                    (_jsonSerializer.SerializationBinder as AllowedTypesSerializationBinder)?.Verify();
+                    if (_jsonSerializer.SerializationBinder is AllowedTypesSerializationBinder allowedTypesBinder)
+                    {
+                        allowedTypesBinder.Verify();
+                    }
 
                     if (item is IStoreItem storeItem)
                     {
@@ -227,7 +225,10 @@ namespace Microsoft.Bot.Builder.Azure
             foreach (var change in changes)
             {
                 var json = JObject.FromObject(change.Value, _jsonSerializer);
-                (_jsonSerializer.SerializationBinder as AllowedTypesSerializationBinder)?.Verify();
+                if (_jsonSerializer.SerializationBinder is AllowedTypesSerializationBinder allowedTypesBinder)
+                {
+                    allowedTypesBinder.Verify();
+                }
 
                 // Remove etag from JSON object that was copied from IStoreItem.
                 // The ETag information is updated as an _etag attribute in the document metadata.

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobStorageTests.cs
@@ -257,20 +257,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 
             _mockAccount = new Mock<CloudStorageAccount>(new StorageCredentials("accountName", "S2V5VmFsdWU=", "key"), false);
 
-            var jsonSerializer = new JsonSerializer
-            {
-                TypeNameHandling = TypeNameHandling.Objects, // lgtm [cs/unsafe-type-name-handling]
-                MaxDepth = null,
-                SerializationBinder = new AllowedTypesSerializationBinder(
-                    new List<Type>
-                    {
-                        typeof(IStoreItem),
-                        typeof(Dictionary<string, object>),
-                        typeof(Activity)
-                    }),
-            };
-
-            _blobStorage = new AzureBlobStorage(_mockAccount.Object, ContainerName, _mockBlobClient.Object, jsonSerializer);
+            _blobStorage = new AzureBlobStorage(_mockAccount.Object, ContainerName, _mockBlobClient.Object);
         }
         
         private class StoreItem : IStoreItem

--- a/tests/Microsoft.Bot.Builder.Tests/AllowedTypesSerializationBinderTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/AllowedTypesSerializationBinderTests.cs
@@ -15,15 +15,15 @@ namespace Microsoft.Bot.Builder.Tests
         {
             // Empty AllowedTypes.
             Assert.NotNull(new AllowedTypesSerializationBinder().AllowedTypes);
-            Assert.NotEmpty(new AllowedTypesSerializationBinder().AllowedTypes);
+            Assert.Empty(new AllowedTypesSerializationBinder().AllowedTypes);
 
             // Null AllowedTypes.
             Assert.NotNull(new AllowedTypesSerializationBinder(null).AllowedTypes);
-            Assert.NotEmpty(new AllowedTypesSerializationBinder(null).AllowedTypes);
+            Assert.Empty(new AllowedTypesSerializationBinder(null).AllowedTypes);
 
             // With AllowedTypes.
             Assert.NotNull(new AllowedTypesSerializationBinder(new List<Type> { typeof(ExampleType) }).AllowedTypes);
-            Assert.NotEmpty(new AllowedTypesSerializationBinder(new List<Type> { typeof(ExampleType) }).AllowedTypes);
+            Assert.Single(new AllowedTypesSerializationBinder(new List<Type> { typeof(ExampleType) }).AllowedTypes);
         }
 
         [Fact]
@@ -60,19 +60,6 @@ namespace Microsoft.Bot.Builder.Tests
         }
 
         [Fact]
-        public void BindToNameWithImplicitAllowedType()
-        {
-            // Should dynamically load BotBuilder's Activity type.
-            var expectedType = typeof(Activity);
-            var binder = new AllowedTypesSerializationBinder();
-            binder.BindToName(expectedType, out var assemblyName, out var typeName);
-
-            Assert.Null(assemblyName);
-            Assert.Equal(expectedType.AssemblyQualifiedName, typeName);
-            binder.Verify();
-        }
-
-        [Fact]
         public void BindToNameWithNestedType()
         {
             var expectedType = typeof(ExampleType);
@@ -104,18 +91,6 @@ namespace Microsoft.Bot.Builder.Tests
             var resultType = binder.BindToType(expectedType.Assembly.GetName().Name, expectedType.FullName);
 
             Assert.Equal(expectedType, resultType);
-        }
-
-        [Fact]
-        public void BindToTypeWithImplicitAllowedType()
-        {
-            // Should dynamically load BotBuilder's Activity type.
-            var expectedType = typeof(Activity);
-            var binder = new AllowedTypesSerializationBinder();
-            var resultType = binder.BindToType(expectedType.Assembly.GetName().Name, expectedType.FullName);
-
-            Assert.Equal(expectedType, resultType);
-            binder.Verify();
         }
 
         [Fact]


### PR DESCRIPTION
Fixes # 6590
#minor

## Description
This PR refactors the use of `AllowedTypesSerializationBinder` to be optionally provided through a `JsonSerializer` configuration across Blobs and CosmosDB storage constructors.

Behavior of `AllowedTypesSerializationBinder`:
- It will only be used in the Blobs and CosmosDB storage when provided through the `JsonSerializer.SerializationBinder`, otherwise it will not execute any related code to the class.
- When provided, it will evaluate which types need to be allowed and fail with a message to do so.
- When provided with all the types to allow, it will behave as normal, but with an extra layer of security to allow only desired types in the application.

## Specific Changes
  - Removed all code that was making _Blobs_, _AzureBlobs_ (removed altogether, since it's deprecated) and _CosmosDB_ storage dependent of the `AllowedTypesSerializationBinder` class, leaving only the verification process when the class is provided.
  - Updated the `AllowedTypesSerializationBinder` internal class behavior, removing the process that loads the types dynamically to use only the ones provided by the user, and added a step to recognize types that are represented as a generic type (e.g. _List<T>_).
  - Updated the tests related to this process by removing the ones that weren't necessary anymore, and adding new ones to test when the `AllowedTypesSerializationBinder` is provided through the `JsonSerializer` instance.

## Testing
The following images show the unit tests passing successfully and how the new binder implementation works.
![image](https://user-images.githubusercontent.com/62260472/221284738-c4a62398-dcf5-4c47-a6be-56e92de94da2.png)
![image](https://user-images.githubusercontent.com/62260472/221284747-db111038-5108-4b36-8452-b8ff9fb8ac62.png)