### PR TITLE
Southworks/add/teams batch operations all users tenant

### DIFF
--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
@@ -359,6 +359,25 @@ namespace Microsoft.Bot.Builder.Teams
             }
         }
 
+        /// <summary>
+        /// Sends a message to the provided list of Teams members.
+        /// </summary>
+        /// <param name="turnContext"> Turn context. </param>
+        /// <param name="activity"> The activity to send to the tenant. </param>
+        /// <param name="tenantId"> The tenant ID. </param>
+        /// <param name="cancellationToken"> The cancellation token. </param>
+        /// <returns>The operation Id.</returns>
+        public static async Task<string> SendMessageToAllUsersInTenantAsync(ITurnContext turnContext, IActivity activity, string tenantId, CancellationToken cancellationToken = default)
+        {
+            activity = activity ?? throw new InvalidOperationException($"{nameof(activity)} is required.");
+            tenantId = tenantId ?? throw new InvalidOperationException($"{nameof(tenantId)} is required.");
+
+            using (var teamsClient = GetTeamsConnectorClient(turnContext))
+            {
+                return await teamsClient.Teams.SendMessageToAllUsersInTenantAsync(activity, tenantId, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
         private static async Task<IEnumerable<TeamsChannelAccount>> GetMembersAsync(IConnectorClient connectorClient, string conversationId, CancellationToken cancellationToken)
         {
             if (conversationId == null)

--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
@@ -338,6 +338,27 @@ namespace Microsoft.Bot.Builder.Teams
             }
         }
 
+        /// <summary>
+        /// Sends a message to the provided list of Teams members.
+        /// </summary>
+        /// <param name="turnContext"> Turn context. </param>
+        /// <param name="activity"> The activity to send. </param>
+        /// <param name="teamsMembers"> The list of members. </param>
+        /// <param name="tenantId"> The tenant ID. </param>
+        /// <param name="cancellationToken"> The cancellation token. </param>
+        /// <returns>The operation Id.</returns>
+        public static async Task<string> SendMessageToListOfUsersAsync(ITurnContext turnContext, IActivity activity, List<object> teamsMembers, string tenantId, CancellationToken cancellationToken = default)
+        {
+            activity = activity ?? throw new InvalidOperationException($"{nameof(activity)} is required.");
+            teamsMembers = teamsMembers ?? throw new InvalidOperationException($"{nameof(teamsMembers)} is required.");
+            tenantId = tenantId ?? throw new InvalidOperationException($"{nameof(tenantId)} is required.");
+
+            using (var teamsClient = GetTeamsConnectorClient(turnContext))
+            {
+                return await teamsClient.Teams.SendMessageToListOfUsersAsync(activity, teamsMembers, tenantId, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
         private static async Task<IEnumerable<TeamsChannelAccount>> GetMembersAsync(IConnectorClient connectorClient, string conversationId, CancellationToken cancellationToken)
         {
             if (conversationId == null)

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
@@ -668,6 +668,186 @@ namespace Microsoft.Bot.Connector.Teams
             return result;
         }
 
+        /// <summary>
+        /// Send a message to all the users in a tenant.
+        /// </summary>
+        /// <param name="activity"> The activity to send. </param>
+        /// <param name="tenantId"> The tenant ID. </param>
+        /// <param name="customHeaders"> Headers that will be added to request. </param>
+        /// <param name='cancellationToken'> The cancellation token.  </param>
+        /// <exception cref="HttpOperationException">
+        /// Thrown when the operation returned an invalid status code.
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when an input value does not match the expected data type, range or pattern.
+        /// </exception>
+        /// <returns>
+        /// A response object containing the operation id.
+        /// </returns>
+        public async Task<HttpOperationResponse<string>> SendMessageToAllUsersInTenantAsync(IActivity activity, string tenantId, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (activity == null)
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, nameof(activity));
+            }
+
+            if (string.IsNullOrEmpty(tenantId))
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, nameof(tenantId));
+            }
+
+            // Tracing
+            var shouldTrace = ServiceClientTracing.IsEnabled;
+            string invocationId = null;
+            if (shouldTrace)
+            {
+                invocationId = ServiceClientTracing.NextInvocationId.ToString(CultureInfo.InvariantCulture);
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
+                tracingParameters.Add("activity", activity);
+                tracingParameters.Add("tenantId", tenantId);
+                tracingParameters.Add("cancellationToken", cancellationToken);
+                ServiceClientTracing.Enter(invocationId, this, "SendMessageToAllUsersInTenant", tracingParameters);
+            }
+
+            // Construct URL
+            var baseUrl = Client.BaseUri.AbsoluteUri;
+            var url = new System.Uri(new System.Uri(baseUrl + (baseUrl.EndsWith("/", System.StringComparison.InvariantCulture) ? string.Empty : "/")), "v3/batch/conversation/tenant/").ToString();
+            using var httpRequest = new HttpRequestMessage();
+            httpRequest.Method = new HttpMethod("POST");
+            httpRequest.RequestUri = new System.Uri(url);
+
+            HttpResponseMessage httpResponse = null;
+
+            // Create HTTP transport objects
+#pragma warning disable CA2000 // Dispose objects before losing scope
+            var result = new HttpOperationResponse<string>();
+#pragma warning restore CA2000 // Dispose objects before losing scope
+            try
+            {
+                // Set Headers
+                if (customHeaders != null)
+                {
+                    foreach (var header in customHeaders)
+                    {
+                        if (httpRequest.Headers.Contains(header.Key))
+                        {
+                            httpRequest.Headers.Remove(header.Key);
+                        }
+
+                        httpRequest.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                    }
+                }
+
+                var content = new
+                {
+                    Activity = activity,
+                    TenantId = tenantId,
+                };
+
+                // Serialize Request
+                string requestContent = null;
+
+                if (activity != null)
+                {
+                    requestContent = Rest.Serialization.SafeJsonConvert.SerializeObject(content);
+                    httpRequest.Content = new StringContent(requestContent, System.Text.Encoding.UTF8);
+                    httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; charset=utf-8");
+                }
+
+                // Set Credentials
+                if (Client.Credentials != null)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await Client.Credentials.ProcessHttpRequestAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+                }
+
+                // Send Request
+                if (shouldTrace)
+                {
+                    ServiceClientTracing.SendRequest(invocationId, httpRequest);
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+                httpResponse = await Client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+                if (shouldTrace)
+                {
+                    ServiceClientTracing.ReceiveResponse(invocationId, httpResponse);
+                }
+
+                HttpStatusCode statusCode = httpResponse.StatusCode;
+                cancellationToken.ThrowIfCancellationRequested();
+                string responseContent = null;
+
+                // Create Result
+                result.Request = httpRequest;
+                result.Response = httpResponse;
+
+                if ((int)statusCode == 201)
+                {
+                    // 201: created
+                    try
+                    {
+                        responseContent = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                        result.Body = responseContent;
+                    }
+                    catch (JsonException ex)
+                    {
+                        if (shouldTrace)
+                        {
+                            ServiceClientTracing.Error(invocationId, ex);
+                        }
+
+                        throw new SerializationException("Unable to deserialize the response.", responseContent, ex);
+                    }
+                }
+                else if ((int)statusCode == 429)
+                {
+                    //TODO: implement retry logic.
+                }
+                else
+                {
+                    // 400: when request payload validation fails.
+                    // 401: if the bot token is invalid 
+                    // 403: if bot does not have permission to post messages within Tenant.
+                    // 404: when Team is not found.
+
+                    // invalid/unexpected status code
+                    var ex = new HttpOperationException($"Operation returned an invalid status code '{statusCode}'");
+                    if (httpResponse.Content != null)
+                    {
+                        responseContent = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        responseContent = string.Empty;
+                    }
+
+                    ex.Request = new HttpRequestMessageWrapper(httpRequest, requestContent);
+                    ex.Response = new HttpResponseMessageWrapper(httpResponse, responseContent);
+                    if (shouldTrace)
+                    {
+                        ServiceClientTracing.Error(invocationId, ex);
+                    }
+
+                    throw ex;
+                }
+            }
+            finally
+            {
+                if (httpResponse != null)
+                {
+                    httpResponse.Dispose();
+                }
+            }
+
+            if (shouldTrace)
+            {
+                ServiceClientTracing.Exit(invocationId, result);
+            }
+
+            return result;
+        }
+
         private async Task<HttpOperationResponse<T>> GetResponseAsync<T>(string url, bool shouldTrace, string invocationId, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             // Create HTTP transport objects

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
@@ -627,9 +627,9 @@ namespace Microsoft.Bot.Connector.Teams
                 }
                 else
                 {
-                    // 400: when request payload validation fails. For instance, 
+                    // 400: when request payload validation fails.
                     // 401: if the bot token is invalid 
-                    // 403: if the bot is not allowed to send messages.
+                    // 403: if bot does not have permission to post messages within Tenant.
 
                     // invalid/unexpected status code
                     var ex = new HttpOperationException($"Operation returned an invalid status code '{statusCode}'");

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperationsExtensions.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperationsExtensions.cs
@@ -179,5 +179,36 @@ namespace Microsoft.Bot.Connector.Teams
                 throw new InvalidOperationException("TeamsOperations with SendMessageToListOfUsersAsync is required for SendMessageToListOfUsersAsync.");
             }
         }
