### PR TITLE
[#6589] Default to MSAL and eliminate ADAL without breaking changes

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Authentication/AppCredentials.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AppCredentials.cs
@@ -217,6 +217,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// Builds the lazy <see cref="AdalAuthenticator" /> to be used for token acquisition.
         /// </summary>
         /// <returns>A lazy <see cref="AdalAuthenticator"/>.</returns>
+        [Obsolete("This method is deprecated. Use BuildIAuthenticator instead.", false)]
         protected abstract Lazy<AdalAuthenticator> BuildAuthenticator();
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Connector/Authentication/ConstantHttpClientFactory.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ConstantHttpClientFactory.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Net.Http;
+using Microsoft.Identity.Client;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
 
 namespace Microsoft.Bot.Connector.Authentication
@@ -10,7 +11,7 @@ namespace Microsoft.Bot.Connector.Authentication
     /// <summary>
     /// HttpClientFactory that always returns the same HttpClient instance for ADAL AcquireTokenAsync calls.
     /// </summary>
-    internal class ConstantHttpClientFactory : Microsoft.IdentityModel.Clients.ActiveDirectory.IHttpClientFactory
+    internal class ConstantHttpClientFactory : Microsoft.IdentityModel.Clients.ActiveDirectory.IHttpClientFactory, IMsalHttpClientFactory
     {
         private readonly HttpClient httpClient;
 

--- a/libraries/Microsoft.Bot.Connector/Authentication/ConstantHttpClientFactory.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ConstantHttpClientFactory.cs
@@ -4,14 +4,13 @@
 using System;
 using System.Net.Http;
 using Microsoft.Identity.Client;
-using Microsoft.IdentityModel.Clients.ActiveDirectory;
 
 namespace Microsoft.Bot.Connector.Authentication
 {
     /// <summary>
     /// HttpClientFactory that always returns the same HttpClient instance for ADAL AcquireTokenAsync calls.
     /// </summary>
-    internal class ConstantHttpClientFactory : Microsoft.IdentityModel.Clients.ActiveDirectory.IHttpClientFactory, IMsalHttpClientFactory
+    internal class ConstantHttpClientFactory : IdentityModel.Clients.ActiveDirectory.IHttpClientFactory, IMsalHttpClientFactory
     {
         private readonly HttpClient httpClient;
 

--- a/libraries/Microsoft.Bot.Connector/Authentication/IJwtTokenProviderFactory.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/IJwtTokenProviderFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Net.Http;
 using Microsoft.Azure.Services.AppAuthentication;
 
@@ -9,6 +10,7 @@ namespace Microsoft.Bot.Connector.Authentication
     /// <summary>
     /// A factory that can create OAuth token providers for generating JWT auth tokens.
     /// </summary>
+    [Obsolete("This class is deprecated.", false)]
     public interface IJwtTokenProviderFactory
     {
         /// <summary>

--- a/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenProviderFactory.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenProviderFactory.cs
@@ -8,6 +8,7 @@ using Microsoft.Azure.Services.AppAuthentication;
 namespace Microsoft.Bot.Connector.Authentication
 {
     /// <inheritdoc />
+    [Obsolete("This class is deprecated.", false)]
     public class JwtTokenProviderFactory : IJwtTokenProviderFactory
     {
         /// <inheritdoc />

--- a/libraries/Microsoft.Bot.Connector/Authentication/ManagedIdentityAppCredentials.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ManagedIdentityAppCredentials.cs
@@ -13,8 +13,6 @@ namespace Microsoft.Bot.Connector.Authentication
     /// </summary>
     public class ManagedIdentityAppCredentials : AppCredentials
     {
-        private readonly IJwtTokenProviderFactory _tokenProviderFactory;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ManagedIdentityAppCredentials"/> class.
         /// Managed Identity for AAD credentials auth and caching.
@@ -24,7 +22,21 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="tokenProviderFactory">The JWT token provider factory to use.</param>
         /// <param name="customHttpClient">Optional <see cref="HttpClient"/> to be used when acquiring tokens.</param>
         /// <param name="logger">Optional <see cref="ILogger"/> to gather telemetry data while acquiring and managing credentials.</param>
+        [Obsolete("This method is deprecated, the IJwtTokenProviderFactory argument is now redundant. Use the overload without this argument.", false)]
         public ManagedIdentityAppCredentials(string appId, string oAuthScope, IJwtTokenProviderFactory tokenProviderFactory, HttpClient customHttpClient = null, ILogger logger = null)
+            : this(appId, oAuthScope, customHttpClient, logger)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ManagedIdentityAppCredentials"/> class.
+        /// Managed Identity for AAD credentials auth and caching.
+        /// </summary>
+        /// <param name="appId">Client ID for the managed identity assigned to the bot.</param>
+        /// <param name="oAuthScope">The scope for the token.</param>
+        /// <param name="customHttpClient">Optional <see cref="HttpClient"/> to be used when acquiring tokens.</param>
+        /// <param name="logger">Optional <see cref="ILogger"/> to gather telemetry data while acquiring and managing credentials.</param>
+        public ManagedIdentityAppCredentials(string appId, string oAuthScope, HttpClient customHttpClient = null, ILogger logger = null)
             : base(channelAuthTenant: null, customHttpClient, logger, oAuthScope)
         {
             if (string.IsNullOrWhiteSpace(appId))
@@ -32,12 +44,11 @@ namespace Microsoft.Bot.Connector.Authentication
                 throw new ArgumentNullException(nameof(appId));
             }
 
-            _tokenProviderFactory = tokenProviderFactory ?? throw new ArgumentNullException(nameof(tokenProviderFactory));
-
             MicrosoftAppId = appId;
         }
 
         /// <inheritdoc/>
+        [Obsolete("This method is deprecated. Use BuildIAuthenticator instead.", false)]
         protected override Lazy<AdalAuthenticator> BuildAuthenticator()
         {
             // Should not be called, legacy
@@ -48,7 +59,7 @@ namespace Microsoft.Bot.Connector.Authentication
         protected override Lazy<IAuthenticator> BuildIAuthenticator()
         {
             return new Lazy<IAuthenticator>(
-                () => new ManagedIdentityAuthenticator(MicrosoftAppId, OAuthScope, _tokenProviderFactory, CustomHttpClient, Logger),
+                () => new ManagedIdentityAuthenticator(MicrosoftAppId, OAuthScope, CustomHttpClient, Logger),
                 LazyThreadSafetyMode.ExecutionAndPublication);
         }
     }

--- a/libraries/Microsoft.Bot.Connector/Authentication/ManagedIdentityServiceClientCredentialsFactory.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ManagedIdentityServiceClientCredentialsFactory.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Bot.Connector.Authentication
     public class ManagedIdentityServiceClientCredentialsFactory : ServiceClientCredentialsFactory
     {
         private readonly string _appId;
-        private readonly IJwtTokenProviderFactory _tokenProviderFactory;
         private readonly HttpClient _httpClient;
         private readonly ILogger _logger;
 
@@ -27,7 +26,19 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="tokenProviderFactory">The JWT token provider factory to use.</param>
         /// <param name="httpClient">A custom httpClient to use.</param>
         /// <param name="logger">A logger instance to use.</param>
+        [Obsolete("This method is deprecated, the IJwtTokenProviderFactory argument is now redundant. Use the overload without this argument.", false)]
         public ManagedIdentityServiceClientCredentialsFactory(string appId, IJwtTokenProviderFactory tokenProviderFactory, HttpClient httpClient = null, ILogger logger = null)
+            : this(appId, httpClient, logger)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ManagedIdentityServiceClientCredentialsFactory"/> class.
+        /// </summary>
+        /// <param name="appId">Client ID for the managed identity assigned to the bot.</param>
+        /// <param name="httpClient">A custom httpClient to use.</param>
+        /// <param name="logger">A logger instance to use.</param>
+        public ManagedIdentityServiceClientCredentialsFactory(string appId, HttpClient httpClient = null, ILogger logger = null)
         {
             if (string.IsNullOrWhiteSpace(appId))
             {
@@ -35,7 +46,6 @@ namespace Microsoft.Bot.Connector.Authentication
             }
 
             _appId = appId;
-            _tokenProviderFactory = tokenProviderFactory ?? throw new ArgumentNullException(nameof(tokenProviderFactory));
             _httpClient = httpClient;
             _logger = logger;
         }
@@ -63,7 +73,7 @@ namespace Microsoft.Bot.Connector.Authentication
             }
 
             return Task.FromResult<ServiceClientCredentials>(
-                new ManagedIdentityAppCredentials(_appId, audience, _tokenProviderFactory, _httpClient, _logger));
+                new ManagedIdentityAppCredentials(_appId, audience, _httpClient, _logger));
         }
     }
 }

--- a/libraries/Microsoft.Bot.Connector/Authentication/MsalAppCredentials.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/MsalAppCredentials.cs
@@ -113,6 +113,7 @@ namespace Microsoft.Bot.Connector.Authentication
         }
 
         /// <inheritdoc/>
+        [Obsolete("This method is deprecated. Use BuildIAuthenticator instead.", false)]
         protected override Lazy<AdalAuthenticator> BuildAuthenticator()
         {
             throw new NotImplementedException();

--- a/libraries/Microsoft.Bot.Connector/Microsoft.Bot.Connector.csproj
+++ b/libraries/Microsoft.Bot.Connector/Microsoft.Bot.Connector.csproj
@@ -29,8 +29,7 @@
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.37.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.4" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.50.0" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.6.0" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ConfigurationServiceClientCredentialFactory.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ConfigurationServiceClientCredentialFactory.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                         throw new ArgumentException($"{MicrosoftAppCredentials.MicrosoftAppPasswordKey} must not be set for MSI in configuration.");
                     }
 
-                    _inner = new ManagedIdentityServiceClientCredentialsFactory(appId, new JwtTokenProviderFactory(), httpClient, logger);
+                    _inner = new ManagedIdentityServiceClientCredentialsFactory(appId, httpClient, logger);
                     break;
 
                 case MicrosoftAppType.SingleTenant:

--- a/tests/Microsoft.Bot.Builder.Tests/MockAppCredentials.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/MockAppCredentials.cs
@@ -14,7 +14,8 @@ namespace Microsoft.Bot.Builder.Tests
             : base(channelAuthTenant, customHttpClient, logger)
         {
         }
-
+        
+        [Obsolete("This method is deprecated. Use BuildIAuthenticator instead.", false)]
         protected override Lazy<AdalAuthenticator> BuildAuthenticator()
         {
             return new Lazy<AdalAuthenticator>();

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/AppCredentialsTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/AppCredentialsTests.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
                 Request = request;
             }
 
+            [Obsolete("This method is deprecated. Use BuildIAuthenticator instead.", false)]
             protected override Lazy<AdalAuthenticator> BuildAuthenticator()
             {
                 return new Mock<Lazy<AdalAuthenticator>>().Object;

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/ManagedIdentityAppCredentialsTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/ManagedIdentityAppCredentialsTests.cs
@@ -68,12 +68,9 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         }
 
         [Fact]
-        public void CannotCreateCredentialsWithoutTokenProviderFactory()
+        public void CanCreateCredentialsWithoutTokenProviderFactory()
         {
-            Assert.Throws<ArgumentNullException>(() =>
-            {
-                _ = new ManagedIdentityAppCredentials(TestAppId, TestAudience, tokenProviderFactory: null);
-            });
+            _ = new ManagedIdentityAppCredentials(TestAppId, TestAudience, tokenProviderFactory: null);
         }
     }
 }

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/ManagedIdentityServiceClientCredentialsFactoryTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/ManagedIdentityServiceClientCredentialsFactoryTests.cs
@@ -48,12 +48,9 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         }
 
         [Fact]
