### PR TITLE
Implementation of SendMessageToAllUsersInTeam Teams batch APIs

### DIFF
--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
@@ -378,6 +378,27 @@ namespace Microsoft.Bot.Builder.Teams
             }
         }
 
+        /// <summary>
+        /// Sends a message to all the users in a team.
+        /// </summary>
+        /// <param name="turnContext"> Turn context. </param>
+        /// <param name="activity"> The activity to send to the tenant. </param>
+        /// <param name="teamId"> The team ID. </param>
+        /// <param name="tenantId"> The tenant ID. </param>
+        /// <param name="cancellationToken"> The cancellation token. </param>
+        /// <returns>The operation Id.</returns>
+        public static async Task<string> SendMessageToAllUsersInTeamAsync(ITurnContext turnContext, IActivity activity, string teamId, string tenantId, CancellationToken cancellationToken = default)
+        {
+            activity = activity ?? throw new InvalidOperationException($"{nameof(activity)} is required.");
+            teamId = teamId ?? throw new InvalidOperationException($"{nameof(teamId)} is required.");
+            tenantId = tenantId ?? throw new InvalidOperationException($"{nameof(tenantId)} is required.");
+
+            using (var teamsClient = GetTeamsConnectorClient(turnContext))
+            {
+                return await teamsClient.Teams.SendMessageToAllUsersInTeamAsync(activity, teamId, tenantId, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
         private static async Task<IEnumerable<TeamsChannelAccount>> GetMembersAsync(IConnectorClient connectorClient, string conversationId, CancellationToken cancellationToken)
         {
             if (conversationId == null)

--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
@@ -382,7 +382,7 @@ namespace Microsoft.Bot.Builder.Teams
         /// Sends a message to all the users in a team.
         /// </summary>
         /// <param name="turnContext"> Turn context. </param>
-        /// <param name="activity"> The activity to send to the tenant. </param>
+        /// <param name="activity"> The activity to send to the users in the team. </param>
         /// <param name="teamId"> The team ID. </param>
         /// <param name="tenantId"> The tenant ID. </param>
         /// <param name="cancellationToken"> The cancellation token. </param>

--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
@@ -359,6 +359,25 @@ namespace Microsoft.Bot.Builder.Teams
             }
         }
 
+        /// <summary>
+        /// Sends a message to the provided list of Teams members.
+        /// </summary>
+        /// <param name="turnContext"> Turn context. </param>
+        /// <param name="activity"> The activity to send to the tenant. </param>
+        /// <param name="tenantId"> The tenant ID. </param>
+        /// <param name="cancellationToken"> The cancellation token. </param>
+        /// <returns>The operation Id.</returns>
+        public static async Task<string> SendMessageToAllUsersInTenantAsync(ITurnContext turnContext, IActivity activity, string tenantId, CancellationToken cancellationToken = default)
+        {
+            activity = activity ?? throw new InvalidOperationException($"{nameof(activity)} is required.");
+            tenantId = tenantId ?? throw new InvalidOperationException($"{nameof(tenantId)} is required.");
+
+            using (var teamsClient = GetTeamsConnectorClient(turnContext))
+            {
+                return await teamsClient.Teams.SendMessageToAllUsersInTenantAsync(activity, tenantId, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
         private static async Task<IEnumerable<TeamsChannelAccount>> GetMembersAsync(IConnectorClient connectorClient, string conversationId, CancellationToken cancellationToken)
         {
             if (conversationId == null)

--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
@@ -360,7 +360,7 @@ namespace Microsoft.Bot.Builder.Teams
         }
 
         /// <summary>
-        /// Sends a message to the provided list of Teams members.
+        /// Sends a message to all the users in a tenant.
         /// </summary>
         /// <param name="turnContext"> Turn context. </param>
         /// <param name="activity"> The activity to send to the tenant. </param>

--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
@@ -338,6 +338,27 @@ namespace Microsoft.Bot.Builder.Teams
             }
         }
 
+        /// <summary>
+        /// Sends a message to the provided list of Teams members.
+        /// </summary>
+        /// <param name="turnContext"> Turn context. </param>
+        /// <param name="activity"> The activity to send. </param>
+        /// <param name="teamsMembers"> The list of members. </param>
+        /// <param name="tenantId"> The tenant ID. </param>
+        /// <param name="cancellationToken"> The cancellation token. </param>
+        /// <returns>The operation Id.</returns>
+        public static async Task<string> SendMessageToListOfUsersAsync(ITurnContext turnContext, IActivity activity, List<object> teamsMembers, string tenantId, CancellationToken cancellationToken = default)
+        {
+            activity = activity ?? throw new InvalidOperationException($"{nameof(activity)} is required.");
+            teamsMembers = teamsMembers ?? throw new InvalidOperationException($"{nameof(teamsMembers)} is required.");
+            tenantId = tenantId ?? throw new InvalidOperationException($"{nameof(tenantId)} is required.");
+
+            using (var teamsClient = GetTeamsConnectorClient(turnContext))
+            {
+                return await teamsClient.Teams.SendMessageToListOfUsersAsync(activity, teamsMembers, tenantId, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
         private static async Task<IEnumerable<TeamsChannelAccount>> GetMembersAsync(IConnectorClient connectorClient, string conversationId, CancellationToken cancellationToken)
         {
             if (conversationId == null)

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
@@ -527,6 +527,42 @@ namespace Microsoft.Bot.Connector.Teams
             return result;
         }
 
+        /// <summary>
+        /// Send a message to all the users in a tenant.
+        /// </summary>
+        /// <param name="activity"> The activity to send. </param>
+        /// <param name="tenantId"> The tenant ID. </param>
+        /// <param name="customHeaders"> Headers that will be added to request. </param>
+        /// <param name='cancellationToken'> The cancellation token.  </param>
+        /// <exception cref="HttpOperationException">
+        /// Thrown when the operation returned an invalid status code.
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when an input value does not match the expected data type, range or pattern.
+        /// </exception>
+        /// <returns>
+        /// A response object containing the operation id.
+        /// </returns>
+        public async Task<HttpOperationResponse<string>> SendMessageToAllUsersInTenantAsync(IActivity activity, string tenantId, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (activity == null)
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, nameof(activity));
+            }
+
+            if (string.IsNullOrEmpty(tenantId))
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, nameof(tenantId));
+            }
+
+            // In case of throttling, it will retry the operation with default values (10 retries every 50 miliseconds).
+            var result = await RetryAction.RunAsync(
+                task: () => SendMessageToAllUsersInTenantWithRetryAsync(activity, tenantId, customHeaders, cancellationToken),
+                retryExceptionHandler: (ex, ct) => HandleThrottlingException(ex, ct)).ConfigureAwait(false);
+
+            return result;            
+        }
+
         private static RetryParams HandleThrottlingException(Exception ex, int currentRetryCount)
         {
             if (ex is ThrottleException throttlException)
@@ -537,6 +573,167 @@ namespace Microsoft.Bot.Connector.Teams
             {
                 return RetryParams.StopRetrying;
             }
+        }
+
+        private async Task<HttpOperationResponse<string>> SendMessageToAllUsersInTenantWithRetryAsync(IActivity activity, string tenantId, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            // Tracing
+            var shouldTrace = ServiceClientTracing.IsEnabled;
+            string invocationId = null;
+            if (shouldTrace)
+            {
+                invocationId = ServiceClientTracing.NextInvocationId.ToString(CultureInfo.InvariantCulture);
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
+                tracingParameters.Add("activity", activity);
+                tracingParameters.Add("tenantId", tenantId);
+                tracingParameters.Add("cancellationToken", cancellationToken);
+                ServiceClientTracing.Enter(invocationId, this, "SendMessageToAllUsersInTenant", tracingParameters);
+            }
+
+            // Construct URL
+            var baseUrl = Client.BaseUri.AbsoluteUri;
+            var url = new System.Uri(new System.Uri(baseUrl + (baseUrl.EndsWith("/", System.StringComparison.InvariantCulture) ? string.Empty : "/")), "v3/batch/conversation/tenant/").ToString();
+            using var httpRequest = new HttpRequestMessage();
+            httpRequest.Method = new HttpMethod("POST");
+            httpRequest.RequestUri = new System.Uri(url);
+
+            HttpResponseMessage httpResponse = null;
+
+            // Create HTTP transport objects
+#pragma warning disable CA2000 // Dispose objects before losing scope
+            var result = new HttpOperationResponse<string>();
+#pragma warning restore CA2000 // Dispose objects before losing scope
+            try
+            {
+                // Set Headers
+                if (customHeaders != null)
+                {
+                    foreach (var header in customHeaders)
+                    {
+                        if (httpRequest.Headers.Contains(header.Key))
+                        {
+                            httpRequest.Headers.Remove(header.Key);
+                        }
+
+                        httpRequest.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                    }
+                }
+
+                var content = new
+                {
+                    Activity = activity,
+                    TenantId = tenantId,
+                };
+
+                // Serialize Request
+                string requestContent = null;
+
+                if (activity != null)
+                {
+                    requestContent = Rest.Serialization.SafeJsonConvert.SerializeObject(content);
+                    httpRequest.Content = new StringContent(requestContent, System.Text.Encoding.UTF8);
+                    httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; charset=utf-8");
+                }
+
+                // Set Credentials
+                if (Client.Credentials != null)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await Client.Credentials.ProcessHttpRequestAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+                }
+
+                // Send Request
+                if (shouldTrace)
+                {
+                    ServiceClientTracing.SendRequest(invocationId, httpRequest);
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+                httpResponse = await Client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+                if (shouldTrace)
+                {
+                    ServiceClientTracing.ReceiveResponse(invocationId, httpResponse);
+                }
+
+                HttpStatusCode statusCode = httpResponse.StatusCode;
+                cancellationToken.ThrowIfCancellationRequested();
+                string responseContent = null;
+
+                // Create Result
+                result.Request = httpRequest;
+                result.Response = httpResponse;
+
+                if ((int)statusCode == 201)
+                {
+                    // 201: created
+                    try
+                    {
+                        responseContent = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                        result.Body = responseContent;
+                    }
+                    catch (JsonException ex)
+                    {
+                        if (shouldTrace)
+                        {
+                            ServiceClientTracing.Error(invocationId, ex);
+                        }
+
+                        throw new SerializationException("Unable to deserialize the response.", responseContent, ex);
+                    }
+                    finally
+                    {
+                        // This means the request was successfull. We can make our retry policy null.
+                        if (currentRetryPolicy != null)
+                        {
+                            currentRetryPolicy = null;
+                        }
+                    }
+                }
+                else if ((int)statusCode == 429)
+                {
+                    throw new ThrottleException() { RetryParams = currentRetryPolicy };
+                }
+                else
+                {
+                    // 400: when request payload validation fails.
+                    // 401: if the bot token is invalid 
+                    // 403: if bot does not have permission to post messages within Tenant.
+
+                    // invalid/unexpected status code
+                    var ex = new HttpOperationException($"Operation returned an invalid status code '{statusCode}'");
+                    if (httpResponse.Content != null)
+                    {
+                        responseContent = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        responseContent = string.Empty;
+                    }
+
+                    ex.Request = new HttpRequestMessageWrapper(httpRequest, requestContent);
+                    ex.Response = new HttpResponseMessageWrapper(httpResponse, responseContent);
+                    if (shouldTrace)
+                    {
+                        ServiceClientTracing.Error(invocationId, ex);
+                    }
+
+                    throw ex;
+                }
+            }
+            finally
+            {
+                if (httpResponse != null)
+                {
+                    httpResponse.Dispose();
+                }
+            }
+
+            if (shouldTrace)
+            {
+                ServiceClientTracing.Exit(invocationId, result);
+            }
+
+            return result;
         }
 
         private async Task<HttpOperationResponse<string>> SendMessageToListOfUsersWithRetryAsync(IActivity activity, List<object> teamsMembers, string tenantId, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
@@ -663,185 +860,6 @@ namespace Microsoft.Bot.Connector.Teams
                 {
                     // 400: when request payload validation fails.
                     // 401: if the bot token is invalid. 
-                    // 403: if bot does not have permission to post messages within Tenant.
-
-                    // invalid/unexpected status code
-                    var ex = new HttpOperationException($"Operation returned an invalid status code '{statusCode}'");
-                    if (httpResponse.Content != null)
-                    {
-                        responseContent = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    }
-                    else
-                    {
-                        responseContent = string.Empty;
-                    }
-
-                    ex.Request = new HttpRequestMessageWrapper(httpRequest, requestContent);
-                    ex.Response = new HttpResponseMessageWrapper(httpResponse, responseContent);
-                    if (shouldTrace)
-                    {
-                        ServiceClientTracing.Error(invocationId, ex);
-                    }
-
-                    throw ex;
-                }
-            }
-            finally
-            {
-                if (httpResponse != null)
-                {
-                    httpResponse.Dispose();
-                }
-            }
-
-            if (shouldTrace)
-            {
-                ServiceClientTracing.Exit(invocationId, result);
-            }
-
-            return result;
-        }
-
-        /// <summary>
-        /// Send a message to all the users in a tenant.
-        /// </summary>
-        /// <param name="activity"> The activity to send. </param>
-        /// <param name="tenantId"> The tenant ID. </param>
-        /// <param name="customHeaders"> Headers that will be added to request. </param>
-        /// <param name='cancellationToken'> The cancellation token.  </param>
-        /// <exception cref="HttpOperationException">
-        /// Thrown when the operation returned an invalid status code.
-        /// </exception>
-        /// <exception cref="ValidationException">
-        /// Thrown when an input value does not match the expected data type, range or pattern.
-        /// </exception>
-        /// <returns>
-        /// A response object containing the operation id.
-        /// </returns>
-        public async Task<HttpOperationResponse<string>> SendMessageToAllUsersInTenantAsync(IActivity activity, string tenantId, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            if (activity == null)
-            {
-                throw new ValidationException(ValidationRules.CannotBeNull, nameof(activity));
-            }
-
-            if (string.IsNullOrEmpty(tenantId))
-            {
-                throw new ValidationException(ValidationRules.CannotBeNull, nameof(tenantId));
-            }
-
-            // Tracing
-            var shouldTrace = ServiceClientTracing.IsEnabled;
-            string invocationId = null;
-            if (shouldTrace)
-            {
-                invocationId = ServiceClientTracing.NextInvocationId.ToString(CultureInfo.InvariantCulture);
-                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
-                tracingParameters.Add("activity", activity);
-                tracingParameters.Add("tenantId", tenantId);
-                tracingParameters.Add("cancellationToken", cancellationToken);
-                ServiceClientTracing.Enter(invocationId, this, "SendMessageToAllUsersInTenant", tracingParameters);
-            }
-
-            // Construct URL
-            var baseUrl = Client.BaseUri.AbsoluteUri;
-            var url = new System.Uri(new System.Uri(baseUrl + (baseUrl.EndsWith("/", System.StringComparison.InvariantCulture) ? string.Empty : "/")), "v3/batch/conversation/tenant/").ToString();
-            using var httpRequest = new HttpRequestMessage();
-            httpRequest.Method = new HttpMethod("POST");
-            httpRequest.RequestUri = new System.Uri(url);
-
-            HttpResponseMessage httpResponse = null;
-
-            // Create HTTP transport objects
-#pragma warning disable CA2000 // Dispose objects before losing scope
-            var result = new HttpOperationResponse<string>();
-#pragma warning restore CA2000 // Dispose objects before losing scope
-            try
-            {
-                // Set Headers
-                if (customHeaders != null)
-                {
-                    foreach (var header in customHeaders)
-                    {
-                        if (httpRequest.Headers.Contains(header.Key))
-                        {
-                            httpRequest.Headers.Remove(header.Key);
-                        }
-
-                        httpRequest.Headers.TryAddWithoutValidation(header.Key, header.Value);
-                    }
-                }
-
-                var content = new
-                {
-                    Activity = activity,
-                    TenantId = tenantId,
-                };
-
-                // Serialize Request
-                string requestContent = null;
-
-                if (activity != null)
-                {
-                    requestContent = Rest.Serialization.SafeJsonConvert.SerializeObject(content);
-                    httpRequest.Content = new StringContent(requestContent, System.Text.Encoding.UTF8);
-                    httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; charset=utf-8");
-                }
-
-                // Set Credentials
-                if (Client.Credentials != null)
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    await Client.Credentials.ProcessHttpRequestAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-                }
-
-                // Send Request
-                if (shouldTrace)
-                {
-                    ServiceClientTracing.SendRequest(invocationId, httpRequest);
-                }
-
-                cancellationToken.ThrowIfCancellationRequested();
-                httpResponse = await Client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-                if (shouldTrace)
-                {
-                    ServiceClientTracing.ReceiveResponse(invocationId, httpResponse);
-                }
-
-                HttpStatusCode statusCode = httpResponse.StatusCode;
-                cancellationToken.ThrowIfCancellationRequested();
-                string responseContent = null;
-
-                // Create Result
-                result.Request = httpRequest;
-                result.Response = httpResponse;
-
-                if ((int)statusCode == 201)
-                {
-                    // 201: created
-                    try
-                    {
-                        responseContent = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                        result.Body = responseContent;
-                    }
-                    catch (JsonException ex)
-                    {
-                        if (shouldTrace)
-                        {
-                            ServiceClientTracing.Error(invocationId, ex);
-                        }
-
-                        throw new SerializationException("Unable to deserialize the response.", responseContent, ex);
-                    }
-                }
-                else if ((int)statusCode == 429)
-                {
-                    //TODO: implement retry logic.
-                }
-                else
-                {
-                    // 400: when request payload validation fails.
-                    // 401: if the bot token is invalid 
                     // 403: if bot does not have permission to post messages within Tenant.
 
                     // invalid/unexpected status code

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
@@ -563,6 +563,48 @@ namespace Microsoft.Bot.Connector.Teams
             return result;            
         }
 
+        /// <summary>
+        /// Send a message to all the users in a team.
+        /// </summary>
+        /// <param name="activity"> The activity to send. </param>
+        /// <param name="teamId"> The team ID. </param>
+        /// <param name="tenantId"> The tenant ID. </param>
+        /// <param name="customHeaders"> Headers that will be added to request. </param>
+        /// <param name='cancellationToken'> The cancellation token.  </param>
+        /// <exception cref="HttpOperationException">
+        /// Thrown when the operation returned an invalid status code.
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when an input value does not match the expected data type, range or pattern.
+        /// </exception>
+        /// <returns>
+        /// A response object containing the operation id.
+        /// </returns>
+        public async Task<HttpOperationResponse<string>> SendMessageToAllUsersInTeamAsync(IActivity activity, string teamId, string tenantId, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (activity == null)
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, nameof(activity));
+            }
+
+            if (string.IsNullOrEmpty(teamId))
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, nameof(teamId));
+            }
+
+            if (string.IsNullOrEmpty(tenantId))
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, nameof(tenantId));
+            }
+
+            // In case of throttling, it will retry the operation with default values (10 retries every 50 miliseconds).
+            var result = await RetryAction.RunAsync(
+                task: () => SendMessageToAllUsersInTeamWithRetryAsync(activity, teamId, tenantId, customHeaders, cancellationToken),
+                retryExceptionHandler: (ex, ct) => HandleThrottlingException(ex, ct)).ConfigureAwait(false);
+
+            return result;
+        }
+
         private static RetryParams HandleThrottlingException(Exception ex, int currentRetryCount)
         {
             if (ex is ThrottleException throttlException)
@@ -861,6 +903,170 @@ namespace Microsoft.Bot.Connector.Teams
                     // 400: when request payload validation fails.
                     // 401: if the bot token is invalid. 
                     // 403: if bot does not have permission to post messages within Tenant.
+
+                    // invalid/unexpected status code
+                    var ex = new HttpOperationException($"Operation returned an invalid status code '{statusCode}'");
+                    if (httpResponse.Content != null)
+                    {
+                        responseContent = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        responseContent = string.Empty;
+                    }
+
+                    ex.Request = new HttpRequestMessageWrapper(httpRequest, requestContent);
+                    ex.Response = new HttpResponseMessageWrapper(httpResponse, responseContent);
+                    if (shouldTrace)
+                    {
+                        ServiceClientTracing.Error(invocationId, ex);
+                    }
+
+                    throw ex;
+                }
+            }
+            finally
+            {
+                if (httpResponse != null)
+                {
+                    httpResponse.Dispose();
+                }
+            }
+
+            if (shouldTrace)
+            {
+                ServiceClientTracing.Exit(invocationId, result);
+            }
+
+            return result;
+        }
+
+        private async Task<HttpOperationResponse<string>> SendMessageToAllUsersInTeamWithRetryAsync(IActivity activity, string teamId, string tenantId, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            // Tracing
+            var shouldTrace = ServiceClientTracing.IsEnabled;
+            string invocationId = null;
+            if (shouldTrace)
+            {
+                invocationId = ServiceClientTracing.NextInvocationId.ToString(CultureInfo.InvariantCulture);
+                var tracingParameters = new Dictionary<string, object>();
+                tracingParameters.Add("activity", activity);
+                tracingParameters.Add("teamId", teamId);
+                tracingParameters.Add("tenantId", tenantId);
+                tracingParameters.Add("cancellationToken", cancellationToken);
+                ServiceClientTracing.Enter(invocationId, this, "SendMessageToAllUsersInTenant", tracingParameters);
+            }
+
+            // Construct URL
+            var baseUrl = Client.BaseUri.AbsoluteUri;
+            var url = new System.Uri(new System.Uri(baseUrl + (baseUrl.EndsWith("/", System.StringComparison.InvariantCulture) ? string.Empty : "/")), "v3/batch/conversation/team/").ToString();
+            using var httpRequest = new HttpRequestMessage();
+            httpRequest.Method = new HttpMethod("POST");
+            httpRequest.RequestUri = new System.Uri(url);
+
+            HttpResponseMessage httpResponse = null;
+
+            // Create HTTP transport objects
+#pragma warning disable CA2000 // Dispose objects before losing scope
+            var result = new HttpOperationResponse<string>();
+#pragma warning restore CA2000 // Dispose objects before losing scope
+            try
+            {
+                // Set Headers
+                if (customHeaders != null)
+                {
+                    foreach (var header in customHeaders)
+                    {
+                        if (httpRequest.Headers.Contains(header.Key))
+                        {
+                            httpRequest.Headers.Remove(header.Key);
+                        }
+
+                        httpRequest.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                    }
+                }
+
+                var content = new
+                {
+                    Activity = activity,
+                    teamId = teamId,
+                    TenantId = tenantId,
+                };
+
+                // Serialize Request
+                string requestContent = null;
+
+                if (activity != null)
+                {
+                    requestContent = Rest.Serialization.SafeJsonConvert.SerializeObject(content);
+                    httpRequest.Content = new StringContent(requestContent, System.Text.Encoding.UTF8);
+                    httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; charset=utf-8");
+                }
+
+                // Set Credentials
+                if (Client.Credentials != null)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await Client.Credentials.ProcessHttpRequestAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+                }
+
+                // Send Request
+                if (shouldTrace)
+                {
+                    ServiceClientTracing.SendRequest(invocationId, httpRequest);
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+                httpResponse = await Client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+                if (shouldTrace)
+                {
+                    ServiceClientTracing.ReceiveResponse(invocationId, httpResponse);
+                }
+
+                HttpStatusCode statusCode = httpResponse.StatusCode;
+                cancellationToken.ThrowIfCancellationRequested();
+                string responseContent = null;
+
+                // Create Result
+                result.Request = httpRequest;
+                result.Response = httpResponse;
+
+                if ((int)statusCode == 201)
+                {
+                    // 201: created
+                    try
+                    {
+                        responseContent = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                        result.Body = responseContent;
+                    }
+                    catch (JsonException ex)
+                    {
+                        if (shouldTrace)
+                        {
+                            ServiceClientTracing.Error(invocationId, ex);
+                        }
+
+                        throw new SerializationException("Unable to deserialize the response.", responseContent, ex);
+                    }
+                    finally
+                    {
+                        // This means the request was successfull. We can make our retry policy null.
+                        if (currentRetryPolicy != null)
+                        {
+                            currentRetryPolicy = null;
+                        }
+                    }
+                }
+                else if ((int)statusCode == 429)
+                {
+                    throw new ThrottleException() { RetryParams = currentRetryPolicy };
+                }
+                else
+                {
+                    // 400: when request payload validation fails.
+                    // 401: if the bot token is invalid 
+                    // 403: if bot does not have permission to post messages within Tenant.
+                    // 404: when Team is not found.
 
                     // invalid/unexpected status code
                     var ex = new HttpOperationException($"Operation returned an invalid status code '{statusCode}'");

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
@@ -668,6 +668,186 @@ namespace Microsoft.Bot.Connector.Teams
             return result;
         }
 
+        /// <summary>
+        /// Send a message to all the users in a tenant.
+        /// </summary>
+        /// <param name="activity"> The activity to send. </param>
+        /// <param name="tenantId"> The tenant ID. </param>
+        /// <param name="customHeaders"> Headers that will be added to request. </param>
+        /// <param name='cancellationToken'> The cancellation token.  </param>
+        /// <exception cref="HttpOperationException">
+        /// Thrown when the operation returned an invalid status code.
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when an input value does not match the expected data type, range or pattern.
+        /// </exception>
+        /// <returns>
+        /// A response object containing the operation id.
+        /// </returns>
+        public async Task<HttpOperationResponse<string>> SendMessageToAllUsersInTenantAsync(IActivity activity, string tenantId, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (activity == null)
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, nameof(activity));
+            }
+
+            if (string.IsNullOrEmpty(tenantId))
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, nameof(tenantId));
+            }
+
+            // Tracing
+            var shouldTrace = ServiceClientTracing.IsEnabled;
+            string invocationId = null;
+            if (shouldTrace)
+            {
+                invocationId = ServiceClientTracing.NextInvocationId.ToString(CultureInfo.InvariantCulture);
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
+                tracingParameters.Add("activity", activity);
+                tracingParameters.Add("tenantId", tenantId);
+                tracingParameters.Add("cancellationToken", cancellationToken);
+                ServiceClientTracing.Enter(invocationId, this, "SendMessageToAllUsersInTenant", tracingParameters);
+            }
+
+            // Construct URL
+            var baseUrl = Client.BaseUri.AbsoluteUri;
+            var url = new System.Uri(new System.Uri(baseUrl + (baseUrl.EndsWith("/", System.StringComparison.InvariantCulture) ? string.Empty : "/")), "v3/batch/conversation/tenant/").ToString();
+            using var httpRequest = new HttpRequestMessage();
+            httpRequest.Method = new HttpMethod("POST");
+            httpRequest.RequestUri = new System.Uri(url);
+
+            HttpResponseMessage httpResponse = null;
+
+            // Create HTTP transport objects
+#pragma warning disable CA2000 // Dispose objects before losing scope
+            var result = new HttpOperationResponse<string>();
+#pragma warning restore CA2000 // Dispose objects before losing scope
+            try
+            {
+                // Set Headers
+                if (customHeaders != null)
+                {
+                    foreach (var header in customHeaders)
+                    {
+                        if (httpRequest.Headers.Contains(header.Key))
+                        {
+                            httpRequest.Headers.Remove(header.Key);
+                        }
+
+                        httpRequest.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                    }
+                }
+
+                var content = new
+                {
+                    Activity = activity,
+                    TenantId = tenantId,
+                };
+
+                // Serialize Request
+                string requestContent = null;
+
+                if (activity != null)
+                {
+                    requestContent = Rest.Serialization.SafeJsonConvert.SerializeObject(content);
+                    httpRequest.Content = new StringContent(requestContent, System.Text.Encoding.UTF8);
+                    httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; charset=utf-8");
+                }
+
+                // Set Credentials
+                if (Client.Credentials != null)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await Client.Credentials.ProcessHttpRequestAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+                }
+
+                // Send Request
+                if (shouldTrace)
+                {
+                    ServiceClientTracing.SendRequest(invocationId, httpRequest);
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+                httpResponse = await Client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+                if (shouldTrace)
+                {
+                    ServiceClientTracing.ReceiveResponse(invocationId, httpResponse);
+                }
+
+                HttpStatusCode statusCode = httpResponse.StatusCode;
+                cancellationToken.ThrowIfCancellationRequested();
+                string responseContent = null;
+
+                // Create Result
+                result.Request = httpRequest;
+                result.Response = httpResponse;
+
+                if ((int)statusCode == 201)
+                {
+                    // 201: created
+                    try
+                    {
+                        responseContent = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                        result.Body = responseContent;
+                    }
+                    catch (JsonException ex)
+                    {
+                        if (shouldTrace)
+                        {
+                            ServiceClientTracing.Error(invocationId, ex);
+                        }
+
+                        throw new SerializationException("Unable to deserialize the response.", responseContent, ex);
+                    }
+                }
+                else if ((int)statusCode == 429)
+                {
+                    //TODO: implement retry logic.
+                }
+                else
+                {
+                    // 400: when request payload validation fails.
+                    // 401: if the bot token is invalid 
+                    // 403: if bot does not have permission to post messages within Tenant.
+                    // 404: when Team is not found.
+
+                    // invalid/unexpected status code
+                    var ex = new HttpOperationException($"Operation returned an invalid status code '{statusCode}'");
+                    if (httpResponse.Content != null)
+                    {
+                        responseContent = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        responseContent = string.Empty;
+                    }
+
+                    ex.Request = new HttpRequestMessageWrapper(httpRequest, requestContent);
+                    ex.Response = new HttpResponseMessageWrapper(httpResponse, responseContent);
+                    if (shouldTrace)
+                    {
+                        ServiceClientTracing.Error(invocationId, ex);
+                    }
+
+                    throw ex;
+                }
+            }
+            finally
+            {
+                if (httpResponse != null)
+                {
+                    httpResponse.Dispose();
+                }
+            }
+
+            if (shouldTrace)
+            {
+                ServiceClientTracing.Exit(invocationId, result);
+            }
+
+            return result;
+        }
+
         private async Task<HttpOperationResponse<T>> GetResponseAsync<T>(string url, bool shouldTrace, string invocationId, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             // Create HTTP transport objects

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Bot.Connector.Teams
     using System.Globalization;
     using System.Net;
     using System.Net.Http;
+    using System.Net.Http.Headers;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Bot.Connector.Authentication;
@@ -634,10 +635,10 @@ namespace Microsoft.Bot.Connector.Teams
 
             // Construct URL
             var baseUrl = Client.BaseUri.AbsoluteUri;
-            var url = new System.Uri(new System.Uri(baseUrl + (baseUrl.EndsWith("/", System.StringComparison.InvariantCulture) ? string.Empty : "/")), "v3/batch/conversation/tenant/").ToString();
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/", StringComparison.InvariantCulture) ? string.Empty : "/")), "v3/batch/conversation/tenant/").ToString();
             using var httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
-            httpRequest.RequestUri = new System.Uri(url);
+            httpRequest.RequestUri = new Uri(url);
 
             HttpResponseMessage httpResponse = null;
 
@@ -674,7 +675,7 @@ namespace Microsoft.Bot.Connector.Teams
                 {
                     requestContent = Rest.Serialization.SafeJsonConvert.SerializeObject(content);
                     httpRequest.Content = new StringContent(requestContent, System.Text.Encoding.UTF8);
-                    httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; charset=utf-8");
+                    httpRequest.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json; charset=utf-8");
                 }
 
                 // Set Credentials
@@ -837,7 +838,7 @@ namespace Microsoft.Bot.Connector.Teams
                 {
                     requestContent = Rest.Serialization.SafeJsonConvert.SerializeObject(content);
                     httpRequest.Content = new StringContent(requestContent, System.Text.Encoding.UTF8);
-                    httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; charset=utf-8");
+                    httpRequest.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json; charset=utf-8");
                 }
 
                 // Set Credentials
@@ -959,10 +960,10 @@ namespace Microsoft.Bot.Connector.Teams
 
             // Construct URL
             var baseUrl = Client.BaseUri.AbsoluteUri;
-            var url = new System.Uri(new System.Uri(baseUrl + (baseUrl.EndsWith("/", System.StringComparison.InvariantCulture) ? string.Empty : "/")), "v3/batch/conversation/team/").ToString();
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/", StringComparison.InvariantCulture) ? string.Empty : "/")), "v3/batch/conversation/team/").ToString();
             using var httpRequest = new HttpRequestMessage();
             httpRequest.Method = new HttpMethod("POST");
-            httpRequest.RequestUri = new System.Uri(url);
+            httpRequest.RequestUri = new Uri(url);
 
             HttpResponseMessage httpResponse = null;
 
@@ -989,7 +990,7 @@ namespace Microsoft.Bot.Connector.Teams
                 var content = new
                 {
                     Activity = activity,
-                    teamId = teamId,
+                    TeamId = teamId,
                     TenantId = tenantId,
                 };
 
@@ -1000,7 +1001,7 @@ namespace Microsoft.Bot.Connector.Teams
                 {
                     requestContent = Rest.Serialization.SafeJsonConvert.SerializeObject(content);
                     httpRequest.Content = new StringContent(requestContent, System.Text.Encoding.UTF8);
-                    httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; charset=utf-8");
+                    httpRequest.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json; charset=utf-8");
                 }
 
                 // Set Credentials

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
@@ -809,7 +809,6 @@ namespace Microsoft.Bot.Connector.Teams
                     // 400: when request payload validation fails.
                     // 401: if the bot token is invalid 
                     // 403: if bot does not have permission to post messages within Tenant.
-                    // 404: when Team is not found.
 
                     // invalid/unexpected status code
                     var ex = new HttpOperationException($"Operation returned an invalid status code '{statusCode}'");

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Bot.Connector.Teams
     using System.Globalization;
     using System.Net;
     using System.Net.Http;
-    using System.Net.Http.Headers;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Bot.Connector.Authentication;
@@ -675,7 +674,7 @@ namespace Microsoft.Bot.Connector.Teams
                 {
                     requestContent = Rest.Serialization.SafeJsonConvert.SerializeObject(content);
                     httpRequest.Content = new StringContent(requestContent, System.Text.Encoding.UTF8);
-                    httpRequest.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json; charset=utf-8");
+                    httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; charset=utf-8");
                 }
 
                 // Set Credentials
@@ -838,7 +837,7 @@ namespace Microsoft.Bot.Connector.Teams
                 {
                     requestContent = Rest.Serialization.SafeJsonConvert.SerializeObject(content);
                     httpRequest.Content = new StringContent(requestContent, System.Text.Encoding.UTF8);
-                    httpRequest.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json; charset=utf-8");
+                    httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; charset=utf-8");
                 }
 
                 // Set Credentials
@@ -955,7 +954,7 @@ namespace Microsoft.Bot.Connector.Teams
                 tracingParameters.Add("teamId", teamId);
                 tracingParameters.Add("tenantId", tenantId);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                ServiceClientTracing.Enter(invocationId, this, "SendMessageToAllUsersInTenant", tracingParameters);
+                ServiceClientTracing.Enter(invocationId, this, "SendMessageToAllUsersInTeam", tracingParameters);
             }
 
             // Construct URL