+
+        /// <summary>
+        /// Sends a message to all the users in a tenant.
+        /// </summary>
+        /// <param name='operations'>
+        /// The operations group for this extension method.
+        /// </param>
+        /// <param name='activity'>
+        /// The activity to send.
+        /// </param>
+        /// <param name='tenantId'>
+        /// The tenant ID.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        /// <returns>The operation Id.</returns>
+        public static async Task<string> SendMessageToAllUsersInTenantAsync(this ITeamsOperations operations, IActivity activity, string tenantId, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (operations is TeamsOperations teamsOperations)
+            {
+                using (var result = await teamsOperations.SendMessageToAllUsersInTenantAsync(activity, tenantId, null, cancellationToken).ConfigureAwait(false))
+                {
+                    return result.Body;
+                }
+            }
+            else
+            {
+                throw new InvalidOperationException("TeamsOperations with SendMessageToAllUsersInTenantAsync is required for SendMessageToAllUsersInTenantAsync.");
+            }
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperationsExtensions.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperationsExtensions.cs
@@ -4,8 +4,10 @@
 namespace Microsoft.Bot.Connector.Teams
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Bot.Schema;
     using Microsoft.Bot.Schema.Teams;
 
     /// <summary>
@@ -141,6 +143,40 @@ namespace Microsoft.Bot.Connector.Teams
             else
             {
                 throw new InvalidOperationException("TeamsOperations with SendMeetingNotificationWithHttpMessagesAsync is required for SendMeetingNotificationAsync.");
+            }
+        }
+
+        /// <summary>
+        /// Sends a message to a list of Teams users.
+        /// </summary>
+        /// <param name='operations'>
+        /// The operations group for this extension method.
+        /// </param>
+        /// <param name='activity'>
+        /// The activity to send.
+        /// </param>
+        /// <param name='teamsMembers'>
+        /// The list of members recipients for the message.
+        /// </param>
+        /// <param name='tenantId'>
+        /// The tenant ID.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        /// <returns>The operation Id.</returns>
+        public static async Task<string> SendMessageToListOfUsersAsync(this ITeamsOperations operations, IActivity activity, List<object> teamsMembers, string tenantId, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (operations is TeamsOperations teamsOperations)
+            {
+                using (var result = await teamsOperations.SendMessageToListOfUsersAsync(activity, teamsMembers, tenantId, null, cancellationToken).ConfigureAwait(false))
+                {
+                    return result.Body;
+                }
+            }
+            else
+            {
+                throw new InvalidOperationException("TeamsOperations with SendMessageToListOfUsersAsync is required for SendMessageToListOfUsersAsync.");
             }
         }
     }


### PR DESCRIPTION
#minor

## Description
This PR implements the SendMessageToAllUsersInTenant method of the new Teams batch APIs in TeamsOperations.

- [x] Send message to a list of users
- [x] Send message to all users    in a tenant
- [ ] Send message to all users in a team
- [ ] Send message to a list of channels  
- [ ] Get Operation State
- [ ] Get failed entries paginated
- [ ] Cancel Operation

## Specific Changes
- Implemented the new methods of **_SendMessageToAllUsersInTenant_** in **_TeamsOperations_**, **_TeamsOperationsExtensions_**, and **_TeamsInfo_**.