### PR TITLE
Implementation of CancelOperation Teams batch APIs

### DIFF
--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
@@ -379,19 +379,19 @@ namespace Microsoft.Bot.Builder.Teams
         }
 
         /// <summary>
-        /// Cancels the proccess of an operation.
+        /// Cancels the process of an operation.
         /// </summary>
         /// <param name="turnContext"> Turn context. </param>
-        /// <param name="operationId"> The operationId of the operation to cancel. </param>
+        /// <param name="operationId"> The id of the operation to cancel. </param>
         /// <param name="cancellationToken"> The cancellation token. </param>
         /// <returns>The state and responses of the operation.</returns>
-        public static async Task<string> CancelOperationAsync(ITurnContext turnContext, string operationId, CancellationToken cancellationToken = default)
+        public static async Task CancelOperationAsync(ITurnContext turnContext, string operationId, CancellationToken cancellationToken = default)
         {
             operationId = operationId ?? throw new InvalidOperationException($"{nameof(operationId)} is required.");
 
             using (var teamsClient = GetTeamsConnectorClient(turnContext))
             {
-                return await teamsClient.Teams.CancelOperationAsync(operationId, cancellationToken).ConfigureAwait(false);
+                await teamsClient.Teams.CancelOperationAsync(operationId, cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
@@ -437,7 +437,6 @@ namespace Microsoft.Bot.Builder.Teams
             }
         }
 
-
         /// <summary>
         /// Cancels the process of an operation.
         /// </summary>

--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
@@ -378,6 +378,23 @@ namespace Microsoft.Bot.Builder.Teams
             }
         }
 
