### PR TITLE
Implementation of SendMessageToListOfChannels Teams batch APIs

### DIFF
--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
@@ -378,6 +378,27 @@ namespace Microsoft.Bot.Builder.Teams
             }
         }
 
+        /// <summary>
+        /// Sends a message to the provided list of Teams channels.
+        /// </summary>
+        /// <param name="turnContext"> Turn context. </param>
+        /// <param name="activity"> The activity to send. </param>
+        /// <param name="channelsMembers"> The list of channels. </param>
+        /// <param name="tenantId"> The tenant ID. </param>
+        /// <param name="cancellationToken"> The cancellation token. </param>
+        /// <returns>The operation Id.</returns>
+        public static async Task<string> SendMessageToListOfChannelsAsync(ITurnContext turnContext, IActivity activity, List<object> channelsMembers, string tenantId, CancellationToken cancellationToken = default)
+        {
+            activity = activity ?? throw new InvalidOperationException($"{nameof(activity)} is required.");
+            channelsMembers = channelsMembers ?? throw new InvalidOperationException($"{nameof(channelsMembers)} is required.");
+            tenantId = tenantId ?? throw new InvalidOperationException($"{nameof(tenantId)} is required.");
+
+            using (var teamsClient = GetTeamsConnectorClient(turnContext))
+            {
+                return await teamsClient.Teams.SendMessageToListOfChannelsAsync(activity, channelsMembers, tenantId, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
         private static async Task<IEnumerable<TeamsChannelAccount>> GetMembersAsync(IConnectorClient connectorClient, string conversationId, CancellationToken cancellationToken)
         {
             if (conversationId == null)

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
@@ -724,7 +724,7 @@ namespace Microsoft.Bot.Connector.Teams
                     }
                     finally
                     {
-                        // This means the request was successfull. We can make our retry policy null.
+                        // This means the request was successful. We can make our retry policy null.
                         if (currentRetryPolicy != null)
                         {
                             currentRetryPolicy = null;
@@ -887,7 +887,7 @@ namespace Microsoft.Bot.Connector.Teams
                     }
                     finally
                     {
-                        // This means the request was successfull. We can make our retry policy null.
+                        // This means the request was successful. We can make our retry policy null.
                         if (currentRetryPolicy != null)
                         {
                             currentRetryPolicy = null;
@@ -1050,7 +1050,7 @@ namespace Microsoft.Bot.Connector.Teams
                     }
                     finally
                     {
-                        // This means the request was successfull. We can make our retry policy null.
+                        // This means the request was successful. We can make our retry policy null.
                         if (currentRetryPolicy != null)
                         {
                             currentRetryPolicy = null;

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
@@ -954,7 +954,7 @@ namespace Microsoft.Bot.Connector.Teams
                 tracingParameters.Add("channelsMembers", channelsMembers);
                 tracingParameters.Add("tenantId", tenantId);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                ServiceClientTracing.Enter(invocationId, this, "SendMessageToListOfUsers", tracingParameters);
+                ServiceClientTracing.Enter(invocationId, this, "SendMessageToListOfChannels", tracingParameters);
             }
 
             // Construct URL

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
@@ -563,6 +563,48 @@ namespace Microsoft.Bot.Connector.Teams
             return result;            
         }
 
+        /// <summary>
+        /// Send a message to a list of Teams channels.
+        /// </summary>
+        /// <param name="activity"> The activity to send. </param>
+        /// <param name="channelsMembers"> The list of channels. </param>
+        /// <param name="tenantId"> The tenant ID. </param>
+        /// <param name="customHeaders"> Headers that will be added to request. </param>
+        /// <param name='cancellationToken'> The cancellation token.  </param>
+        /// <exception cref="HttpOperationException">
+        /// Thrown when the operation returned an invalid status code.
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when an input value does not match the expected data type, range or pattern.
+        /// </exception>
+        /// <returns>
+        /// A response object containing the operation id.
+        /// </returns>
+        public async Task<HttpOperationResponse<string>> SendMessageToListOfChannelsAsync(IActivity activity, List<object> channelsMembers, string tenantId, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (activity == null)
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, nameof(activity));
+            }
+
+            if (channelsMembers.Count == 0)
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, nameof(channelsMembers));
+            }
+
+            if (string.IsNullOrEmpty(tenantId))
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, nameof(tenantId));
+            }
+
+            // In case of throttling, it will retry the operation with default values (10 retries every 50 miliseconds).
+            var result = await RetryAction.RunAsync(
+                task: () => SendMessageToListOfChannelsWithRetryAsync(activity, channelsMembers, tenantId, customHeaders, cancellationToken),
+                retryExceptionHandler: (ex, ct) => HandleThrottlingException(ex, ct)).ConfigureAwait(false);
+
+            return result;
+        }
+
         private static RetryParams HandleThrottlingException(Exception ex, int currentRetryCount)
         {
             if (ex is ThrottleException throttlException)
@@ -784,6 +826,169 @@ namespace Microsoft.Bot.Connector.Teams
                 var content = new
                 {
                     Members = teamsMembers,
+                    Activity = activity,
+                    TenantId = tenantId,
+                };
+
+                // Serialize Request
+                string requestContent = null;
+
+                if (activity != null)
+                {
+                    requestContent = Rest.Serialization.SafeJsonConvert.SerializeObject(content);
+                    httpRequest.Content = new StringContent(requestContent, System.Text.Encoding.UTF8);
+                    httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; charset=utf-8");
+                }
+
+                // Set Credentials
+                if (Client.Credentials != null)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await Client.Credentials.ProcessHttpRequestAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+                }
+
+                // Send Request
+                if (shouldTrace)
+                {
+                    ServiceClientTracing.SendRequest(invocationId, httpRequest);
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+                httpResponse = await Client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+                if (shouldTrace)
+                {
+                    ServiceClientTracing.ReceiveResponse(invocationId, httpResponse);
+                }
+
+                var statusCode = httpResponse.StatusCode;
+                cancellationToken.ThrowIfCancellationRequested();
+                string responseContent = null;
+
+                // Create Result
+                result.Request = httpRequest;
+                result.Response = httpResponse;
+
+                if ((int)statusCode == 201)
+                {
+                    // 201: created
+                    try
+                    {
+                        responseContent = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                        result.Body = responseContent;
+                    }
+                    catch (JsonException ex)
+                    {
+                        if (shouldTrace)
+                        {
+                            ServiceClientTracing.Error(invocationId, ex);
+                        }
+
+                        throw new SerializationException("Unable to deserialize the response.", responseContent, ex);
+                    }
+                    finally
+                    {
+                        // This means the request was successfull. We can make our retry policy null.
+                        if (currentRetryPolicy != null)
+                        {
+                            currentRetryPolicy = null;
+                        }
+                    }
+                }
+                else if ((int)statusCode == 429)
+                {
+                    throw new ThrottleException() { RetryParams = currentRetryPolicy };
+                }
+                else
+                {
+                    // 400: when request payload validation fails.
+                    // 401: if the bot token is invalid. 
+                    // 403: if bot does not have permission to post messages within Tenant.
+
+                    // invalid/unexpected status code
+                    var ex = new HttpOperationException($"Operation returned an invalid status code '{statusCode}'");
+                    if (httpResponse.Content != null)
+                    {
+                        responseContent = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        responseContent = string.Empty;
+                    }
+
+                    ex.Request = new HttpRequestMessageWrapper(httpRequest, requestContent);
+                    ex.Response = new HttpResponseMessageWrapper(httpResponse, responseContent);
+                    if (shouldTrace)
+                    {
+                        ServiceClientTracing.Error(invocationId, ex);
+                    }
+
+                    throw ex;
+                }
+            }
+            finally
+            {
+                if (httpResponse != null)
+                {
+                    httpResponse.Dispose();
+                }
+            }
+
+            if (shouldTrace)
+            {
+                ServiceClientTracing.Exit(invocationId, result);
+            }
+
+            return result;
+        }
+
+        private async Task<HttpOperationResponse<string>> SendMessageToListOfChannelsWithRetryAsync(IActivity activity, List<object> channelsMembers, string tenantId, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            // Tracing
+            var shouldTrace = ServiceClientTracing.IsEnabled;
+            string invocationId = null;
+            if (shouldTrace)
+            {
+                invocationId = ServiceClientTracing.NextInvocationId.ToString(CultureInfo.InvariantCulture);
+                var tracingParameters = new Dictionary<string, object>();
+                tracingParameters.Add("activity", activity);
+                tracingParameters.Add("channelsMembers", channelsMembers);
+                tracingParameters.Add("tenantId", tenantId);
+                tracingParameters.Add("cancellationToken", cancellationToken);
+                ServiceClientTracing.Enter(invocationId, this, "SendMessageToListOfUsers", tracingParameters);
+            }
+
+            // Construct URL
+            var baseUrl = Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/", StringComparison.InvariantCulture) ? string.Empty : "/")), "v3/batch/conversation/channels/").ToString();
+            using var httpRequest = new HttpRequestMessage();
+            httpRequest.Method = new HttpMethod("POST");
+            httpRequest.RequestUri = new Uri(url);
+
+            HttpResponseMessage httpResponse = null;
+
+            // Create HTTP transport objects
+#pragma warning disable CA2000 // Dispose objects before losing scope
+            var result = new HttpOperationResponse<string>();
+#pragma warning restore CA2000 // Dispose objects before losing scope
+            try
+            {
+                // Set Headers
+                if (customHeaders != null)
+                {
+                    foreach (var header in customHeaders)
+                    {
+                        if (httpRequest.Headers.Contains(header.Key))
+                        {
+                            httpRequest.Headers.Remove(header.Key);
+                        }
+
+                        httpRequest.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                    }
+                }
+
+                var content = new
+                {
+                    Members = channelsMembers,
                     Activity = activity,
                     TenantId = tenantId,
                 };

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperationsExtensions.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperationsExtensions.cs
@@ -210,5 +210,39 @@ namespace Microsoft.Bot.Connector.Teams
                 throw new InvalidOperationException("TeamsOperations with SendMessageToAllUsersInTenantAsync is required for SendMessageToAllUsersInTenantAsync.");
             }
         }
