### PR TITLE
[#6643] WithManagedIdentity is experimental and not exist in Microsoft.Identity.Client 4.51.0

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Authentication/ManagedIdentityAuthenticator.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ManagedIdentityAuthenticator.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.AppConfig;
 
 namespace Microsoft.Bot.Connector.Authentication
 {
@@ -16,10 +17,9 @@ namespace Microsoft.Bot.Connector.Authentication
     /// </summary>
     public class ManagedIdentityAuthenticator : IAuthenticator
     {
-        private readonly string _appId;
         private readonly string _resource;
         private readonly ILogger _logger;
-        private readonly IConfidentialClientApplication _clientApplication;
+        private readonly IManagedIdentityApplication _clientApplication;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ManagedIdentityAuthenticator"/> class.
@@ -54,7 +54,6 @@ namespace Microsoft.Bot.Connector.Authentication
                 throw new ArgumentNullException(nameof(resource));
             }
             
-            _appId = appId;
             _resource = resource;
             _logger = logger ?? NullLogger.Instance;
             _clientApplication = CreateClientApplication(appId, customHttpClient);
@@ -77,10 +76,8 @@ namespace Microsoft.Bot.Connector.Authentication
 
         private async Task<AuthenticatorResult> AcquireTokenAsync(bool forceRefresh)
         {
-            var scopes = new string[] { $"{_resource}/.default" };
             var authResult = await _clientApplication
-                .AcquireTokenForClient(scopes)
-                .WithManagedIdentity(_appId)
+                .AcquireTokenForManagedIdentity(_resource)
                 .WithForceRefresh(forceRefresh)
                 .ExecuteAsync()
                 .ConfigureAwait(false);
@@ -100,10 +97,9 @@ namespace Microsoft.Bot.Connector.Authentication
                 : RetryParams.DefaultBackOff(retryCount);
         }
 
-        private IConfidentialClientApplication CreateClientApplication(string appId, HttpClient customHttpClient = null)
+        private IManagedIdentityApplication CreateClientApplication(string appId, HttpClient customHttpClient = null)
         {
-            var clientBuilder = ConfidentialClientApplicationBuilder.Create(appId)
-               .WithExperimentalFeatures();
+            var clientBuilder = ManagedIdentityApplicationBuilder.Create(ManagedIdentityId.WithUserAssignedClientId(appId));
 
             if (customHttpClient != null)
             {

--- a/libraries/Microsoft.Bot.Connector/Microsoft.Bot.Connector.csproj
+++ b/libraries/Microsoft.Bot.Connector/Microsoft.Bot.Connector.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.50.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.55.0" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.6.0" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />


### PR DESCRIPTION
Fixes # 6643

## Description
This PR updates the `Microsoft.Identity.Client` package from `4.50` to `4.55` to implement the official MSI functionality.

## Specific Changes
  - Replaced `IConfidentialClientApplication` with `IManagedIdentityApplication`.
  - Replaced `AcquireTokenForClient` with `AcquireTokenForManagedIdentity` due to the new application type.
  - Removed unused `_appId` property.
  - Removed experimental flag.
  - Removed `scopes`, only the resource is required.

## Testing
The following image shows the bot working with the new implementation.
![image](https://github.com/southworks/botbuilder-dotnet/assets/62260472/70c33104-0156-458c-9358-26f8bdd8e65e)