### PR TITLE
[#5820] Outgoing Activity Locale being Overwritten

### DIFF
--- a/libraries/Microsoft.Bot.Schema/ActivityEx.cs
+++ b/libraries/Microsoft.Bot.Schema/ActivityEx.cs
@@ -509,13 +509,13 @@ namespace Microsoft.Bot.Schema
         /// activity to get a conversation reference that you can then use to update an
         /// outgoing activity with the correct delivery information.
         /// </remarks>
-        /// <returns>This activy, updated with the delivery information.</returns>
+        /// <returns>This activity, updated with the delivery information.</returns>
         public Activity ApplyConversationReference(ConversationReference reference, bool isIncoming = false)
         {
             ChannelId = reference.ChannelId;
             ServiceUrl = reference.ServiceUrl;
             Conversation = reference.Conversation;
-            Locale = reference.Locale ?? Locale;
+            Locale ??= reference.Locale;
 
             if (isIncoming)
             {

--- a/tests/Microsoft.Bot.Schema.Tests/ActivityTest.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/ActivityTest.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Bot.Schema.Tests
         [Fact]
         public void ApplyConversationReference_isIncoming()
         {
-            var activity = CreateActivity("en-us");
+            var activity = CreateActivity("en-uS"); // Intentionally oddly-cased to check that it isn't defaulted somewhere, but tests stay in English
             var conversationReference = new ConversationReference
             {
                 ChannelId = "cr_123",
@@ -125,19 +125,19 @@ namespace Microsoft.Bot.Schema.Tests
                     Id = "cr_def",
                 },
                 ActivityId = "cr_12345",
-                Locale = "en-uS" // Intentionally oddly-cased to check that it isn't defaulted somewhere, but tests stay in English
+                Locale = "en-us"
             };
 
-            activity.ApplyConversationReference(conversationReference, true);
+            var activityToSend = activity.ApplyConversationReference(conversationReference, true);
 
             Assert.Equal(conversationReference.ChannelId, activity.ChannelId);
-            Assert.Equal(conversationReference.Locale, activity.Locale);
             Assert.Equal(conversationReference.ServiceUrl, activity.ServiceUrl);
             Assert.Equal(conversationReference.Conversation.Id, activity.Conversation.Id);
 
             Assert.Equal(conversationReference.User.Id, activity.From.Id);
             Assert.Equal(conversationReference.Bot.Id, activity.Recipient.Id);
             Assert.Equal(conversationReference.ActivityId, activity.Id);
+            Assert.Equal(activity.Locale, activityToSend.Locale);
         }
 
         [Theory]
@@ -145,7 +145,7 @@ namespace Microsoft.Bot.Schema.Tests
         [InlineData(null)]
         public void ApplyConversationReference(string convoRefLocale)
         {
-            var activity = CreateActivity("en-us");
+            var activity = CreateActivity(convoRefLocale);
 
             var conversationReference = new ConversationReference
             {
@@ -164,10 +164,10 @@ namespace Microsoft.Bot.Schema.Tests
                     Id = "def",
                 },
                 ActivityId = "12345",
-                Locale = convoRefLocale
+                Locale = "en-us"
             };
 
-            activity.ApplyConversationReference(conversationReference, false);
+            var activityToSend = activity.ApplyConversationReference(conversationReference, false);
 
             Assert.Equal(conversationReference.ChannelId, activity.ChannelId);
             Assert.Equal(conversationReference.ServiceUrl, activity.ServiceUrl);
@@ -179,11 +179,11 @@ namespace Microsoft.Bot.Schema.Tests
 
             if (convoRefLocale == null)
             {
-                Assert.NotEqual(conversationReference.Locale, activity.Locale);
+                Assert.Equal(conversationReference.Locale, activityToSend.Locale);
             }
             else
             {
-                Assert.Equal(conversationReference.Locale, activity.Locale);
+                Assert.Equal(activity.Locale, activityToSend.Locale);
             }
         }
 


### PR DESCRIPTION
Fixes # 5820
#minor

## Description
This PR updates the Activity's **_ApplyConversationReference_** method to prioritize the activity's _locale_ over the reference _locale_.

## Specific Changes
- Updated **_ApplyConversationReference_** method in _ActivityEx_ class to use the activity's _locale_ first. If it's null, use the reference's _locale_.

## Testing
These images show the overridden _locale_ property (before) and how it's kept after the changes.

**BEFORE**:
![image](https://user-images.githubusercontent.com/44245136/236231566-ac31b80b-216c-4852-9f07-180b289b41ea.png)

**AFTER**: 
![image](https://user-images.githubusercontent.com/44245136/236231665-7da79127-4916-4488-9e61-9f67ccd64a90.png)