+
+        /// <summary>
+        /// Sends a message to a list of Teams channels.
+        /// </summary>
+        /// <param name='operations'>
+        /// The operations group for this extension method.
+        /// </param>
+        /// <param name='activity'>
+        /// The activity to send.
+        /// </param>
+        /// <param name='channelsMembers'>
+        /// The list of channels for the message.
+        /// </param>
+        /// <param name='tenantId'>
+        /// The tenant ID.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        /// <returns>The operation Id.</returns>
+        public static async Task<string> SendMessageToListOfChannelsAsync(this ITeamsOperations operations, IActivity activity, List<object> channelsMembers, string tenantId, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (operations is TeamsOperations teamsOperations)
+            {
+                using (var result = await teamsOperations.SendMessageToListOfChannelsAsync(activity, channelsMembers, tenantId, null, cancellationToken).ConfigureAwait(false))
+                {
+                    return result.Body;
+                }
+            }
+            else
+            {
+                throw new InvalidOperationException("TeamsOperations with SendMessageToListOfChannelsAsync is required for SendMessageToListOfChannelsAsync.");
+            }
+        }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsInfoTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsInfoTests.cs
@@ -489,6 +489,47 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             await handler.OnTurnAsync(turnContext);
         }
 
+        [Theory]
+        [InlineData("201")]
+        [InlineData("400")]
+        [InlineData("403")]
+        [InlineData("429")]
+        public async Task TestSendMessageToListOfChannelsAsync(string statusCode)
+        {
+            // 201: created
+            // 400: when send message to list of users request payload validation fails.
+            // 403: if the bot is not allowed to send messages.
+            // 429: too many requests for throttled requests.
+
+            var baseUri = new Uri("https://test.coffee");
+            var customHttpClient = new HttpClient(new RosterHttpMessageHandler());
+
+            // Set a special base address so then we can make sure the connector client is honoring this http client
+            customHttpClient.BaseAddress = baseUri;
+            var connectorClient = new ConnectorClient(new Uri("http://localhost/"), new MicrosoftAppCredentials(string.Empty, string.Empty), customHttpClient);
+
+            var activity = new Activity
+            {
+                Type = "message",
+                Text = "Test-SendMessageToListOfChannelsAsync",
+                ChannelId = Channels.Msteams,
+                ServiceUrl = "https://test.coffee",
+                From = new ChannelAccount()
+                {
+                    Id = "id-1",
+
+                    // Hack for test. use the Name field to pass expected status code to test code
+                    Name = statusCode
+                },
+                Conversation = new ConversationAccount() { Id = "conversation-id" }
+            };
+
+            var turnContext = new TurnContext(new SimpleAdapter(), activity);
+            turnContext.TurnState.Add<IConnectorClient>(connectorClient);
+            var handler = new TestTeamsActivityHandler();
+            await handler.OnTurnAsync(turnContext);
+        }
+
         private class TestTeamsActivityHandler : TeamsActivityHandler
         {
             public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default)
