### PR TITLE
[Teams] Add support for meeting participants added/removed events

### DIFF
--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityHandler.cs
@@ -809,6 +809,10 @@ namespace Microsoft.Bot.Builder.Teams
                         return OnTeamsMeetingStartAsync(JObject.FromObject(turnContext.Activity.Value).ToObject<MeetingStartEventDetails>(), turnContext, cancellationToken);
                     case "application/vnd.microsoft.meetingEnd":
                         return OnTeamsMeetingEndAsync(JObject.FromObject(turnContext.Activity.Value).ToObject<MeetingEndEventDetails>(), turnContext, cancellationToken);
+                    case "application/vnd.microsoft.meetingParticipantsAdded":
+                        return OnTeamsMeetingParticipantsAddedAsync(JObject.FromObject(turnContext.Activity.Value).ToObject<MeetingParticipantsAddedEventDetails>(), turnContext, cancellationToken);
+                    case "application/vnd.microsoft.meetingParticipantsRemoved":
+                        return OnTeamsMeetingParticipantsRemovedAsync(JObject.FromObject(turnContext.Activity.Value).ToObject<MeetingParticipantsRemovedEventDetails>(), turnContext, cancellationToken);
                 }
             }
 
@@ -853,6 +857,34 @@ namespace Microsoft.Bot.Builder.Teams
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A task that represents the work queued to execute.</returns>
         protected virtual Task OnTeamsReadReceiptAsync(ReadReceiptInfo readReceiptInfo, ITurnContext<IEventActivity> turnContext, CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Invoked when a Teams Participants Added event activity is received from the connector.
+        /// Override this in a derived class to provide logic for when meeting participants are added.
+        /// </summary>
+        /// <param name="meeting">The details of the meeting.</param>
+        /// <param name="turnContext">A strongly-typed context object for this turn.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        protected virtual Task OnTeamsMeetingParticipantsAddedAsync(MeetingParticipantsAddedEventDetails meeting, ITurnContext<IEventActivity> turnContext, CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Invoked when a Teams Participants Removed event activity is received from the connector.
+        /// Override this in a derived class to provide logic for when meeting participants are removed.
+        /// </summary>
+        /// <param name="meeting">The details of the meeting.</param>
+        /// <param name="turnContext">A strongly-typed context object for this turn.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        protected virtual Task OnTeamsMeetingParticipantsRemovedAsync(MeetingParticipantsRemovedEventDetails meeting, ITurnContext<IEventActivity> turnContext, CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }

--- a/libraries/Microsoft.Bot.Schema/Teams/MeetingParticipantsAddedEventDetails.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MeetingParticipantsAddedEventDetails.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Schema.Teams
+{
+    /// <summary>
+    /// Specific details of a Teams meeting participants added event.
+    /// </summary>
+    public partial class MeetingParticipantsAddedEventDetails : MeetingEventDetails
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MeetingParticipantsAddedEventDetails"/> class.
+        /// </summary>
+        public MeetingParticipantsAddedEventDetails()
+        {
+            CustomInit();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MeetingParticipantsAddedEventDetails"/> class.
+        /// </summary>
+        /// <param name="id">The meeting's Id, encoded as a BASE64 string.</param>
+        /// <param name="joinUrl">The URL used to join the meeting.</param>
+        /// <param name="title">The title of the meeting.</param>
+        /// <param name="meetingType">The meeting's type.</param>
+        /// <param name="participantsAdded">The added participant accounts.</param>
+        public MeetingParticipantsAddedEventDetails(
+            string id,
+            Uri joinUrl = null,
+            string title = null,
+            string meetingType = "Scheduled",
+            IList<TeamsChannelAccount> participantsAdded = default)
+            : base(id, joinUrl, title, meetingType)
+        {
+            ParticipantsAdded = participantsAdded;
+
+            CustomInit();
+        }
+
+        /// <summary>
+        /// Gets the added meeting participants.
+        /// </summary>
+        /// <value>
+        /// The added participant accounts.
+        /// </value>
+        [JsonProperty(PropertyName = "ParticipantsAdded")]
+        public IList<TeamsChannelAccount> ParticipantsAdded { get; private set; } = new List<TeamsChannelAccount>();
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults.
+        /// </summary>
+        partial void CustomInit();
+    }
+}

--- a/libraries/Microsoft.Bot.Schema/Teams/MeetingParticipantsRemovedEventDetails.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MeetingParticipantsRemovedEventDetails.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Schema.Teams
+{
+    /// <summary>
+    /// Specific details of a Teams meeting participants removed event.
+    /// </summary>
+    public partial class MeetingParticipantsRemovedEventDetails : MeetingEventDetails
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MeetingParticipantsRemovedEventDetails"/> class.
+        /// </summary>
+        public MeetingParticipantsRemovedEventDetails()
+        {
+            CustomInit();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MeetingParticipantsRemovedEventDetails"/> class.
+        /// </summary>
+        /// <param name="id">The meeting's Id, encoded as a BASE64 string.</param>
+        /// <param name="joinUrl">The URL used to join the meeting.</param>
+        /// <param name="title">The title of the meeting.</param>
+        /// <param name="meetingType">The meeting's type.</param>
+        /// <param name="participantsRemoved">The removed participant accounts.</param>
+        public MeetingParticipantsRemovedEventDetails(
+            string id,
+            Uri joinUrl = null,
+            string title = null,
+            string meetingType = "Scheduled",
+            IList<TeamsChannelAccount> participantsRemoved = default)
+            : base(id, joinUrl, title, meetingType)
+        {
+            ParticipantsRemoved = participantsRemoved;
+
+            CustomInit();
+        }
+
+        /// <summary>
+        /// Gets the removed meeting participants.
+        /// </summary>
+        /// <value>
+        /// The removed participant accounts.
+        /// </value>
+        [JsonProperty(PropertyName = "ParticipantsRemoved")]
+        public IList<TeamsChannelAccount> ParticipantsRemoved { get; private set; } = new List<TeamsChannelAccount>();
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults.
+        /// </summary>
+        partial void CustomInit();
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/MeetingParticipantsAddedEventDetailsTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/MeetingParticipantsAddedEventDetailsTests.cs
@@ -1,0 +1,48 @@
+﻿// Copyright(c) Microsoft Corporation.All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class MeetingParticipantsAddedEventDetailsTests
+    {
+        [Fact]
+        public void MeetingParticipantsAddedEventDetailsInits()
+        {
+            // Arrange
+            var meetingId = "meetingId";
+            var meetingJoinUrl = new Uri("http://meetingJoinUrl");
+            var meetingTitle = "meetingTitle";
+            var meetingType = "meetingType";
+            var participant = new TeamsChannelAccount("id", "name", "givenName", "surname", "email", "userPrincipalName");
+            var participantsAdded = new List<TeamsChannelAccount>() { participant };
+
+            // Act
+            var meeting = new MeetingParticipantsAddedEventDetails(meetingId, meetingJoinUrl, meetingTitle, meetingType, participantsAdded);
+
+            // Assert
+            Assert.NotNull(meeting);
+            Assert.IsType<MeetingParticipantsAddedEventDetails>(meeting);
+            Assert.Equal(meetingId, meeting.Id);
+            Assert.Equal(meetingJoinUrl, meeting.JoinUrl);
+            Assert.Equal(meetingTitle, meeting.Title);
+            Assert.Equal(meetingType, meeting.MeetingType);
+            Assert.StrictEqual(participantsAdded, meeting.ParticipantsAdded);
+        }
+
+        [Fact]
+        public void MeetingParticipantsAddedEventDetailsInitsWithNoArgs()
+        {
+            // Act
+            var meeting = new MeetingParticipantsAddedEventDetails();
+
+            // Assert
+            Assert.NotNull(meeting);
+            Assert.IsType<MeetingParticipantsAddedEventDetails>(meeting);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/MeetingParticipantsRemovedEventDetailsTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/MeetingParticipantsRemovedEventDetailsTests.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class MeetingParticipantsRemovedEventDetailsTests
+    {
+        [Fact]
+        public void MeetingParticipantsRemovedEventDetailsInits()
+        {
+            // Arrange
+            var meetingId = "meetingId";
+            var meetingJoinUrl = new Uri("http://meetingJoinUrl");
+            var meetingTitle = "meetingTitle";
+            var meetingType = "meetingType";
+            var participant = new TeamsChannelAccount("id", "name", "givenName", "surname", "email", "userPrincipalName");
+            var participantsRemoved = new List<TeamsChannelAccount>() { participant };
+
+            // Act
+            var meeting = new MeetingParticipantsRemovedEventDetails(meetingId, meetingJoinUrl, meetingTitle, meetingType, participantsRemoved);
+
+            // Assert
+            Assert.NotNull(meeting);
+            Assert.IsType<MeetingParticipantsRemovedEventDetails>(meeting);
+            Assert.Equal(meetingId, meeting.Id);
+            Assert.Equal(meetingJoinUrl, meeting.JoinUrl);
+            Assert.Equal(meetingTitle, meeting.Title);
+            Assert.Equal(meetingType, meeting.MeetingType);
+            Assert.StrictEqual(participantsRemoved, meeting.ParticipantsRemoved);
+        }
+
+        [Fact]
+        public void MeetingParticipantsRemovedEventDetailsInitsWithNoArgs()
+        {
+            // Act
+            var meeting = new MeetingParticipantsRemovedEventDetails();
+
+            // Assert
+            Assert.NotNull(meeting);
+            Assert.IsType<MeetingParticipantsRemovedEventDetails>(meeting);
+        }
+    }
+}


### PR DESCRIPTION
#minor

## Description
This PR is based on # 5809. It adds support to TeamsActivityHandler for meeting participants added/removed events.

## Specific Changes
- Added support for 2 new activity types - `application/vnd.microsoft.meetingParticipantsAdded` and `application/vnd.microsoft.meetingParticipantsRemoved`.
- Added functions to register handlers for when teams meeting participants are added/removed.
- Added unit tests.

## Testing
These images show the new unit tests passing.
![image](https://github.com/southworks/botbuilder-dotnet/assets/44245136/f568c121-5c96-4963-95bb-bdcc7d007eb7)