@@ -1001,7 +1000,7 @@ namespace Microsoft.Bot.Connector.Teams
                 {
                     requestContent = Rest.Serialization.SafeJsonConvert.SerializeObject(content);
                     httpRequest.Content = new StringContent(requestContent, System.Text.Encoding.UTF8);
-                    httpRequest.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json; charset=utf-8");
+                    httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; charset=utf-8");
                 }
 
                 // Set Credentials

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
@@ -627,9 +627,9 @@ namespace Microsoft.Bot.Connector.Teams
                 }
                 else
                 {
-                    // 400: when request payload validation fails. For instance, 
+                    // 400: when request payload validation fails.
                     // 401: if the bot token is invalid 
-                    // 403: if the bot is not allowed to send messages.
+                    // 403: if bot does not have permission to post messages within Tenant.
 
                     // invalid/unexpected status code
                     var ex = new HttpOperationException($"Operation returned an invalid status code '{statusCode}'");

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperationsExtensions.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperationsExtensions.cs
@@ -179,5 +179,36 @@ namespace Microsoft.Bot.Connector.Teams
                 throw new InvalidOperationException("TeamsOperations with SendMessageToListOfUsersAsync is required for SendMessageToListOfUsersAsync.");
             }
         }
+
+        /// <summary>
+        /// Sends a message to all the users in a tenant.
+        /// </summary>
+        /// <param name='operations'>
+        /// The operations group for this extension method.
+        /// </param>
+        /// <param name='activity'>
+        /// The activity to send.
+        /// </param>
+        /// <param name='tenantId'>
+        /// The tenant ID.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        /// <returns>The operation Id.</returns>
+        public static async Task<string> SendMessageToAllUsersInTenantAsync(this ITeamsOperations operations, IActivity activity, string tenantId, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (operations is TeamsOperations teamsOperations)
+            {
+                using (var result = await teamsOperations.SendMessageToAllUsersInTenantAsync(activity, tenantId, null, cancellationToken).ConfigureAwait(false))
+                {
+                    return result.Body;
+                }
+            }
+            else
+            {
+                throw new InvalidOperationException("TeamsOperations with SendMessageToAllUsersInTenantAsync is required for SendMessageToAllUsersInTenantAsync.");
+            }
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperationsExtensions.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperationsExtensions.cs
@@ -210,5 +210,39 @@ namespace Microsoft.Bot.Connector.Teams
                 throw new InvalidOperationException("TeamsOperations with SendMessageToAllUsersInTenantAsync is required for SendMessageToAllUsersInTenantAsync.");
             }
         }