@@ -529,6 +570,9 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                         break;
                     case "Test-SendMessageToAllUsersInTenantAsync":
                         await CallSendMessageToAllUsersInTenantAsync(turnContext);
+                        break;
+                    case "Test-SendMessageToListOfChannelsAsync":
+                        await CallSendMessageToListOfUsersAsync(turnContext);
                         break;
                     default:
                         Assert.True(false);
@@ -825,6 +869,59 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                     }
                 }
             }
+
+            private async Task CallSendMessageToListOfChannelsAsync(ITurnContext turnContext)
+            {
+                var from = turnContext.Activity.From;
+                var members = new List<object>()
+                {
+                    new { Id = "channel-1" },
+                    new { Id = "channel-2" },
+                    new { Id = "channel-3" },
+                };
+                var tenantId = "tenant-id";
+
+                try
+                {
+                    var operationId = await TeamsInfo.SendMessageToListOfChannelsAsync(turnContext, turnContext.Activity, members, tenantId).ConfigureAwait(false);
+
+                    switch (from.Name)
+                    {
+                        case "201":
+                            Assert.Equal("operation-1", operationId);
+                            break;
+                        default:
+                            throw new InvalidOperationException($"Expected {nameof(HttpOperationException)} with response status code {from.Name}.");
+                    }
+                }
+                catch (AggregateException ex)
+                {
+                    var firstException = ex.InnerExceptions.First();
+                    var httpException = new HttpOperationException();
+                    var errorResponse = new ErrorResponse();
+
+                    switch (from.Name)
+                    {
+                        case "400":
+                            Assert.Single(ex.InnerExceptions);
+                            httpException = (HttpOperationException)firstException;
+                            errorResponse = JsonConvert.DeserializeObject<ErrorResponse>(httpException.Response.Content.ToString());
+                            Assert.Equal("BadSyntax", errorResponse.Error.Code);
+                            break;
+                        case "403":
+                            Assert.Single(ex.InnerExceptions);
+                            httpException = (HttpOperationException)firstException;
+                            errorResponse = JsonConvert.DeserializeObject<ErrorResponse>(httpException.Response.Content.ToString());
+                            Assert.Equal("Forbidden", errorResponse.Error.Code);
+                            break;
+                        case "429":
+                            Assert.Equal(11, ex.InnerExceptions.Count);
+                            break;
+                        default:
+                            throw new InvalidOperationException($"Expected {nameof(HttpOperationException)} with response status code {from.Name}.");
+                    }
+                }
+            }
         }
 
         private class RosterHttpMessageHandler : HttpMessageHandler
