### PR TITLE
Implement GetPagedFailedEntriesAsync Teams Batch API

### DIFF
--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
@@ -437,6 +437,22 @@ namespace Microsoft.Bot.Builder.Teams
             }
         }
 
+        /// <summary>
+        /// Gets the failed entries of a batch operation.
+        /// </summary>
+        /// <param name="turnContext">The turn context.</param>
+        /// <param name="operationId">The operationId to get the failed entries of.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The list of failed entries of the operation.</returns>
+        public static async Task<BatchFailedEntriesResponse> GetPagedFailedEntriesAsync(ITurnContext turnContext, string operationId, CancellationToken cancellationToken = default)
+        {
+            operationId = operationId ?? throw new InvalidOperationException($"{nameof(operationId)} is required.");
+
+            using (var teamsClient = GetTeamsConnectorClient(turnContext))
+            {
+                return await teamsClient.Teams.GetPagedFailedEntriesAsync(operationId, cancellationToken).ConfigureAwait(false);
+            }
+        }
 
         private static async Task<IEnumerable<TeamsChannelAccount>> GetMembersAsync(IConnectorClient connectorClient, string conversationId, CancellationToken cancellationToken)
         {

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperationsExtensions.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperationsExtensions.cs
@@ -306,5 +306,27 @@ namespace Microsoft.Bot.Connector.Teams
                 throw new InvalidOperationException("TeamsOperations with GetOperationStateAsync is required for GetOperationStateAsync.");
             }
         }
+
+        /// <summary>
+        /// Gets the failed entries of a batch operation.
+        /// </summary>
+        /// <param name='operations'>The operations group for this extension method.</param>
+        /// <param name='operationId'>The operationId to get the failed entries of.</param>
+        /// <param name='cancellationToken'>The cancellation token.</param>
+        /// <returns>The list of failed entries of the operation.</returns>
+        public static async Task<BatchFailedEntriesResponse> GetPagedFailedEntriesAsync(this ITeamsOperations operations, string operationId, CancellationToken cancellationToken = default)
+        {
+            if (operations is TeamsOperations teamsOperations)
+            {
+                using (var result = await teamsOperations.GetPagedFailedEntriesAsync(operationId, null, cancellationToken).ConfigureAwait(false))
+                {
+                    return result.Body;
+                }
+            }
+            else
+            {
+                throw new InvalidOperationException("TeamsOperations with GetPagedFailedEntriesAsync is required for GetPagedFailedEntriesAsync.");
+            }
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/BatchFailedEntriesResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/BatchFailedEntriesResponse.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Schema.Teams
+{
+    /// <summary>
+    /// Specifies the failed entries response.
+    /// Contains a list of <see cref="BatchFailedEntry"/>.
+    /// </summary>
+    public class BatchFailedEntriesResponse
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BatchFailedEntriesResponse"/> class.
+        /// </summary>
+        public BatchFailedEntriesResponse()
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the continuation token for paginated results.
+        /// </summary>
+        /// <value>The continuation token for paginated results.</value>
+        [JsonProperty(PropertyName = "continuationToken")]
+        public string ContinuationToken { get; set; }
+
+        /// <summary>
+        /// Gets the list of failed entries result of a batch operation.
+        /// </summary>
+        /// <value>The list of failed entries result of a batch operation.</value>
+        [JsonProperty(PropertyName = "failedEntries")]
+        public IList<BatchFailedEntry> FailedEntries { get; private set; } = new List<BatchFailedEntry>();
+    }
+}

--- a/libraries/Microsoft.Bot.Schema/Teams/BatchFailedEntry.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/BatchFailedEntry.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Schema.Teams
+{
+    /// <summary>
+    /// Specifies the failed entry with its id and error.
+    /// </summary>
+    public class BatchFailedEntry
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BatchFailedEntry"/> class.
+        /// </summary>
+        public BatchFailedEntry()
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the id of the failed entry.
+        /// </summary>
+        /// <value>The id of the failed entry.</value>
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the error of the failed entry.
+        /// </summary>
+        /// <value>The error of the failed entry.</value>
+        [JsonProperty(PropertyName = "error")]
+        public string Error { get; set; }
+    }
+}


### PR DESCRIPTION
#minor

## Description
This PR implements the Get failed entries paginated operation of the new Teams batch APIs in TeamsOperations.

**_NOTE: The API is not working yet, we forced the response for testing. Also, the specs for the use of the continuation token to call for consequent results are still pending._**

## Specific Changes
- Implemented the new methods of **_GetPagedFailedEntriesAsync_** in **_TeamsOperations_**, **_TeamsOperationsExtensions_**, and **_TeamsInfo_**.
- Added **_BatchFailedEntriesResponse_** and **_BatchFailedEntry_** classes to handle the API response object.

## Testing
These images show the new unit tests passing and the new functionality tested with a sample bot.
![image](https://github.com/southworks/botbuilder-dotnet/assets/44245136/23f3d884-fe6d-46d5-820f-80a27bbcf8de)