-        public void CannotCreateCredentialsFactoryWithoutTokenProviderFactory()
+        public void CanCreateCredentialsFactoryWithoutTokenProviderFactory()
         {
-            Assert.Throws<ArgumentNullException>(() =>
-            {
-                _ = new ManagedIdentityServiceClientCredentialsFactory(TestAppId, tokenProviderFactory: null);
-            });
+            _ = new ManagedIdentityServiceClientCredentialsFactory(TestAppId, tokenProviderFactory: null);
         }
 
         [Fact]

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/Mocks/MockAppCredentials.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/Mocks/MockAppCredentials.cs
@@ -14,7 +14,8 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests.Mocks
             : base(channelAuthTenant, customHttpClient, logger)
         {
         }
-
+        
+        [Obsolete("This method is deprecated. Use BuildIAuthenticator instead.", false)]
         protected override Lazy<AdalAuthenticator> BuildAuthenticator()
         {
             return new Lazy<AdalAuthenticator>();


### PR DESCRIPTION
Fixes # 6589
#minor

## Description
This PR migrates ADAL related functionality to MSAL internally.

> **Note:** The public `JwtTokenProviderFactory` class has been deprecated since its all related to ADAL functionality, said class is only being used for MSI classes, these classes will no longer use the deprecated provider and instead use the MSAL functionality.

## Specific Changes
- `AppCredentials.BuildAuthenticator` has been deprecated and the `BuildIAuthenticator` method should be used instead.
- Added `BuildIAuthenticator` method to the `CertificateAppCredentials` class, providing the MSAL authenticator instance, also the internal class variables have been changed to minimize the ADAL implementation without generating breaking changes.
- Deprecated `JwtTokenProviderFactory` since it's no longer used in MSI related classes internally. Related classes will redirect any constructor using the provider to the one without it.
- Updated the `ManagedIdentityAuthenticator` class to use MSAL functionality instead of `JwtTokenProviderFactory` to acquire the token.
- Added `BuildIAuthenticator` method to the `MicrosoftAppCredentials` class, providing the MSAL authenticator instance.
- Removed the `Microsoft.IdentityModel.Clients.ActiveDirectory` (ADAL) package reference from Connector, since it's no longer used.
    - The `Microsoft.Azure.Services.AppAuthentication` package reference that uses ADAL underneath couldn't be removed, since it will generate breaking changes.
 - Updated existing unit tests due to failures when providing and mocking the `JwtTokenProviderFactory` parameter class.
 - Added new unit tests to validate the new implementation works as expected.

## Testing
The following image shows a few bots working, the combination of skill bots and the [FunctionalTests](https://github.com/microsoft/BotFramework-FunctionalTests) pipeline passing successfully.
![image](https://user-images.githubusercontent.com/62260472/225437461-119b9eff-76b8-465b-a02e-d3b353b778c1.png)