+        /// <summary>
+        /// Cancels the proccess of an operation.
+        /// </summary>
+        /// <param name="turnContext"> Turn context. </param>
+        /// <param name="operationId"> The operationId of the operation to cancel. </param>
+        /// <param name="cancellationToken"> The cancellation token. </param>
+        /// <returns>The state and responses of the operation.</returns>
+        public static async Task<string> CancelOperationAsync(ITurnContext turnContext, string operationId, CancellationToken cancellationToken = default)
+        {
+            operationId = operationId ?? throw new InvalidOperationException($"{nameof(operationId)} is required.");
+
+            using (var teamsClient = GetTeamsConnectorClient(turnContext))
+            {
+                return await teamsClient.Teams.CancelOperationAsync(operationId, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
         private static async Task<IEnumerable<TeamsChannelAccount>> GetMembersAsync(IConnectorClient connectorClient, string conversationId, CancellationToken cancellationToken)
         {
             if (conversationId == null)

--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
@@ -460,7 +460,7 @@ namespace Microsoft.Bot.Builder.Teams
         /// <param name="turnContext"> Turn context. </param>
         /// <param name="operationId"> The id of the operation to cancel. </param>
         /// <param name="cancellationToken"> The cancellation token. </param>
-        /// <returns>The response state code.</returns>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public static async Task CancelOperationAsync(ITurnContext turnContext, string operationId, CancellationToken cancellationToken = default)
         {
             operationId = operationId ?? throw new InvalidOperationException($"{nameof(operationId)} is required.");

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
@@ -720,7 +720,7 @@ namespace Microsoft.Bot.Connector.Teams
         /// Thrown when an input value does not match the expected data type, range or pattern.
         /// </exception>
         /// <returns>
-        /// The response state code.
+        /// A <see cref="Task"/> representing the asynchronous operation.
         /// </returns>
         public async Task<HttpOperationResponse> CancelOperationAsync(string operationId, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
@@ -563,6 +563,36 @@ namespace Microsoft.Bot.Connector.Teams
             return result;            
         }
 
+        /// <summary>
+        /// Cancels the proccess of an operation.
+        /// </summary>
+        /// <param name="operationId"> The operationId of the operation to cancel. </param>
+        /// <param name="customHeaders"> Headers that will be added to request. </param>
+        /// <param name='cancellationToken'> The cancellation token. </param>
+        /// <exception cref="HttpOperationException">
+        /// Thrown when the operation returned an invalid status code.
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when an input value does not match the expected data type, range or pattern.
+        /// </exception>
+        /// <returns>
+        /// A response object containing the state and responses of the operation.
+        /// </returns>
+        public async Task<HttpOperationResponse<string>> CancelOperationAsync(string operationId, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (string.IsNullOrEmpty(operationId))
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, nameof(operationId));
+            }
+
+            // In case of throttling, it will retry the operation with default values (10 retries every 50 miliseconds).
+            var result = await RetryAction.RunAsync(
+                task: () => CancelOperationWithRetryAsync(operationId, customHeaders, cancellationToken),
+                retryExceptionHandler: (ex, ct) => HandleThrottlingException(ex, ct)).ConfigureAwait(false);
+
+            return result;
+        }
+
         private static RetryParams HandleThrottlingException(Exception ex, int currentRetryCount)
         {
             if (ex is ThrottleException throttlException)
@@ -874,6 +904,150 @@ namespace Microsoft.Bot.Connector.Teams
                     }
 
                     ex.Request = new HttpRequestMessageWrapper(httpRequest, requestContent);
+                    ex.Response = new HttpResponseMessageWrapper(httpResponse, responseContent);
+                    if (shouldTrace)
+                    {
+                        ServiceClientTracing.Error(invocationId, ex);
+                    }
+
+                    throw ex;
+                }
+            }
+            finally
+            {
+                if (httpResponse != null)
+                {
+                    httpResponse.Dispose();
+                }
+            }
+
+            if (shouldTrace)
+            {
+                ServiceClientTracing.Exit(invocationId, result);
+            }
+
+            return result;
+        }
+
+        private async Task<HttpOperationResponse<string>> CancelOperationWithRetryAsync(string operationId, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            // Tracing
+            var shouldTrace = ServiceClientTracing.IsEnabled;
+            string invocationId = null;
+            if (shouldTrace)
+            {
+                invocationId = ServiceClientTracing.NextInvocationId.ToString(CultureInfo.InvariantCulture);
+                var tracingParameters = new Dictionary<string, object>();
+                tracingParameters.Add("operationId", operationId);
+                tracingParameters.Add("cancellationToken", cancellationToken);
+                ServiceClientTracing.Enter(invocationId, this, "CancelOperation", tracingParameters);
+            }
+
+            // Construct URL
+            var baseUrl = Client.BaseUri.AbsoluteUri;
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/", StringComparison.InvariantCulture) ? string.Empty : "/")), "v3/batch/conversation/{operationId}").ToString();
+            url = url.Replace("{operationId}", System.Uri.EscapeDataString(operationId));
+            using var httpRequest = new HttpRequestMessage();
+            httpRequest.Method = new HttpMethod("DELETE");
+            httpRequest.RequestUri = new Uri(url);
+
+            HttpResponseMessage httpResponse = null;
+
+            // Create HTTP transport objects
+#pragma warning disable CA2000 // Dispose objects before losing scope
+            var result = new HttpOperationResponse<string>();
+#pragma warning restore CA2000 // Dispose objects before losing scope
+            try
+            {
+                // Set Headers
+                if (customHeaders != null)
+                {
+                    foreach (var header in customHeaders)
+                    {
+                        if (httpRequest.Headers.Contains(header.Key))
+                        {
+                            httpRequest.Headers.Remove(header.Key);
+                        }
+
+                        httpRequest.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                    }
+                }
+
+                // Set Credentials
+                if (Client.Credentials != null)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await Client.Credentials.ProcessHttpRequestAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+                }
+
+                // Send Request
+                if (shouldTrace)
+                {
+                    ServiceClientTracing.SendRequest(invocationId, httpRequest);
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+                httpResponse = await Client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+                if (shouldTrace)
+                {
+                    ServiceClientTracing.ReceiveResponse(invocationId, httpResponse);
+                }
+
+                var statusCode = httpResponse.StatusCode;
+                cancellationToken.ThrowIfCancellationRequested();
+                string responseContent = null;
+
+                // Create Result
+                result.Request = httpRequest;
+                result.Response = httpResponse;
+
+                if ((int)statusCode == 200)
+                {
+                    // 200: OK for successful cancelled operations (Operations in state completed, or failed will not change state to cancel but still return 200)
+
+                    responseContent = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    try
+                    {
+                        result.Body = Rest.Serialization.SafeJsonConvert.DeserializeObject<string>(responseContent, Client.DeserializationSettings);
+                    }
+                    catch (JsonException ex)
+                    {
+                        if (shouldTrace)
+                        {
+                            ServiceClientTracing.Error(invocationId, ex);
+                        }
+
+                        throw new SerializationException("Unable to deserialize the response.", responseContent, ex);
+                    }
+                    finally
+                    {
+                        // This means the request was successful. We can make our retry policy null.
+                        if (currentRetryPolicy != null)
+                        {
+                            currentRetryPolicy = null;
+                        }
+                    }
+                }
+                else if ((int)statusCode == 429)
+                {
+                    throw new ThrottleException() { RetryParams = currentRetryPolicy };
+                }
+                else
+                {
+                    // 400: for requests with invalid operationId (Which should be of type GUID)
+
+                    // invalid/unexpected status code
+                    var ex = new HttpOperationException($"Operation returned an invalid status code '{statusCode}'");
+                    if (httpResponse.Content != null)
+                    {
+                        responseContent = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        responseContent = string.Empty;
+                    }
+
+                    ex.Request = new HttpRequestMessageWrapper(httpRequest, operationId);
                     ex.Response = new HttpResponseMessageWrapper(httpResponse, responseContent);
                     if (shouldTrace)
                     {

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
@@ -564,9 +564,9 @@ namespace Microsoft.Bot.Connector.Teams
         }
 
         /// <summary>
-        /// Cancels the proccess of an operation.
+        /// Cancels the process of an operation.
         /// </summary>
-        /// <param name="operationId"> The operationId of the operation to cancel. </param>
+        /// <param name="operationId"> The id of the operation to cancel. </param>
         /// <param name="customHeaders"> Headers that will be added to request. </param>
         /// <param name='cancellationToken'> The cancellation token. </param>
         /// <exception cref="HttpOperationException">
@@ -578,7 +578,7 @@ namespace Microsoft.Bot.Connector.Teams
         /// <returns>
         /// A response object containing the state and responses of the operation.
         /// </returns>
-        public async Task<HttpOperationResponse<string>> CancelOperationAsync(string operationId, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<HttpOperationResponse> CancelOperationAsync(string operationId, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (string.IsNullOrEmpty(operationId))
             {
@@ -929,7 +929,7 @@ namespace Microsoft.Bot.Connector.Teams
             return result;
         }
 
-        private async Task<HttpOperationResponse<string>> CancelOperationWithRetryAsync(string operationId, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        private async Task<HttpOperationResponse> CancelOperationWithRetryAsync(string operationId, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             // Tracing
             var shouldTrace = ServiceClientTracing.IsEnabled;
@@ -955,7 +955,7 @@ namespace Microsoft.Bot.Connector.Teams
 
             // Create HTTP transport objects
 #pragma warning disable CA2000 // Dispose objects before losing scope
-            var result = new HttpOperationResponse<string>();
+            var result = new HttpOperationResponse();
 #pragma warning restore CA2000 // Dispose objects before losing scope
             try
             {
@@ -1006,27 +1006,6 @@ namespace Microsoft.Bot.Connector.Teams
                     // 200: OK for successful cancelled operations (Operations in state completed, or failed will not change state to cancel but still return 200)
 
                     responseContent = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    try
-                    {
-                        result.Body = Rest.Serialization.SafeJsonConvert.DeserializeObject<string>(responseContent, Client.DeserializationSettings);
-                    }
-                    catch (JsonException ex)
-                    {
-                        if (shouldTrace)
-                        {
-                            ServiceClientTracing.Error(invocationId, ex);
-                        }
-
-                        throw new SerializationException("Unable to deserialize the response.", responseContent, ex);
-                    }
-                    finally
-                    {
-                        // This means the request was successful. We can make our retry policy null.
-                        if (currentRetryPolicy != null)
-                        {
-                            currentRetryPolicy = null;
-                        }
-                    }
                 }
                 else if ((int)statusCode == 429)
                 {

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperationsExtensions.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperationsExtensions.cs
@@ -341,7 +341,7 @@ namespace Microsoft.Bot.Connector.Teams
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        /// <returns>The response state code.</returns>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public static async Task CancelOperationAsync(this ITeamsOperations operations, string operationId, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (operations is TeamsOperations teamsOperations)

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperationsExtensions.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperationsExtensions.cs
@@ -212,26 +212,23 @@ namespace Microsoft.Bot.Connector.Teams
         }
 
         /// <summary>
-        /// Cancels the proccess of an operation.
+        /// Cancels the process of an operation.
         /// </summary>
         /// <param name='operations'>
         /// The operations group for this extension method.
         /// </param>
         /// <param name='operationId'>
-        /// The operationId of the operation to cancel.
+        /// The id of the operation to cancel.
         /// </param>
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
         /// <returns>The state and responses of the operation.</returns>
-        public static async Task<string> CancelOperationAsync(this ITeamsOperations operations, string operationId, CancellationToken cancellationToken = default(CancellationToken))
+        public static async Task CancelOperationAsync(this ITeamsOperations operations, string operationId, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (operations is TeamsOperations teamsOperations)
             {
-                using (var result = await teamsOperations.CancelOperationAsync(operationId, null, cancellationToken).ConfigureAwait(false))
-                {
-                    return result.Body;
-                }
+                await teamsOperations.CancelOperationAsync(operationId, null, cancellationToken).ConfigureAwait(false);
             }
             else
             {

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperationsExtensions.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperationsExtensions.cs
@@ -210,5 +210,33 @@ namespace Microsoft.Bot.Connector.Teams
                 throw new InvalidOperationException("TeamsOperations with SendMessageToAllUsersInTenantAsync is required for SendMessageToAllUsersInTenantAsync.");
             }
         }
+
+        /// <summary>
+        /// Cancels the proccess of an operation.
+        /// </summary>
+        /// <param name='operations'>
+        /// The operations group for this extension method.
+        /// </param>
+        /// <param name='operationId'>
+        /// The operationId of the operation to cancel.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        /// <returns>The state and responses of the operation.</returns>
+        public static async Task<string> CancelOperationAsync(this ITeamsOperations operations, string operationId, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (operations is TeamsOperations teamsOperations)
+            {
+                using (var result = await teamsOperations.CancelOperationAsync(operationId, null, cancellationToken).ConfigureAwait(false))
+                {
+                    return result.Body;
+                }
+            }
+            else
+            {
+                throw new InvalidOperationException("TeamsOperations with CancelOperationAsync is required for CancelOperationAsync.");
+            }
+        }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsInfoTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsInfoTests.cs
@@ -530,7 +530,7 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             var handler = new TestTeamsActivityHandler();
             await handler.OnTurnAsync(turnContext);
         }
-        
+
         [Theory]
         [InlineData("201")]
         [InlineData("400")]
@@ -1052,7 +1052,7 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                     }
                 }
             }
-            
+
             private async Task CallSendMessageToListOfChannelsAsync(ITurnContext turnContext)
             {
                 var from = turnContext.Activity.From;
@@ -1105,7 +1105,7 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                     }
                 }
             }
-            
+
             private async Task CallGetOperationStateAsync(ITurnContext turnContext)
             {
                 var from = turnContext.Activity.From.Name;
@@ -1153,8 +1153,6 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                     }
                 }
             }