+
+        /// <summary>
+        /// Sends a message to all the users in a team.
+        /// </summary>
+        /// <param name='operations'>
+        /// The operations group for this extension method.
+        /// </param>
+        /// <param name='activity'>
+        /// The activity to send.
+        /// </param>
+        /// <param name='teamId'>
+        /// The team ID.
+        /// </param>
+        /// <param name='tenantId'>
+        /// The tenant ID.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        /// <returns>The operation Id.</returns>
+        public static async Task<string> SendMessageToAllUsersInTeamAsync(this ITeamsOperations operations, IActivity activity, string teamId, string tenantId, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (operations is TeamsOperations teamsOperations)
+            {
+                using (var result = await teamsOperations.SendMessageToAllUsersInTeamAsync(activity, teamId, tenantId, null, cancellationToken).ConfigureAwait(false))
+                {
+                    return result.Body;
+                }
+            }
+            else
+            {
+                throw new InvalidOperationException("TeamsOperations with SendMessageToAllUsersInTeamAsync is required for SendMessageToAllUsersInTeamAsync.");
+            }
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperationsExtensions.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperationsExtensions.cs
@@ -4,8 +4,10 @@
 namespace Microsoft.Bot.Connector.Teams
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Bot.Schema;
     using Microsoft.Bot.Schema.Teams;
 
     /// <summary>
@@ -141,6 +143,40 @@ namespace Microsoft.Bot.Connector.Teams
             else
             {
                 throw new InvalidOperationException("TeamsOperations with SendMeetingNotificationWithHttpMessagesAsync is required for SendMeetingNotificationAsync.");
+            }
+        }
+
+        /// <summary>
+        /// Sends a message to a list of Teams users.
+        /// </summary>
+        /// <param name='operations'>
+        /// The operations group for this extension method.
+        /// </param>
+        /// <param name='activity'>
+        /// The activity to send.
+        /// </param>
+        /// <param name='teamsMembers'>
+        /// The list of members recipients for the message.
+        /// </param>
+        /// <param name='tenantId'>
+        /// The tenant ID.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        /// <returns>The operation Id.</returns>
+        public static async Task<string> SendMessageToListOfUsersAsync(this ITeamsOperations operations, IActivity activity, List<object> teamsMembers, string tenantId, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (operations is TeamsOperations teamsOperations)
+            {
+                using (var result = await teamsOperations.SendMessageToListOfUsersAsync(activity, teamsMembers, tenantId, null, cancellationToken).ConfigureAwait(false))
+                {
+                    return result.Body;
+                }
+            }
+            else
+            {
+                throw new InvalidOperationException("TeamsOperations with SendMessageToListOfUsersAsync is required for SendMessageToListOfUsersAsync.");
             }
         }
     }

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsInfoTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsInfoTests.cs
@@ -457,7 +457,6 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             // 201: created
             // 400: when send message to list of users request payload validation fails.
             // 403: if the bot is not allowed to send messages.
