### PR TITLE
[#5577] BotFrameworkClientImpl.PostActivityAsync() doesn't support null fromBotId and toBotId values

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkClientImpl.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkClientImpl.cs
@@ -39,8 +39,8 @@ namespace Microsoft.Bot.Connector.Authentication
 
         public async override Task<InvokeResponse<T>> PostActivityAsync<T>(string fromBotId, string toBotId, Uri toUrl, Uri serviceUrl, string conversationId, Activity activity, CancellationToken cancellationToken = default)
         {
-            _ = fromBotId ?? throw new ArgumentNullException(nameof(fromBotId));
-            _ = toBotId ?? throw new ArgumentNullException(nameof(toBotId));
+            fromBotId = fromBotId ?? string.Empty;
+            toBotId = toBotId ?? string.Empty;
             _ = toUrl ?? throw new ArgumentNullException(nameof(toUrl));
             _ = serviceUrl ?? throw new ArgumentNullException(nameof(serviceUrl));
             _ = conversationId ?? throw new ArgumentNullException(nameof(conversationId));


### PR DESCRIPTION
#minor

## Description
This PR allows to use null values for _fromBotId_ and _toBotId_ with skill bots using them as optional parameters, this to avoid the null _appId_ error when the property is removed from the bot's settings directly.

## Specific Changes
  - Replaced the throw errors by the assignation of an empty string as default values in the method _PostActivityAsync_ in _BotFrameworkClientImpl_.

## Testing
The following images show the bots working created by Composer and with skill bots samples.
![image](https://user-images.githubusercontent.com/122501764/234941793-a2688483-3e7b-49e9-89ed-c9b9773d7048.png)
