### PR TITLE
[#6619] UserId not being passed to AzureDiagnostics

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/LanguageServiceUtils.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/LanguageServiceUtils.cs
@@ -197,7 +197,8 @@ namespace Microsoft.Bot.Builder.AI.QnA.Utils
                     qnaId = options.QnAId,
                     rankerType = options.RankerType,
                     answerSpanRequest = new { enable = options.EnablePreciseAnswer },
-                    includeUnstructuredSources = options.IncludeUnstructuredSources
+                    includeUnstructuredSources = options.IncludeUnstructuredSources,
+                    userId = messageActivity.From?.Id
                 }, Formatting.None,
                 _settings);
             var httpRequestHelper = new HttpRequestUtils(_httpClient);

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/LanguageServiceTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/LanguageServiceTests.cs
@@ -1246,20 +1246,20 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
         }
 
         /// <summary>
-        /// The LanguageService_ReturnsAnswer_WithoutUserId.
+        /// The LanguageService_ReturnsAnswer_WithNullUserId.
         /// </summary>
         /// <returns>The <see cref="Task"/>.</returns>
         [Fact]
         [Trait("TestCategory", "AI")]
         [Trait("TestCategory", "LanguageService")]
-        public async Task LanguageService_ReturnsAnswer_WithoutUserId()
+        public async Task LanguageService_ReturnsAnswer_WithNullUserId()
         {
             var mockHttp = new MockHttpMessageHandler();
             mockHttp.When(HttpMethod.Post, GetRequestUrl())
                 .WithContent("{\"question\":\"how do I clean the stove?\",\"top\":1,\"filters\":{\"MetadataFilter\":{\"Metadata\":[],\"LogicalOperation\":\"AND\"},\"SourceFilter\":[],\"LogicalOperation\":null},\"confidenceScoreThreshold\":0.3,\"context\":null,\"qnaId\":0,\"rankerType\":\"Default\",\"answerSpanRequest\":{\"enable\":true},\"includeUnstructuredSources\":true,\"userId\":null}")
                 .Respond("application/json", GetResponse("LanguageService_ReturnsAnswer.json"));
 
-            var adapter = new TestAdapter(TestAdapter.CreateConversation(nameof(LanguageService_ReturnsAnswer_WithoutUserId)));
+            var adapter = new TestAdapter(TestAdapter.CreateConversation(nameof(LanguageService_ReturnsAnswer_WithNullUserId)));
             var activity = new Activity
             {
                 Type = ActivityTypes.Message,


### PR DESCRIPTION
Fixes # 6619
#minor

## Description
This PR fixes an issue where the `userId` property was empty when displaying the AzureDiagnostics table in the Log Analytics workspace resource.

## Specific Changes
  - Added `userId` property to the `query-knowledgebases` request in the `LanguageServiceUtils` file.
  - Added unit test in the `LanguageServiceTests` file to validate when the `userId` property is empty.
  - Updated failing tests in the `LanguageServiceTests` file.

## Testing
The following images show the unit tests passing and the AzureDiagnostics logs from the Language service resource.
![image](https://user-images.githubusercontent.com/62260472/234387260-f02546cd-9b2e-495e-8af0-6a74218236a4.png)
![image](https://user-images.githubusercontent.com/62260472/234387271-f8aa1d01-a26d-466d-a7a5-ae3f683f1ad7.png)