-            // 404: when Team is not found.
             // 429: too many requests for throttled requests.
 
             var baseUri = new Uri("https://test.coffee");
@@ -471,6 +470,48 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             {
                 Type = "message",
                 Text = "Test-SendMessageToAllUsersInTenantAsync",
+                ChannelId = Channels.Msteams,
+                ServiceUrl = "https://test.coffee",
+                From = new ChannelAccount()
+                {
+                    Id = "id-1",
+
+                    // Hack for test. use the Name field to pass expected status code to test code
+                    Name = statusCode
+                },
+                Conversation = new ConversationAccount() { Id = "conversation-id" }
+            };
+
+            var turnContext = new TurnContext(new SimpleAdapter(), activity);
+            turnContext.TurnState.Add<IConnectorClient>(connectorClient);
+            var handler = new TestTeamsActivityHandler();
+            await handler.OnTurnAsync(turnContext);
+        }
+
+        [Theory]
+        [InlineData("201")]
+        [InlineData("400")]
+        [InlineData("403")]
+        [InlineData("404")]
+        [InlineData("429")]
+        public async Task TestSendMessageToAllUsersInTeamAsync(string statusCode)
+        {
+            // 201: created
+            // 400: when send message to list of users request payload validation fails.
+            // 403: if the bot is not allowed to send messages.
+            // 429: too many requests for throttled requests.
+
+            var baseUri = new Uri("https://test.coffee");
+            var customHttpClient = new HttpClient(new RosterHttpMessageHandler());
+
+            // Set a special base address so then we can make sure the connector client is honoring this http client
+            customHttpClient.BaseAddress = baseUri;
+            var connectorClient = new ConnectorClient(new Uri("http://localhost/"), new MicrosoftAppCredentials(string.Empty, string.Empty), customHttpClient);
+
+            var activity = new Activity
+            {
+                Type = "message",
+                Text = "Test-SendMessageToAllUsersInTeamAsync",
                 ChannelId = Channels.Msteams,
                 ServiceUrl = "https://test.coffee",
                 From = new ChannelAccount()
@@ -529,6 +570,9 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                         break;
                     case "Test-SendMessageToAllUsersInTenantAsync":
                         await CallSendMessageToAllUsersInTenantAsync(turnContext);
+                        break;
+                    case "Test-SendMessageToAllUsersInTeamAsync":
+                        await CallSendMessageToAllUsersInTeamAsync(turnContext);
                         break;
                     default:
                         Assert.True(false);
@@ -825,6 +869,60 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                     }
                 }
             }
