### PR TITLE
[#6642] Handle null content

### DIFF
--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/CloudAdapter.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/CloudAdapter.cs
@@ -349,7 +349,12 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                             Path = httpRequestMessage.RequestUri.OriginalString.Substring(httpRequestMessage.RequestUri.OriginalString.IndexOf("/v3", StringComparison.Ordinal)),
                             Verb = httpRequestMessage.Method.ToString(),
                         };
-                        streamingRequest.SetBody(await httpRequestMessage.Content.ReadAsStringAsync().ConfigureAwait(false));
+
+                        if (httpRequestMessage.Content != null) 
+                        {
+                            streamingRequest.SetBody(await httpRequestMessage.Content.ReadAsStringAsync().ConfigureAwait(false));
+                        }
+
                         return streamingRequest;
                     }
 


### PR DESCRIPTION
Fixes # 6642
#minor

## Description
This PR allows the sending of requests without a body when the content is null in streaming requests.

## Specific Changes
  - Added validation of content before reading the data in _CreateSteamingRequestAsync_.

## Testing
The following image shows the handle of the null content.
![image](https://github.com/microsoft/botbuilder-dotnet/assets/122501764/ac2d36fa-551e-4aac-b372-557935a41ea0)