### PR TITLE
Implementation of GetOperationState Teams batch APIs

### DIFF
--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
@@ -378,6 +378,23 @@ namespace Microsoft.Bot.Builder.Teams
             }
         }
 
+        /// <summary>
+        /// Gets the state of a operation.
+        /// </summary>
+        /// <param name="turnContext"> Turn context. </param>
+        /// <param name="operationId"> The operationId to get the state. </param>
+        /// <param name="cancellationToken"> The cancellation token. </param>
+        /// <returns>The state and responses of the operation.</returns>
+        public static async Task<string> GetOperationStateAsync(ITurnContext turnContext, string operationId, CancellationToken cancellationToken = default)
+        {
+            operationId = operationId ?? throw new InvalidOperationException($"{nameof(operationId)} is required.");
+
+            using (var teamsClient = GetTeamsConnectorClient(turnContext))
+            {
+                return await teamsClient.Teams.GetOperationStateAsync(operationId, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
         private static async Task<IEnumerable<TeamsChannelAccount>> GetMembersAsync(IConnectorClient connectorClient, string conversationId, CancellationToken cancellationToken)
         {
             if (conversationId == null)

--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
@@ -379,13 +379,13 @@ namespace Microsoft.Bot.Builder.Teams
         }
 
         /// <summary>
-        /// Gets the state of a operation.
+        /// Gets the state of an operation.
         /// </summary>
         /// <param name="turnContext"> Turn context. </param>
-        /// <param name="operationId"> The operationId to get the state. </param>
+        /// <param name="operationId"> The operationId to get the state of. </param>
         /// <param name="cancellationToken"> The cancellation token. </param>
         /// <returns>The state and responses of the operation.</returns>
-        public static async Task<string> GetOperationStateAsync(ITurnContext turnContext, string operationId, CancellationToken cancellationToken = default)
+        public static async Task<BatchOperationState> GetOperationStateAsync(ITurnContext turnContext, string operationId, CancellationToken cancellationToken = default)
         {
             operationId = operationId ?? throw new InvalidOperationException($"{nameof(operationId)} is required.");
 

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
@@ -563,6 +563,36 @@ namespace Microsoft.Bot.Connector.Teams
             return result;            
         }
 
+        /// <summary>
+        /// Gets the state of a operation.
+        /// </summary>
+        /// <param name="operationId"> The operationId to get the state. </param>
+        /// <param name="customHeaders"> Headers that will be added to request. </param>
+        /// <param name='cancellationToken'> The cancellation token.  </param>
+        /// <exception cref="HttpOperationException">
+        /// Thrown when the operation returned an invalid status code.
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when an input value does not match the expected data type, range or pattern.
+        /// </exception>
+        /// <returns>
+        /// A response object containing the state and responses of the operation.
+        /// </returns>
+        public async Task<HttpOperationResponse<string>> GetOperationStateAsync(string operationId, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (string.IsNullOrEmpty(operationId))
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, nameof(operationId));
+            }
+
+            // In case of throttling, it will retry the operation with default values (10 retries every 50 miliseconds).
+            var result = await RetryAction.RunAsync(
+                task: () => GetOperationStateWithRetryAsync(operationId, customHeaders, cancellationToken),
+                retryExceptionHandler: (ex, ct) => HandleThrottlingException(ex, ct)).ConfigureAwait(false);
+
+            return result;
+        }
+
         private static RetryParams HandleThrottlingException(Exception ex, int currentRetryCount)
         {
             if (ex is ThrottleException throttlException)
@@ -874,6 +904,148 @@ namespace Microsoft.Bot.Connector.Teams
                     }
 
                     ex.Request = new HttpRequestMessageWrapper(httpRequest, requestContent);
+                    ex.Response = new HttpResponseMessageWrapper(httpResponse, responseContent);
+                    if (shouldTrace)
+                    {
+                        ServiceClientTracing.Error(invocationId, ex);
+                    }
+
+                    throw ex;
+                }
+            }
+            finally
+            {
+                if (httpResponse != null)
+                {
+                    httpResponse.Dispose();
+                }
+            }
+
+            if (shouldTrace)
+            {
+                ServiceClientTracing.Exit(invocationId, result);
+            }
+
+            return result;
+        }
+
+        private async Task<HttpOperationResponse<string>> GetOperationStateWithRetryAsync(string operationId, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            // Tracing
+            var shouldTrace = ServiceClientTracing.IsEnabled;
+            string invocationId = null;
+            if (shouldTrace)
+            {
+                invocationId = ServiceClientTracing.NextInvocationId.ToString(CultureInfo.InvariantCulture);
+                var tracingParameters = new Dictionary<string, object>();
+                tracingParameters.Add("operationId", operationId);
+                tracingParameters.Add("cancellationToken", cancellationToken);
+                ServiceClientTracing.Enter(invocationId, this, "GetOperationState", tracingParameters);
+            }
+
+            // Construct URL
+            var baseUrl = Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/", StringComparison.InvariantCulture) ? string.Empty : "/")), "v3/batch/conversation/" + operationId).ToString();
+            using var httpRequest = new HttpRequestMessage();
+            httpRequest.Method = new HttpMethod("GET");
+            httpRequest.RequestUri = new Uri(url);
+
+            HttpResponseMessage httpResponse = null;
+
+            // Create HTTP transport objects
+#pragma warning disable CA2000 // Dispose objects before losing scope
+            var result = new HttpOperationResponse<string>();
+#pragma warning restore CA2000 // Dispose objects before losing scope
+            try
+            {
+                // Set Headers
+                if (customHeaders != null)
+                {
+                    foreach (var header in customHeaders)
+                    {
+                        if (httpRequest.Headers.Contains(header.Key))
+                        {
+                            httpRequest.Headers.Remove(header.Key);
+                        }
+
+                        httpRequest.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                    }
+                }
+
+                // Set Credentials
+                if (Client.Credentials != null)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await Client.Credentials.ProcessHttpRequestAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+                }
+
+                // Send Request
+                if (shouldTrace)
+                {
+                    ServiceClientTracing.SendRequest(invocationId, httpRequest);
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+                httpResponse = await Client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+                if (shouldTrace)
+                {
+                    ServiceClientTracing.ReceiveResponse(invocationId, httpResponse);
+                }
+
+                var statusCode = httpResponse.StatusCode;
+                cancellationToken.ThrowIfCancellationRequested();
+                string responseContent = null;
+
+                // Create Result
+                result.Request = httpRequest;
+                result.Response = httpResponse;
+
+                if ((int)statusCode == 200)
+                {
+                    // 200: OK
+                    try
+                    {
+                        responseContent = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                        result.Body = responseContent;
+                    }
+                    catch (JsonException ex)
+                    {
+                        if (shouldTrace)
+                        {
+                            ServiceClientTracing.Error(invocationId, ex);
+                        }
+
+                        throw new SerializationException("Unable to deserialize the response.", responseContent, ex);
+                    }
+                    finally
+                    {
+                        // This means the request was successfull. We can make our retry policy null.
+                        if (currentRetryPolicy != null)
+                        {
+                            currentRetryPolicy = null;
+                        }
+                    }
+                }
+                else if ((int)statusCode == 429)
+                {
+                    throw new ThrottleException() { RetryParams = currentRetryPolicy };
+                }
+                else
+                {
+                    // 400: for requests with invalid operationId (Which should be of type GUID)
+
+                    // invalid/unexpected status code
+                    var ex = new HttpOperationException($"Operation returned an invalid status code '{statusCode}'");
+                    if (httpResponse.Content != null)
+                    {
+                        responseContent = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        responseContent = string.Empty;
+                    }
+
+                    ex.Request = new HttpRequestMessageWrapper(httpRequest, operationId);
                     ex.Response = new HttpResponseMessageWrapper(httpResponse, responseContent);
                     if (shouldTrace)
                     {

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
@@ -1021,7 +1021,7 @@ namespace Microsoft.Bot.Connector.Teams
                     }
                     finally
                     {
-                        // This means the request was successfull. We can make our retry policy null.
+                        // This means the request was successful. We can make our retry policy null.
                         if (currentRetryPolicy != null)
                         {
                             currentRetryPolicy = null;

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperationsExtensions.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperationsExtensions.cs
@@ -210,5 +210,33 @@ namespace Microsoft.Bot.Connector.Teams
                 throw new InvalidOperationException("TeamsOperations with SendMessageToAllUsersInTenantAsync is required for SendMessageToAllUsersInTenantAsync.");
             }
         }
+
+        /// <summary>
+        /// Gets the state of a operation.
+        /// </summary>
+        /// <param name='operations'>
+        /// The operations group for this extension method.
+        /// </param>
+        /// <param name='operationId'>
+        /// The operationId to get the state.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        /// <returns>The state and responses of the operation.</returns>
+        public static async Task<string> GetOperationStateAsync(this ITeamsOperations operations,  string operationId, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (operations is TeamsOperations teamsOperations)
+            {
+                using (var result = await teamsOperations.GetOperationStateAsync(operationId, null, cancellationToken).ConfigureAwait(false))
+                {
+                    return result.Body;
+                }
+            }
+            else
+            {
+                throw new InvalidOperationException("TeamsOperations with GetOperationStateAsync is required for GetOperationStateAsync.");
+            }
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperationsExtensions.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperationsExtensions.cs
@@ -212,19 +212,19 @@ namespace Microsoft.Bot.Connector.Teams
         }
 
         /// <summary>
-        /// Gets the state of a operation.
+        /// Gets the state of an operation.
         /// </summary>
         /// <param name='operations'>
         /// The operations group for this extension method.
         /// </param>
         /// <param name='operationId'>
-        /// The operationId to get the state.
+        /// The operationId to get the state of.
         /// </param>
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
         /// <returns>The state and responses of the operation.</returns>
-        public static async Task<string> GetOperationStateAsync(this ITeamsOperations operations,  string operationId, CancellationToken cancellationToken = default(CancellationToken))
+        public static async Task<BatchOperationState> GetOperationStateAsync(this ITeamsOperations operations,  string operationId, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (operations is TeamsOperations teamsOperations)
             {

--- a/libraries/Microsoft.Bot.Schema/Teams/BatchOperationResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/BatchOperationResponse.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Bot.Schema.Teams
+{
+    /// <summary>
+    /// Object representing the operation state reponse.
+    /// </summary>
+    public class BatchOperationResponse
+    {
+        /// <summary>
+        /// Gets the status map of the operation.
+        /// </summary>
+        /// <value>
+        /// The status map for processed users.
+        /// </value>
+        [JsonProperty(PropertyName = "statusMap")]
+        public IDictionary<string, int> StatusMap { get; } = new Dictionary<string, int>();
+    }
+}

--- a/libraries/Microsoft.Bot.Schema/Teams/BatchOperationState.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/BatchOperationState.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Schema.Teams
+{
+    /// <summary>
+    /// Object representing operation state.
+    /// </summary>
+    public class BatchOperationState
+    {
+        /// <summary>
+        /// Gets or sets the operation state.
+        /// </summary>
+        /// <value>
+        /// The operation state.
+        /// </value>
+        [JsonProperty(PropertyName = "state")]
+        public string State { get; set; }
+
+        /// <summary>
+        /// Gets or sets the operation state response.
+        /// </summary>
+        /// <value>
+        /// The operation state response.
+        /// </value>
+        [JsonProperty(PropertyName = "response")]
+        public BatchOperationResponse Response { get; set; }
+
+        /// <summary>
+        /// Gets or sets the total number of entries.
+        /// </summary>
+        /// <value>
+        /// The number of entries.
+        /// </value>
+        [JsonProperty(PropertyName = "totalEntriesCount")]
+        public int TotalEntriesCount { get; set; }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsInfoTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsInfoTests.cs
@@ -1161,10 +1161,10 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                 // GetOperationState
                 else if (request.RequestUri.PathAndQuery.Contains("v3/batch/conversation/operation-id") && request.Method.ToString() == "GET")
                 {
+                    // get status from url for testing
                     var uri = request.RequestUri.PathAndQuery;
                     var status = uri.Substring(uri.IndexOf("*") + 1); 
 
-                    // hack From.Name as expected status code, for testing
                     switch (status)
                     {
                         case "200":


### PR DESCRIPTION
#minor

## Description
This PR implements the GetOperationState method of the new Teams batch APIs in TeamsOperations.

- [x] Send message to a list of users
- [x] Send message to all users    in a tenant
- [x] Send message to all users in a team
- [x] Send message to a list of channels  
- [x] Get Operation State
- [ ] Get failed entries paginated
- [ ] Cancel Operation

## Specific Changes
- Implemented the new methods of **_GetOperationStatet_** in **_TeamsOperations_**, **_TeamsOperationsExtensions_**, and **_TeamsInfo_**.