+
+            private async Task CallSendMessageToAllUsersInTeamAsync(ITurnContext turnContext)
+            {
+                var from = turnContext.Activity.From;
+                var teamId = "team-id";
+                var tenantId = "tenant-id";
+
+                try
+                {
+                    var operationId = await TeamsInfo.SendMessageToAllUsersInTeamAsync(turnContext, turnContext.Activity, teamId, tenantId).ConfigureAwait(false);
+
+                    switch (from.Name)
+                    {
+                        case "201":
+                            Assert.Equal("operation-1", operationId);
+                            break;
+                        default:
+                            throw new InvalidOperationException($"Expected {nameof(HttpOperationException)} with response status code {from.Name}.");
+                    }
+                }
+                catch (AggregateException ex)
+                {
+                    var firstException = ex.InnerExceptions.First();
+                    var httpException = new HttpOperationException();
+                    var errorResponse = new ErrorResponse();
+
+                    switch (from.Name)
+                    {
+                        case "400":
+                            Assert.Single(ex.InnerExceptions);
+                            httpException = (HttpOperationException)firstException;
+                            errorResponse = JsonConvert.DeserializeObject<ErrorResponse>(httpException.Response.Content.ToString());
+                            Assert.Equal("BadSyntax", errorResponse.Error.Code);
+                            break;
+                        case "403":
+                            Assert.Single(ex.InnerExceptions);
+                            httpException = (HttpOperationException)firstException;
+                            errorResponse = JsonConvert.DeserializeObject<ErrorResponse>(httpException.Response.Content.ToString());
+                            Assert.Equal("Forbidden", errorResponse.Error.Code);
+                            break;
+                        case "404":
+                            Assert.Single(ex.InnerExceptions);
+                            httpException = (HttpOperationException)firstException;
+                            errorResponse = JsonConvert.DeserializeObject<ErrorResponse>(httpException.Response.Content.ToString());
+                            Assert.Equal("NotFound", errorResponse.Error.Code);
+                            break;
+                        case "429":
+                            Assert.Equal(11, ex.InnerExceptions.Count);
+                            break;
+                        default:
+                            throw new InvalidOperationException($"Expected {nameof(HttpOperationException)} with response status code {from.Name}.");
+                    }
+                }
+            }
         }
 
         private class RosterHttpMessageHandler : HttpMessageHandler