@@ -1046,6 +1143,38 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                 
                 // SendMessageToAllUsersInTenant
                 else if (request.RequestUri.PathAndQuery.EndsWith("v3/batch/conversation/tenant/"))
+                {
+                    var requestBody = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var payload = JObject.Parse(requestBody);
+                    var requestActivity = payload.SelectToken("Activity").ToObject<Activity>();
+
+                    // hack From.Name as expected status code, for testing
+                    switch (requestActivity.From.Name)
+                    {
+                        case "201":
+                            response.Content = new StringContent("operation-1");
+                            response.StatusCode = HttpStatusCode.Created;
+                            break;
+                        case "400":
+                            response.Content = new StringContent("{\"error\":{\"code\":\"BadSyntax\"}}");
+                            response.StatusCode = HttpStatusCode.BadRequest;
+                            break;
+                        case "403":
+                            response.Content = new StringContent("{\"error\":{\"code\":\"Forbidden\"}}");
+                            response.StatusCode = HttpStatusCode.Forbidden;
+                            break;
+                        case "429":
+                            response.Content = new StringContent("{\"error\":{\"code\":\"TooManyRequests\"}}");
+                            response.StatusCode = HttpStatusCode.TooManyRequests;
+                            break;
+                        default:
+                            response.StatusCode = HttpStatusCode.Accepted;
+                            break;
+                    }
+                }
+
+                // SendMessageToAllUsersInTenant
+                else if (request.RequestUri.PathAndQuery.EndsWith("v3/batch/conversation/channels/"))
                 {
                     var requestBody = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
                     var payload = JObject.Parse(requestBody);

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsInfoTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsInfoTests.cs
@@ -497,7 +497,7 @@ namespace Microsoft.Bot.Builder.Teams.Tests
         public async Task TestSendMessageToListOfChannelsAsync(string statusCode)
         {
             // 201: created
-            // 400: when send message to list of users request payload validation fails.
+            // 400: when send message to list of channels request payload validation fails.
             // 403: if the bot is not allowed to send messages.
             // 429: too many requests for throttled requests.
 
@@ -572,7 +572,7 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                         await CallSendMessageToAllUsersInTenantAsync(turnContext);
                         break;
                     case "Test-SendMessageToListOfChannelsAsync":
-                        await CallSendMessageToListOfUsersAsync(turnContext);
+                        await CallSendMessageToListOfChannelsAsync(turnContext);
                         break;
                     default:
                         Assert.True(false);
@@ -1173,7 +1173,7 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                     }
                 }
 
-                // SendMessageToAllUsersInTenant
+                // SendMessageToListOfChannels
                 else if (request.RequestUri.PathAndQuery.EndsWith("v3/batch/conversation/channels/"))
                 {
                     var requestBody = await request.Content.ReadAsStringAsync().ConfigureAwait(false);


### PR DESCRIPTION
#minor

## Description
This PR implements the SendMessageToListOfChannels method of the new Teams batch APIs in TeamsOperations.

- [x] Send message to a list of users
- [x] Send message to all users    in a tenant
- [x] Send message to all users in a team
- [x] Send message to a list of channels  
- [ ] Get Operation State
- [ ] Get failed entries paginated
- [ ] Cancel Operation

## Specific Changes
- Implemented the new methods of **_SendMessageToListOfChannels_** in **_TeamsOperations_**, **_TeamsOperationsExtensions_**, and **_TeamsInfo_**.