-        }
-
 
             private async Task CallCancelOperationAsync(ITurnContext turnContext)
             {
@@ -1416,6 +1414,7 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                             break;
                     }
                 }
+
                 // SendMessageToAllUsersInTenant
                 else if (request.RequestUri.PathAndQuery.EndsWith("v3/batch/conversation/tenant/"))
                 {
@@ -1447,6 +1446,7 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                             break;
                     }
                 }
+
                 // SendMessageToAllUsersInTeam
                 else if (request.RequestUri.PathAndQuery.EndsWith("v3/batch/conversation/team/"))
                 {
@@ -1482,6 +1482,7 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                             break;
                     }
                 }
+
                 // SendMessageToListOfChannels
                 else if (request.RequestUri.PathAndQuery.EndsWith("v3/batch/conversation/channels/"))
                 {
@@ -1513,12 +1514,13 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                             break;
                     }
                 }
+
                 // GetOperationState
                 else if (request.RequestUri.PathAndQuery.Contains("v3/batch/conversation/operation-id") && request.Method.ToString() == "GET")
                 {
                     // get status from url for testing
                     var uri = request.RequestUri.PathAndQuery;
-                    var status = uri.Substring(uri.IndexOf("%2A") + 3); 
+                    var status = uri.Substring(uri.IndexOf("%2A") + 3);
 
                     switch (status)
                     {


### PR DESCRIPTION
#minor

## Description
This PR implements the CancelOperation method of the new Teams batch APIs in TeamsOperations.

- [x] Send message to a list of users
- [x] Send message to all users    in a tenant
- [x] Send message to all users in a team
- [x] Send message to a list of channels  
- [x] Get Operation State
- [ ] Get failed entries paginated
- [x] Cancel Operation

## Specific Changes
- Implemented the new methods of **_CancelOperation_** in **_TeamsOperations_**, **_TeamsOperationsExtensions_**, and **_TeamsInfo_**.