@@ -1065,6 +1163,42 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                         case "403":
                             response.Content = new StringContent("{\"error\":{\"code\":\"Forbidden\"}}");
                             response.StatusCode = HttpStatusCode.Forbidden;
+                            break;
+                        case "429":
+                            response.Content = new StringContent("{\"error\":{\"code\":\"TooManyRequests\"}}");
+                            response.StatusCode = HttpStatusCode.TooManyRequests;
+                            break;
+                        default:
+                            response.StatusCode = HttpStatusCode.Accepted;
+                            break;
+                    }
+                }
+
+                // SendMessageToAllUsersInTeam
+                else if (request.RequestUri.PathAndQuery.EndsWith("v3/batch/conversation/team/"))
+                {
+                    var requestBody = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var payload = JObject.Parse(requestBody);
+                    var requestActivity = payload.SelectToken("Activity").ToObject<Activity>();
+
+                    // hack From.Name as expected status code, for testing
+                    switch (requestActivity.From.Name)
+                    {
+                        case "201":
+                            response.Content = new StringContent("operation-1");
+                            response.StatusCode = HttpStatusCode.Created;
+                            break;
+                        case "400":
+                            response.Content = new StringContent("{\"error\":{\"code\":\"BadSyntax\"}}");
+                            response.StatusCode = HttpStatusCode.BadRequest;
+                            break;
+                        case "403":
+                            response.Content = new StringContent("{\"error\":{\"code\":\"Forbidden\"}}");
+                            response.StatusCode = HttpStatusCode.Forbidden;
+                            break;
+                        case "404":
+                            response.Content = new StringContent("{\"error\":{\"code\":\"NotFound\"}}");
+                            response.StatusCode = HttpStatusCode.NotFound;
                             break;
                         case "429":
                             response.Content = new StringContent("{\"error\":{\"code\":\"TooManyRequests\"}}");

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsInfoTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsInfoTests.cs
@@ -451,12 +451,14 @@ namespace Microsoft.Bot.Builder.Teams.Tests
         [InlineData("201")]
         [InlineData("400")]
         [InlineData("403")]
+        [InlineData("429")]
         public async Task TestSendMessageToAllUsersInTenantAsync(string statusCode)
         {
             // 201: created
             // 400: when send message to list of users request payload validation fails.
             // 403: if the bot is not allowed to send messages.
-            // 404: when Team is not found..
+            // 404: when Team is not found.
+            // 429: too many requests for throttled requests.
 
             var baseUri = new Uri("https://test.coffee");
             var customHttpClient = new HttpClient(new RosterHttpMessageHandler());
@@ -795,21 +797,28 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                             throw new InvalidOperationException($"Expected {nameof(HttpOperationException)} with response status code {from.Name}.");
                     }
                 }
-                catch (HttpOperationException ex)
+                catch (AggregateException ex)
                 {
-                    Assert.Equal(from.Name, ((int)ex.Response.StatusCode).ToString());
-                    var errorResponse = JsonConvert.DeserializeObject<ErrorResponse>(ex.Response.Content);
+                    var firstException = ex.InnerExceptions.First();
+                    var httpException = new HttpOperationException();
+                    var errorResponse = new ErrorResponse();
 
                     switch (from.Name)
                     {
                         case "400":
+                            Assert.Single(ex.InnerExceptions);
+                            httpException = (HttpOperationException)firstException;
+                            errorResponse = JsonConvert.DeserializeObject<ErrorResponse>(httpException.Response.Content.ToString());
                             Assert.Equal("BadSyntax", errorResponse.Error.Code);
                             break;
                         case "403":
+                            Assert.Single(ex.InnerExceptions);
+                            httpException = (HttpOperationException)firstException;
+                            errorResponse = JsonConvert.DeserializeObject<ErrorResponse>(httpException.Response.Content.ToString());
                             Assert.Equal("Forbidden", errorResponse.Error.Code);
                             break;
-                        case "404":
-                            Assert.Equal("NotFound", errorResponse.Error.Code);
+                        case "429":
+                            Assert.Equal(11, ex.InnerExceptions.Count);
                             break;
                         default:
                             throw new InvalidOperationException($"Expected {nameof(HttpOperationException)} with response status code {from.Name}.");
@@ -1056,6 +1065,10 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                         case "403":
                             response.Content = new StringContent("{\"error\":{\"code\":\"Forbidden\"}}");
                             response.StatusCode = HttpStatusCode.Forbidden;
+                            break;
+                        case "429":
+                            response.Content = new StringContent("{\"error\":{\"code\":\"TooManyRequests\"}}");
+                            response.StatusCode = HttpStatusCode.TooManyRequests;
                             break;
                         default:
                             response.StatusCode = HttpStatusCode.Accepted;

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsInfoTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsInfoTests.cs
@@ -449,7 +449,6 @@ namespace Microsoft.Bot.Builder.Teams.Tests
         [InlineData("201")]
         [InlineData("400")]
         [InlineData("403")]
-        [InlineData("404")]
         public async Task TestSendMessageToAllUsersInTenantAsync(string statusCode)
         {
             // 201: created
@@ -1041,10 +1040,6 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                         case "403":
                             response.Content = new StringContent("{\"error\":{\"code\":\"Forbidden\"}}");
                             response.StatusCode = HttpStatusCode.Forbidden;
-                            break;
-                        case "404":
-                            response.Content = new StringContent("{\"error\":{\"code\":\"NotFound\"}}");
-                            response.StatusCode = HttpStatusCode.NotFound;
                             break;
                         default:
                             response.StatusCode = HttpStatusCode.Accepted;

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsInfoTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsInfoTests.cs
@@ -499,6 +499,7 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             // 201: created
             // 400: when send message to list of users request payload validation fails.
             // 403: if the bot is not allowed to send messages.
+            // 404: when Team is not found.
             // 429: too many requests for throttled requests.
 
             var baseUri = new Uri("https://test.coffee");


### PR DESCRIPTION
#minor

## Description
This PR implements the SendMessageToAllUsersInTeam method of the new Teams batch APIs in TeamsOperations.

- [x] Send message to a list of users
- [x] Send message to all users    in a tenant
- [x] Send message to all users in a team
- [ ] Send message to a list of channels  
- [ ] Get Operation State
- [ ] Get failed entries paginated
- [ ] Cancel Operation

## Specific Changes
- Implemented the new methods of **_SendMessageToAllUsersInTeam_** in **_TeamsOperations_**, **_TeamsOperationsExtensions_**, and **_TeamsInfo_**.