### PR TITLE
[#6596] TeamsChannelData need OnBehalfOf 

### DIFF
--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using Microsoft.Bot.Schema;
 using Microsoft.Bot.Schema.Teams;
 
@@ -90,11 +91,11 @@ namespace Microsoft.Bot.Builder.Teams
         }
 
         /// <summary>
-        /// Gets the OnBehalfOf object from the current activity.
+        /// Gets the Teams OnBehalfOf list from the current activity.
         /// </summary>
         /// <param name="activity">The current activity.</param>
-        /// <returns>The current activity's OnBehalfOf data, or empty string.</returns>
-        public static OnBehalfOf TeamsGetTeamOnBehalfOf(this IActivity activity)
+        /// <returns>The current activity's OnBehalfOf list, or null.</returns>
+        public static IList<OnBehalfOf> TeamsGetTeamOnBehalfOf(this IActivity activity)
         {
             var channelData = activity.GetChannelData<TeamsChannelData>();
             return channelData?.OnBehalfOf;

--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityExtensions.cs
@@ -88,5 +88,16 @@ namespace Microsoft.Bot.Builder.Teams
         {
             activity.TeamsNotifyUser(false);
         }
+
+        /// <summary>
+        /// Gets the OnBehalfOf object from the current activity.
+        /// </summary>
+        /// <param name="activity">The current activity.</param>
+        /// <returns>The current activity's OnBehalfOf data, or empty string.</returns>
+        public static OnBehalfOf TeamsGetTeamOnBehalfOf(this IActivity activity)
+        {
+            var channelData = activity.GetChannelData<TeamsChannelData>();
+            return channelData?.OnBehalfOf;
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/TeamsChannelData.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TeamsChannelData.cs
@@ -28,13 +28,15 @@ namespace Microsoft.Bot.Schema.Teams
         /// <param name="notification">Notification settings for the message.</param>
         /// <param name="tenant">Information about the tenant in which the
         /// message was sent.</param>
-        public TeamsChannelData(ChannelInfo channel = default, string eventType = default, TeamInfo team = default, NotificationInfo notification = default, TenantInfo tenant = default)
+        /// <param name="onBehalfOf">The OnBehalfOf information of the message.</param>
+        public TeamsChannelData(ChannelInfo channel = default, string eventType = default, TeamInfo team = default, NotificationInfo notification = default, TenantInfo tenant = default, IList<OnBehalfOf> onBehalfOf = default)
         {
             Channel = channel;
             EventType = eventType;
             Team = team;
             Notification = notification;
             Tenant = tenant;
+            OnBehalfOf = onBehalfOf ?? new List<OnBehalfOf>();
             CustomInit();
         }
 
@@ -92,11 +94,11 @@ namespace Microsoft.Bot.Schema.Teams
         public TeamsChannelDataSettings Settings { get; set; }
 
         /// <summary>
-        /// Gets or sets information about the delegation of meetings.
+        /// Gets the OnBehalfOf list for user attribution.
         /// </summary>
-        /// <value>The information about the attribution for notifications.</value>
+        /// <value>The Teams activity OnBehalfOf list.</value>
         [JsonProperty(PropertyName = "onBehalfOf")]
-        public OnBehalfOf OnBehalfOf { get; set; }
+        public IList<OnBehalfOf> OnBehalfOf { get; private set; }
 
         /// <summary>
         /// Gets or sets properties that are not otherwise defined by the <see cref="TeamsChannelData"/> type but that

--- a/libraries/Microsoft.Bot.Schema/Teams/TeamsChannelData.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TeamsChannelData.cs
@@ -28,6 +28,25 @@ namespace Microsoft.Bot.Schema.Teams
         /// <param name="notification">Notification settings for the message.</param>
         /// <param name="tenant">Information about the tenant in which the
         /// message was sent.</param>
+        public TeamsChannelData(ChannelInfo channel = default, string eventType = default, TeamInfo team = default, NotificationInfo notification = default, TenantInfo tenant = default)
+        {
+            Channel = channel;
+            EventType = eventType;
+            Team = team;
+            Notification = notification;
+            Tenant = tenant;
+            CustomInit();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TeamsChannelData"/> class.
+        /// </summary>
+        /// <param name="channel">Information about the channel in which the message was sent.</param>
+        /// <param name="eventType">Type of event.</param>
+        /// <param name="team">Information about the team in which the message was sent.</param>
+        /// <param name="notification">Notification settings for the message.</param>
+        /// <param name="tenant">Information about the tenant in which the
+        /// message was sent.</param>
         /// <param name="onBehalfOf">The OnBehalfOf information of the message.</param>
         public TeamsChannelData(ChannelInfo channel = default, string eventType = default, TeamInfo team = default, NotificationInfo notification = default, TenantInfo tenant = default, IList<OnBehalfOf> onBehalfOf = default)
         {

--- a/libraries/Microsoft.Bot.Schema/Teams/TeamsChannelData.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TeamsChannelData.cs
@@ -29,13 +29,8 @@ namespace Microsoft.Bot.Schema.Teams
         /// <param name="tenant">Information about the tenant in which the
         /// message was sent.</param>
         public TeamsChannelData(ChannelInfo channel = default, string eventType = default, TeamInfo team = default, NotificationInfo notification = default, TenantInfo tenant = default)
+            : this(channel, eventType, team, notification, tenant, null)
         {
-            Channel = channel;
-            EventType = eventType;
-            Team = team;
-            Notification = notification;
-            Tenant = tenant;
-            CustomInit();
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Schema/Teams/TeamsChannelData.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TeamsChannelData.cs
@@ -92,6 +92,13 @@ namespace Microsoft.Bot.Schema.Teams
         public TeamsChannelDataSettings Settings { get; set; }
 
         /// <summary>
+        /// Gets or sets information about the delegation of meetings.
+        /// </summary>
+        /// <value>The information about the attribution for notifications.</value>
+        [JsonProperty(PropertyName = "onBehalfOf")]
+        public OnBehalfOf OnBehalfOf { get; set; }
+
+        /// <summary>
         /// Gets or sets properties that are not otherwise defined by the <see cref="TeamsChannelData"/> type but that
         /// might appear in the REST JSON object.
         /// </summary>

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityExtensionsTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityExtensionsTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Collections.Generic;
 using Microsoft.Bot.Schema;
 using Microsoft.Bot.Schema.Teams;
 using Xunit;
@@ -21,7 +23,7 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             // Assert
             Assert.Equal("channel123", channelId);
         }
-        
+
         [Fact]
         public void TeamsGetSelectedChannelIdNullSettings()
         {
@@ -129,6 +131,28 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             // Assert
             Assert.Equal(true, ((TeamsChannelData)activity.ChannelData).Notification.Alert);
             Assert.Equal("team123", ((TeamsChannelData)activity.ChannelData).Team.Id);
+        }
+
+        [Fact]
+        public void TeamsChannelDataExistingOnBehalfOf()
+        {
+            // Arrange
+            var onBehalfOf = new OnBehalfOf
+            {
+                DisplayName = "TestOnBehalfOf",
+                ItemId = new Random().Next(),
+                MentionType = Guid.NewGuid().ToString(),
+                Mri = Guid.NewGuid().ToString()
+            };
+
+            var activity = new Activity { ChannelData = new TeamsChannelData(onBehalfOf: new List<OnBehalfOf> { onBehalfOf }) };        
+
+            // Act
+            var onBehalfOfList = activity.TeamsGetTeamOnBehalfOf();
+
+            // Assert
+            Assert.Equal(1, onBehalfOfList.Count);
+            Assert.Equal("TestOnBehalfOf", onBehalfOfList[0].DisplayName);
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityExtensionsTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityExtensionsTests.cs
@@ -140,8 +140,8 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             var onBehalfOf = new OnBehalfOf
             {
                 DisplayName = "TestOnBehalfOf",
-                ItemId = new Random().Next(),
-                MentionType = Guid.NewGuid().ToString(),
+                ItemId = 0,
+                MentionType = "person",
                 Mri = Guid.NewGuid().ToString()
             };
 

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TeamsChannelDataTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TeamsChannelDataTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Collections.Generic;
 using Microsoft.Bot.Schema.Teams;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -19,7 +21,17 @@ namespace Microsoft.Bot.Schema.Tests.Teams
             var tenant = new TenantInfo("uniqueTenantId");
             var meeting = new TeamsMeetingInfo("BFSE Stand Up");
             var settings = new TeamsChannelDataSettings(channel);
-            var channelData = new TeamsChannelData(channel, eventType, team, notification, tenant)
+            var onBehalfOf = new List<OnBehalfOf>()
+            {
+                new () 
+                {
+                    DisplayName = "onBehalfOfTest",
+                    ItemId = new Random().Next(),
+                    MentionType = Guid.NewGuid().ToString(),
+                    Mri = Guid.NewGuid().ToString()
+                }
+            };
+            var channelData = new TeamsChannelData(channel, eventType, team, notification, tenant, onBehalfOf)
             {
                 Meeting = meeting,
                 Settings = settings
@@ -34,6 +46,7 @@ namespace Microsoft.Bot.Schema.Tests.Teams
             Assert.Equal(tenant, channelData.Tenant);
             Assert.Equal(settings, channelData.Settings);
             Assert.Equal(channel, channelData.Settings.SelectedChannel);
+            Assert.Equal(onBehalfOf[0].DisplayName, channelData.OnBehalfOf[0].DisplayName);
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TeamsChannelDataTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TeamsChannelDataTests.cs
@@ -23,11 +23,11 @@ namespace Microsoft.Bot.Schema.Tests.Teams
             var settings = new TeamsChannelDataSettings(channel);
             var onBehalfOf = new List<OnBehalfOf>()
             {
-                new () 
+                new OnBehalfOf() 
                 {
                     DisplayName = "onBehalfOfTest",
-                    ItemId = new Random().Next(),
-                    MentionType = Guid.NewGuid().ToString(),
+                    ItemId = 0,
+                    MentionType = "person",
                     Mri = Guid.NewGuid().ToString()
                 }
             };
@@ -46,7 +46,7 @@ namespace Microsoft.Bot.Schema.Tests.Teams
             Assert.Equal(tenant, channelData.Tenant);
             Assert.Equal(settings, channelData.Settings);
             Assert.Equal(channel, channelData.Settings.SelectedChannel);
-            Assert.Equal(onBehalfOf[0].DisplayName, channelData.OnBehalfOf[0].DisplayName);
+            Assert.Equal(onBehalfOf, channelData.OnBehalfOf);
         }
 
         [Fact]


### PR DESCRIPTION
#minor

## Description
This PR adds the _OnBehalfOf_ property to send messages via bots on behalf of another user in Teams.

## Specific Changes
  - Added the **_OnBehalfOf_** property in the _TeamsChannelData_ class.
  - Added the _**TeamsGetTeamOnBehalfOf**_ method to return the current activity's _OnBehalfOf_ list
  
## Testing
The following image shows the message of the bot on behalf of another user in the Teams channel.
![image](https://user-images.githubusercontent.com/122501764/227230458-c1ae4fe2-2194-4a30-acd2-89074050b917.png)

The following image shows the related unit test passing.
![image](https://user-images.githubusercontent.com/122501764/227232541-64e028af-2e17-4c98-b445-7a742141a70f.png)