### PR TITLE
Add retry logic to SendMessageToListOfUsersAsync

### DIFF
--- a/libraries/Microsoft.Bot.Connector/RetryAction.cs
+++ b/libraries/Microsoft.Bot.Connector/RetryAction.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Bot.Connector.Authentication;
+
+namespace Microsoft.Bot.Connector
+{
+    /// <summary>
+    /// Retries asynchronous operations. In case of errors, it collects and returns exceptions in an AggregateException object.
+    /// </summary>
+    public static class RetryAction
+    {
+        /// <summary>
+        /// Starts the retry of the action requested.
+        /// </summary>
+        /// <typeparam name="TResult">The result expected from the action performed.</typeparam>
+        /// <param name="task">A reference to the action to retry.</param>
+        /// <param name="retryExceptionHandler">A reference to the method that handles exceptions.</param>
+        /// <returns>A result object.</returns>
+        public static async Task<TResult> RunAsync<TResult>(Func<Task<TResult>> task, Func<Exception, int, RetryParams> retryExceptionHandler)
+        {
+            RetryParams retry;
+            var exceptions = new List<Exception>();
+            var currentRetryCount = 0;
+
+            do
+            {
+                try
+                {
+                    return await task().ConfigureAwait(false);
+                }
+#pragma warning disable CA1031 // Do not catch general exception types (this is a generic catch all to handle retries)
+                catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
+                {
+                    exceptions.Add(ex);
+                    retry = retryExceptionHandler(ex, currentRetryCount);
+                }
+
+                if (retry.ShouldRetry)
+                {
+                    currentRetryCount++;
+                    await Task.Delay(retry.RetryAfter.WithJitter()).ConfigureAwait(false);
+                }
+            }
+            while (retry.ShouldRetry);
+
+            throw new AggregateException("Failed to perform the required operation.", exceptions);
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
@@ -520,7 +520,7 @@ namespace Microsoft.Bot.Connector.Teams
             }
 
             // In case of throttling, it will retry the operation with default values (10 retries every 50 miliseconds).
-            var result = await Retry.Run(
+            var result = await RetryAction.RunAsync(
                 task: () => SendMessageToListOfUsersWithRetryAsync(activity, teamsMembers, tenantId, customHeaders, cancellationToken),
                 retryExceptionHandler: (ex, ct) => HandleThrottlingException(ex, ct)).ConfigureAwait(false);
 

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
@@ -3,12 +3,14 @@
 
 namespace Microsoft.Bot.Connector.Teams
 {
+    using System;
     using System.Collections.Generic;
     using System.Globalization;
     using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Bot.Connector.Authentication;
     using Microsoft.Bot.Schema;
     using Microsoft.Bot.Schema.Teams;
     using Microsoft.Rest;
@@ -19,6 +21,8 @@ namespace Microsoft.Bot.Connector.Teams
     /// </summary>
     public partial class TeamsOperations : IServiceOperations<TeamsConnectorClient>, ITeamsOperations
     {
+        private static volatile RetryParams currentRetryPolicy;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="TeamsOperations"/> class.
         /// </summary>
@@ -515,13 +519,35 @@ namespace Microsoft.Bot.Connector.Teams
                 throw new ValidationException(ValidationRules.CannotBeNull, nameof(tenantId));
             }
 
+            // In case of throttling, it will retry the operation with default values (10 retries every 50 miliseconds).
+            var result = await Retry.Run(
+                task: () => SendMessageToListOfUsersWithRetryAsync(activity, teamsMembers, tenantId, customHeaders, cancellationToken),
+                retryExceptionHandler: (ex, ct) => HandleThrottlingException(ex, ct)).ConfigureAwait(false);
+
+            return result;
+        }
+
+        private static RetryParams HandleThrottlingException(Exception ex, int currentRetryCount)
+        {
+            if (ex is ThrottleException throttlException)
+            {
+                return throttlException.RetryParams ?? RetryParams.DefaultBackOff(currentRetryCount);
+            }
+            else
+            {
+                return RetryParams.StopRetrying;
+            }
+        }
+
+        private async Task<HttpOperationResponse<string>> SendMessageToListOfUsersWithRetryAsync(IActivity activity, List<object> teamsMembers, string tenantId, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
             // Tracing
             var shouldTrace = ServiceClientTracing.IsEnabled;
             string invocationId = null;
             if (shouldTrace)
             {
                 invocationId = ServiceClientTracing.NextInvocationId.ToString(CultureInfo.InvariantCulture);
-                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
+                var tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("activity", activity);
                 tracingParameters.Add("teamsMembers", teamsMembers);
                 tracingParameters.Add("tenantId", tenantId);
@@ -531,10 +557,10 @@ namespace Microsoft.Bot.Connector.Teams
 
             // Construct URL
             var baseUrl = Client.BaseUri.AbsoluteUri;
-            var url = new System.Uri(new System.Uri(baseUrl + (baseUrl.EndsWith("/", System.StringComparison.InvariantCulture) ? string.Empty : "/")), "v3/batch/conversation/users/").ToString();
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/", StringComparison.InvariantCulture) ? string.Empty : "/")), "v3/batch/conversation/users/").ToString();
             using var httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
-            httpRequest.RequestUri = new System.Uri(url);
+            httpRequest.RequestUri = new Uri(url);
 
             HttpResponseMessage httpResponse = null;
 
@@ -595,7 +621,7 @@ namespace Microsoft.Bot.Connector.Teams
                     ServiceClientTracing.ReceiveResponse(invocationId, httpResponse);
                 }
 
-                HttpStatusCode statusCode = httpResponse.StatusCode;
+                var statusCode = httpResponse.StatusCode;
                 cancellationToken.ThrowIfCancellationRequested();
                 string responseContent = null;
 
@@ -620,15 +646,23 @@ namespace Microsoft.Bot.Connector.Teams
 
                         throw new SerializationException("Unable to deserialize the response.", responseContent, ex);
                     }
+                    finally
+                    {
+                        // This means the request was successfull. We can make our retry policy null.
+                        if (currentRetryPolicy != null)
+                        {
+                            currentRetryPolicy = null;
+                        }
+                    }
                 }
                 else if ((int)statusCode == 429)
                 {
-                    //TODO: implement retry logic.
+                    throw new ThrottleException() { RetryParams = currentRetryPolicy };
                 }
                 else
                 {
                     // 400: when request payload validation fails.
-                    // 401: if the bot token is invalid 
+                    // 401: if the bot token is invalid. 
                     // 403: if bot does not have permission to post messages within Tenant.
 
                     // invalid/unexpected status code


### PR DESCRIPTION
#minor

## Description
This PR adds retry logic to the _Send Message to List of Users_ Teams batch operation.

## Specific Changes
- Executes _SendMessageToListOfUsersWithRetryAsync_ in a Retry block.
- Throws a new ThrottleException if the API's return code is 429.
- Adds _HandleThrottlingException_ method to handle the new exception.