### PR TITLE
[#6560] Allow TokenCredential authentication in CosmosDbPartitionedStorage

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Bot.Builder.Azure
                 throw new ArgumentException($"Service EndPoint for CosmosDB is required.", nameof(cosmosDbStorageOptions));
             }
 
-            if (string.IsNullOrEmpty(cosmosDbStorageOptions.AuthKey) && string.IsNullOrEmpty(cosmosDbStorageOptions.TokenCredential))
+            if (string.IsNullOrEmpty(cosmosDbStorageOptions.AuthKey) && cosmosDbStorageOptions.TokenCredential == null)
             {
                 throw new ArgumentException("AuthKey or TokenCredential for CosmosDB is required.", nameof(cosmosDbStorageOptions));
             }
@@ -118,7 +118,7 @@ namespace Microsoft.Bot.Builder.Azure
         /// <para>jsonSerializer.ContractResolver = new DefaultContractResolver().</para>
         /// <para>jsonSerializer.SerializationBinder = new AllowedTypesSerializationBinder().</para>
         /// </param>
-        public CosmosDbPartitionedStorage(CosmosClient client, CosmosDbPartitionedStorageOptions cosmosDbStorageOptions, JsonSerializer jsonSerializer = default)
+        internal CosmosDbPartitionedStorage(CosmosClient client, CosmosDbPartitionedStorageOptions cosmosDbStorageOptions, JsonSerializer jsonSerializer = default)
             : this(cosmosDbStorageOptions)
         {
             _client = client;
@@ -389,10 +389,20 @@ namespace Microsoft.Bot.Builder.Azure
                     var assemblyName = this.GetType().Assembly.GetName();
                     cosmosClientOptions.ApplicationName = string.Concat(assemblyName.Name, " ", assemblyName.Version.ToString());
 
-                    _client = new CosmosClient(
+                    if (_cosmosDbStorageOptions.TokenCredential != null)
+                    {
+                        _client = new CosmosClient(
+                        _cosmosDbStorageOptions.CosmosDbEndpoint,
+                        _cosmosDbStorageOptions.TokenCredential,
+                        cosmosClientOptions);
+                    }
+                    else
+                    {
+                        _client = new CosmosClient(
                         _cosmosDbStorageOptions.CosmosDbEndpoint,
                         _cosmosDbStorageOptions.AuthKey,
                         cosmosClientOptions);
+                    }                  
                 }
 
                 if (_container == null)

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
@@ -9,6 +9,7 @@ using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Core;
 using Microsoft.Azure.Cosmos;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -53,9 +54,9 @@ namespace Microsoft.Bot.Builder.Azure
                 throw new ArgumentException($"Service EndPoint for CosmosDB is required.", nameof(cosmosDbStorageOptions));
             }
 
-            if (string.IsNullOrEmpty(cosmosDbStorageOptions.AuthKey))
+            if (string.IsNullOrEmpty(cosmosDbStorageOptions.AuthKey) && string.IsNullOrEmpty(cosmosDbStorageOptions.TokenCredential))
             {
-                throw new ArgumentException("AuthKey for CosmosDB is required.", nameof(cosmosDbStorageOptions));
+                throw new ArgumentException("AuthKey or TokenCredential for CosmosDB is required.", nameof(cosmosDbStorageOptions));
             }
 
             if (string.IsNullOrEmpty(cosmosDbStorageOptions.DatabaseId))
@@ -117,7 +118,7 @@ namespace Microsoft.Bot.Builder.Azure
         /// <para>jsonSerializer.ContractResolver = new DefaultContractResolver().</para>
         /// <para>jsonSerializer.SerializationBinder = new AllowedTypesSerializationBinder().</para>
         /// </param>
-        internal CosmosDbPartitionedStorage(CosmosClient client, CosmosDbPartitionedStorageOptions cosmosDbStorageOptions, JsonSerializer jsonSerializer = default)
+        public CosmosDbPartitionedStorage(CosmosClient client, CosmosDbPartitionedStorageOptions cosmosDbStorageOptions, JsonSerializer jsonSerializer = default)
             : this(cosmosDbStorageOptions)
         {
             _client = client;

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
@@ -9,7 +9,6 @@ using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.Core;
 using Microsoft.Azure.Cosmos;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorageOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorageOptions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Azure.Core;
 using Microsoft.Azure.Cosmos;
 
 namespace Microsoft.Bot.Builder.Azure
@@ -92,6 +93,6 @@ namespace Microsoft.Bot.Builder.Azure
         /// <value>
         /// The token credential for Cosmos DB.
         /// </value>
-        public string TokenCredential { get; set; }
+        public TokenCredential TokenCredential { get; set; }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorageOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorageOptions.cs
@@ -85,5 +85,13 @@ namespace Microsoft.Bot.Builder.Azure
         /// The default for backwards compatibility is 255 <see cref="CosmosDbKeyEscape.MaxKeyLength"/>.
         /// </value>
         public bool CompatibilityMode { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the token credential for Cosmos DB.
+        /// </summary>
+        /// <value>
+        /// The token credential for Cosmos DB.
+        /// </value>
+        public string TokenCredential { get; set; }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
+++ b/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
@@ -36,7 +36,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.15.1" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.32.2" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="9.4.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbPartitionedStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbPartitionedStorageTests.cs
@@ -44,11 +44,12 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 CosmosDbEndpoint = null,
             }));
 
-            // No Auth Key. Should throw.
+            // No Auth Key or TokenCredential. Should throw.
             Assert.Throws<ArgumentException>(() => new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions()
             {
                 CosmosDbEndpoint = "CosmosDbEndpoint",
                 AuthKey = null,
+                TokenCredential = null
             }));
 
             // No Database Id. Should throw.


### PR DESCRIPTION
#minor

## Description
This PR adds the _CosmosDB_ authentication method through _TokenCredential_ in _CosmosDbPartitionedStorage_.

## Specific Changes
  - Updated the package Microsoft.Azure.Cosmos from 3.15.1 to 3.32.2 to get the CosmosClient constructor that uses TokenCredential.
  - Added TokenCredential property to CosmosDbPartitionedStorageOptions.
  - Added conditional of AuthKey or TokenCredential to avoid throwing an error.
  - Added an alternative to creating a CosmosClient through TokenCredential.

## Testing
The following image shows the registers saved in CosmosDB using the credential given by Azure to authenticate.
![image](https://user-images.githubusercontent.com/122501764/229199723-fcb2a5a9-5852-4a9a-ba78-46c157dab801.png)
