### PR TITLE
port: [#6701] Add ConnectorClientOptions to ConfigurationBotFrameworkAuthentication

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkAuthenticationFactory.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkAuthenticationFactory.cs
@@ -31,7 +31,8 @@ namespace Microsoft.Bot.Connector.Authentication
                 credentialFactory: new PasswordServiceClientCredentialFactory(),
                 authConfiguration: new AuthenticationConfiguration(),
                 httpClientFactory: null,
-                logger: null);
+                logger: null,
+                connectorClientOptions: null);
         }
 
         /// <summary>
@@ -50,6 +51,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="authConfiguration">The <see cref="AuthenticationConfiguration" /> to use.</param>
         /// <param name="httpClientFactory">The <see cref="IHttpClientFactory" /> to use.</param>
         /// <param name="logger">The <see cref="ILogger" /> to use.</param>
+        /// <param name="connectorClientOptions">The <see cref="ConnectorClientOptions"/> to use when creating <see cref="ConnectorClient"/>.</param>
         /// <returns>A new <see cref="BotFrameworkAuthentication" /> instance.</returns>
         public static BotFrameworkAuthentication Create(
             string channelService,
@@ -64,7 +66,8 @@ namespace Microsoft.Bot.Connector.Authentication
             ServiceClientCredentialsFactory credentialFactory,
             AuthenticationConfiguration authConfiguration,
             IHttpClientFactory httpClientFactory,
-            ILogger logger)
+            ILogger logger,
+            ConnectorClientOptions connectorClientOptions = default)
         {
             if (
                 !string.IsNullOrEmpty(toChannelFromBotLoginUrl) || 
@@ -89,7 +92,8 @@ namespace Microsoft.Bot.Connector.Authentication
                     credentialFactory,
                     authConfiguration,
                     httpClientFactory,
-                    logger);
+                    logger,
+                    connectorClientOptions);
             }
             else
             {
@@ -97,11 +101,11 @@ namespace Microsoft.Bot.Connector.Authentication
 
                 if (string.IsNullOrEmpty(channelService))
                 {
-                    return new PublicCloudBotFrameworkAuthentication(credentialFactory, authConfiguration, httpClientFactory, logger);
+                    return new PublicCloudBotFrameworkAuthentication(credentialFactory, authConfiguration, httpClientFactory, logger, connectorClientOptions);
                 }
                 else if (channelService == GovernmentAuthenticationConstants.ChannelService)
                 {
-                    return new GovernmentCloudBotFrameworkAuthentication(credentialFactory, authConfiguration, httpClientFactory, logger);
+                    return new GovernmentCloudBotFrameworkAuthentication(credentialFactory, authConfiguration, httpClientFactory, logger, connectorClientOptions);
                 }
                 else
                 {

--- a/libraries/Microsoft.Bot.Connector/Authentication/BuiltinBotFrameworkAuthentication.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/BuiltinBotFrameworkAuthentication.cs
@@ -34,8 +34,9 @@ namespace Microsoft.Bot.Connector.Authentication
         private readonly AuthenticationConfiguration _authConfiguration;
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly ILogger _logger;
+        private readonly ConnectorClientOptions _connectorClientOptions;
 
-        protected BuiltinBotFrameworkAuthentication(string toChannelFromBotOAuthScope, string loginEndpoint, string callerId, string channelService, string oauthEndpoint, ServiceClientCredentialsFactory credentialsFactory, AuthenticationConfiguration authConfiguration, IHttpClientFactory httpClientFactory, ILogger logger)
+        protected BuiltinBotFrameworkAuthentication(string toChannelFromBotOAuthScope, string loginEndpoint, string callerId, string channelService, string oauthEndpoint, ServiceClientCredentialsFactory credentialsFactory, AuthenticationConfiguration authConfiguration, IHttpClientFactory httpClientFactory, ILogger logger, ConnectorClientOptions connectorClientOptions = default)
         {
             _toChannelFromBotOAuthScope = toChannelFromBotOAuthScope;
             _loginEndpoint = loginEndpoint;
@@ -46,6 +47,7 @@ namespace Microsoft.Bot.Connector.Authentication
             _authConfiguration = authConfiguration;
             _httpClientFactory = httpClientFactory;
             _logger = logger ?? NullLogger.Instance;
+            _connectorClientOptions = connectorClientOptions;
         }
 
         public static string GetAppId(ClaimsIdentity claimsIdentity)
@@ -98,7 +100,7 @@ namespace Microsoft.Bot.Connector.Authentication
 
             var callerId = await GenerateCallerIdAsync(_credentialsFactory, claimsIdentity, _callerId, cancellationToken).ConfigureAwait(false);
 
-            var connectorFactory = new ConnectorFactoryImpl(GetAppId(claimsIdentity), _toChannelFromBotOAuthScope, _loginEndpoint, true, _credentialsFactory, _httpClientFactory, _logger);
+            var connectorFactory = new ConnectorFactoryImpl(GetAppId(claimsIdentity), _toChannelFromBotOAuthScope, _loginEndpoint, true, _credentialsFactory, _httpClientFactory, _logger, _connectorClientOptions);
 
             return new AuthenticateRequestResult { ClaimsIdentity = claimsIdentity, Audience = outboundAudience, CallerId = callerId, ConnectorFactory = connectorFactory };
         }
@@ -121,7 +123,7 @@ namespace Microsoft.Bot.Connector.Authentication
 
         public override ConnectorFactory CreateConnectorFactory(ClaimsIdentity claimsIdentity)
         {
-            return new ConnectorFactoryImpl(GetAppId(claimsIdentity), _toChannelFromBotOAuthScope, _loginEndpoint, true, _credentialsFactory, _httpClientFactory, _logger);
+            return new ConnectorFactoryImpl(GetAppId(claimsIdentity), _toChannelFromBotOAuthScope, _loginEndpoint, true, _credentialsFactory, _httpClientFactory, _logger, _connectorClientOptions);
         }
 
         public override async Task<UserTokenClient> CreateUserTokenClientAsync(ClaimsIdentity claimsIdentity, CancellationToken cancellationToken)
@@ -130,7 +132,7 @@ namespace Microsoft.Bot.Connector.Authentication
 
             var credentials = await _credentialsFactory.CreateCredentialsAsync(appId, _toChannelFromBotOAuthScope, _loginEndpoint, true, cancellationToken).ConfigureAwait(false);
 
-            return new UserTokenClientImpl(appId, credentials, _oauthEndpoint, _httpClientFactory?.CreateClient(), _logger);
+            return new UserTokenClientImpl(appId, credentials, _oauthEndpoint, _httpClientFactory?.CreateClient(), _logger, _connectorClientOptions);
         }
 
         public override BotFrameworkClient CreateBotFrameworkClient()

--- a/libraries/Microsoft.Bot.Connector/Authentication/ConnectorFactoryImpl.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ConnectorFactoryImpl.cs
@@ -18,8 +18,9 @@ namespace Microsoft.Bot.Connector.Authentication
         private readonly ServiceClientCredentialsFactory _credentialFactory;
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly ILogger _logger;
+        private readonly ConnectorClientOptions _connectorClientOptions;
 
-        public ConnectorFactoryImpl(string appId, string toChannelFromBotOAuthScope, string loginEndpoint, bool validateAuthority, ServiceClientCredentialsFactory credentialFactory, IHttpClientFactory httpClientFactory, ILogger logger)
+        public ConnectorFactoryImpl(string appId, string toChannelFromBotOAuthScope, string loginEndpoint, bool validateAuthority, ServiceClientCredentialsFactory credentialFactory, IHttpClientFactory httpClientFactory, ILogger logger, ConnectorClientOptions connectorClientOptions = default)
         {
             _appId = appId;
             _toChannelFromBotOAuthScope = toChannelFromBotOAuthScope;
@@ -28,6 +29,7 @@ namespace Microsoft.Bot.Connector.Authentication
             _credentialFactory = credentialFactory;
             _httpClientFactory = httpClientFactory;
             _logger = logger;
+            _connectorClientOptions = connectorClientOptions;
         }
 
         public override async Task<IConnectorClient> CreateAsync(string serviceUrl, string audience, CancellationToken cancellationToken)
@@ -39,6 +41,8 @@ namespace Microsoft.Bot.Connector.Authentication
 #pragma warning disable CA2000 // Dispose objects before losing scope
             var httpClient = _httpClientFactory?.CreateClient() ?? new HttpClient();
             ConnectorClient.AddDefaultRequestHeaders(httpClient);
+            ConnectorClient.AddUserAgent(httpClient, _connectorClientOptions?.UserAgent);
+
             return new ConnectorClient(new Uri(serviceUrl), credentials, httpClient, true);
 #pragma warning restore CA2000 // Dispose objects before losing scope
         }

--- a/libraries/Microsoft.Bot.Connector/Authentication/GovernmentCloudBotFrameworkAuthentication.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/GovernmentCloudBotFrameworkAuthentication.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Bot.Connector.Authentication
 {
     internal class GovernmentCloudBotFrameworkAuthentication : BuiltinBotFrameworkAuthentication
     {
-        public GovernmentCloudBotFrameworkAuthentication(ServiceClientCredentialsFactory credentialFactory, AuthenticationConfiguration authConfiguration, IHttpClientFactory httpClientFactory, ILogger logger = null)
+        public GovernmentCloudBotFrameworkAuthentication(ServiceClientCredentialsFactory credentialFactory, AuthenticationConfiguration authConfiguration, IHttpClientFactory httpClientFactory, ILogger logger = null, ConnectorClientOptions connectorClientOptions = default)
             : base(
                   GovernmentAuthenticationConstants.ToChannelFromBotOAuthScope,
                   GovernmentAuthenticationConstants.ToChannelFromBotLoginUrl,
@@ -19,7 +19,8 @@ namespace Microsoft.Bot.Connector.Authentication
                   credentialFactory,
                   authConfiguration,
                   httpClientFactory,
-                  logger)
+                  logger,
+                  connectorClientOptions)
         {
         }
     }

--- a/libraries/Microsoft.Bot.Connector/Authentication/ParameterizedBotFrameworkAuthentication.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ParameterizedBotFrameworkAuthentication.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Bot.Connector.Authentication
         private readonly AuthenticationConfiguration _authConfiguration;
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly ILogger _logger;
+        private readonly ConnectorClientOptions _connectorClientOptions;
 
         public ParameterizedBotFrameworkAuthentication(
             bool validateAuthority,
@@ -45,7 +46,8 @@ namespace Microsoft.Bot.Connector.Authentication
             ServiceClientCredentialsFactory credentialsFactory,
             AuthenticationConfiguration authConfiguration,
             IHttpClientFactory httpClientFactory,
-            ILogger logger)
+            ILogger logger,
+            ConnectorClientOptions connectorClientOptions = default)
         {
             _validateAuthority = validateAuthority;
             _toChannelFromBotLoginUrl = toChannelFromBotLoginUrl;
@@ -59,6 +61,7 @@ namespace Microsoft.Bot.Connector.Authentication
             _authConfiguration = authConfiguration;
             _httpClientFactory = httpClientFactory;
             _logger = logger ?? NullLogger.Instance;
+            _connectorClientOptions = connectorClientOptions;
         }
 
         public override string GetOriginatingAudience()
@@ -79,7 +82,7 @@ namespace Microsoft.Bot.Connector.Authentication
 
             var callerId = await GenerateCallerIdAsync(_credentialsFactory, claimsIdentity, _callerId, cancellationToken).ConfigureAwait(false);
 
-            var connectorFactory = new ConnectorFactoryImpl(BuiltinBotFrameworkAuthentication.GetAppId(claimsIdentity), _toChannelFromBotOAuthScope, _toChannelFromBotLoginUrl, _validateAuthority, _credentialsFactory, _httpClientFactory, _logger);
+            var connectorFactory = new ConnectorFactoryImpl(BuiltinBotFrameworkAuthentication.GetAppId(claimsIdentity), _toChannelFromBotOAuthScope, _toChannelFromBotLoginUrl, _validateAuthority, _credentialsFactory, _httpClientFactory, _logger, _connectorClientOptions);
 
             return new AuthenticateRequestResult { ClaimsIdentity = claimsIdentity, Audience = outboundAudience, CallerId = callerId, ConnectorFactory = connectorFactory };
         }
@@ -102,7 +105,7 @@ namespace Microsoft.Bot.Connector.Authentication
 
         public override ConnectorFactory CreateConnectorFactory(ClaimsIdentity claimsIdentity)
         {
-            return new ConnectorFactoryImpl(BuiltinBotFrameworkAuthentication.GetAppId(claimsIdentity), _toChannelFromBotOAuthScope, _toChannelFromBotLoginUrl, _validateAuthority, _credentialsFactory, _httpClientFactory, _logger);
+            return new ConnectorFactoryImpl(BuiltinBotFrameworkAuthentication.GetAppId(claimsIdentity), _toChannelFromBotOAuthScope, _toChannelFromBotLoginUrl, _validateAuthority, _credentialsFactory, _httpClientFactory, _logger, _connectorClientOptions);
         }
 
         public override async Task<UserTokenClient> CreateUserTokenClientAsync(ClaimsIdentity claimsIdentity, CancellationToken cancellationToken)
@@ -111,7 +114,7 @@ namespace Microsoft.Bot.Connector.Authentication
 
             var credentials = await _credentialsFactory.CreateCredentialsAsync(appId, _toChannelFromBotOAuthScope, _toChannelFromBotLoginUrl, _validateAuthority, cancellationToken).ConfigureAwait(false);
 
-            return new UserTokenClientImpl(appId, credentials, _oAuthUrl, _httpClientFactory?.CreateClient(), _logger);
+            return new UserTokenClientImpl(appId, credentials, _oAuthUrl, _httpClientFactory?.CreateClient(), _logger, _connectorClientOptions);
         }
 
         public override BotFrameworkClient CreateBotFrameworkClient()

--- a/libraries/Microsoft.Bot.Connector/Authentication/PublicCloudBotFrameworkAuthentication.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/PublicCloudBotFrameworkAuthentication.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Bot.Connector.Authentication
 {
     internal class PublicCloudBotFrameworkAuthentication : BuiltinBotFrameworkAuthentication
     {
-        public PublicCloudBotFrameworkAuthentication(ServiceClientCredentialsFactory credentialFactory, AuthenticationConfiguration authConfiguration, IHttpClientFactory httpClientFactory, ILogger logger)
+        public PublicCloudBotFrameworkAuthentication(ServiceClientCredentialsFactory credentialFactory, AuthenticationConfiguration authConfiguration, IHttpClientFactory httpClientFactory, ILogger logger, ConnectorClientOptions connectorClientOptions = default)
             : base(
                   AuthenticationConstants.ToChannelFromBotOAuthScope,
                   AuthenticationConstants.ToChannelFromBotLoginUrlTemplate,
@@ -19,7 +19,8 @@ namespace Microsoft.Bot.Connector.Authentication
                   credentialFactory,
                   authConfiguration,
                   httpClientFactory,
-                  logger)
+                  logger,
+                  connectorClientOptions)
         {
         }
     }

--- a/libraries/Microsoft.Bot.Connector/Authentication/UserTokenClientImpl.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/UserTokenClientImpl.cs
@@ -34,11 +34,13 @@ namespace Microsoft.Bot.Connector.Authentication
             ServiceClientCredentials credentials,
             string oauthEndpoint,
             HttpClient httpClient,
-            ILogger logger)
+            ILogger logger,
+            ConnectorClientOptions connectorClientOptions = default)
         {
             _appId = appId;
             _httpClient = httpClient ?? new HttpClient();
             ConnectorClient.AddDefaultRequestHeaders(_httpClient);
+            ConnectorClient.AddUserAgent(_httpClient, connectorClientOptions?.UserAgent);
             _client = new OAuthClient(credentials, _httpClient, true) { BaseUri = new Uri(oauthEndpoint) };
             _logger = logger ?? NullLogger.Instance;
         }

--- a/libraries/Microsoft.Bot.Connector/ConnectorClientEx.cs
+++ b/libraries/Microsoft.Bot.Connector/ConnectorClientEx.cs
@@ -179,6 +179,29 @@ namespace Microsoft.Bot.Connector
         /// Configures an HTTP client to include default headers for the Bot Framework.
         /// </summary>
         /// <param name="httpClient">The HTTP client to configure.</param>
+        /// <param name="userAgent">user agent.</param>
+        public static void AddUserAgent(HttpClient httpClient, string userAgent)
+        {
+            if (httpClient == null)
+            {
+                return;
+            }
+
+            if (string.IsNullOrEmpty(userAgent))
+            {
+                return;
+            }
+
+            lock (httpClient)
+            {
+                httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(userAgent);
+            }
+        }
+
+        /// <summary>
+        /// Configures an HTTP client to include default headers for the Bot Framework.
+        /// </summary>
+        /// <param name="httpClient">The HTTP client to configure.</param>
         public static void AddDefaultRequestHeaders(HttpClient httpClient)
         {
             lock (httpClient)

--- a/libraries/Microsoft.Bot.Connector/ConnectorClientOptions.cs
+++ b/libraries/Microsoft.Bot.Connector/ConnectorClientOptions.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Connector
+{
+    /// <summary>
+    /// A class representing the options for <see cref="Microsoft.Bot.Connector.ConnectorClient"/>.
+    /// </summary>
+    public class ConnectorClientOptions
+    {
+        /// <summary>
+        /// Gets or sets the user agent when sending the request.
+        /// </summary>
+        /// <value>
+        /// The user agent.
+        /// </value>
+        public string UserAgent { get; set; }
+    }
+}

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ConfigurationBotFrameworkAuthentication.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ConfigurationBotFrameworkAuthentication.cs
@@ -6,6 +6,7 @@ using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Skills;
+using Microsoft.Bot.Connector;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
@@ -28,7 +29,8 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
         /// <param name="authConfiguration">An <see cref="AuthenticationConfiguration"/> instance.</param>
         /// <param name="httpClientFactory">The <see cref="IHttpClientFactory"/> to use.</param>
         /// <param name="logger">The ILogger instance to use.</param>
-        public ConfigurationBotFrameworkAuthentication(IConfiguration configuration, ServiceClientCredentialsFactory credentialsFactory = null, AuthenticationConfiguration authConfiguration = null, IHttpClientFactory httpClientFactory = null, ILogger logger = null)
+        /// <param name="connectorClientOptions">The <see cref="ConnectorClientOptions"/> to use when creating <see cref="ConnectorClient"/>.</param>
+        public ConfigurationBotFrameworkAuthentication(IConfiguration configuration, ServiceClientCredentialsFactory credentialsFactory = null, AuthenticationConfiguration authConfiguration = null, IHttpClientFactory httpClientFactory = null, ILogger logger = null, ConnectorClientOptions connectorClientOptions = default)
         {
             var channelService = configuration.GetSection("ChannelService")?.Value;
             var validateAuthority = configuration.GetSection("ValidateAuthority")?.Value;
@@ -53,7 +55,8 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                 credentialsFactory ?? new ConfigurationServiceClientCredentialFactory(configuration),
                 authConfiguration ?? new AuthenticationConfiguration(),
                 httpClientFactory,
-                logger);
+                logger,
+                connectorClientOptions);
         }
 
         /// <inheritdoc />

--- a/tests/Microsoft.Bot.Connector.Tests/ConnectorClientTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/ConnectorClientTests.cs
@@ -25,6 +25,17 @@ namespace Microsoft.Bot.Connector.Tests
         }
 
         [Fact]
+        public void ConnectorClient_CustomHttpClient_CustomUserAgent()
+        {
+            var userAgent = $"CustomUserAgent/{Guid.NewGuid()} CustomUserAgent2/{Guid.NewGuid()} CustomUserAgent3/{Guid.NewGuid()}";
+            var customHttpClient = new HttpClient();
+            ConnectorClient.AddDefaultRequestHeaders(customHttpClient);
+            ConnectorClient.AddUserAgent(customHttpClient, userAgent);
+
+            Assert.Contains(userAgent, customHttpClient.DefaultRequestHeaders.UserAgent.ToString());
+        }
+
+        [Fact]
         public void ConnectorClient_CustomHttpClient_ContainsAcceptAll()
         {
             var customHttpClient = new HttpClient();


### PR DESCRIPTION
Addresses # 6701
#minor

## Description
This PR ports from JavaScript the ability to add a custom user agent through the new ConnectorClientOptions, provided in the ConfigurationBotFrameworkAuthentication class.

## Specific Changes
  - Added `ConnectorClientOptions` class containing the user agent property.
  - Added `AddUserAgent` method to the `ConnectorClientEx` static class.
  - Connected the new `ConnectorClientOptions` class from `ConfigurationBotFrameworkAuthentication` through the code flow, up to `ConnectorFactoryImpl` and `UserTokenClientImpl`.
  - Added new unit tests around the new `ConnectorClientOptions` class.

## Testing
The following images show the new test passing and how the new ConnectorClientOptions could be used from a bot.
![imagen](https://github.com/southworks/botbuilder-dotnet/assets/62260472/0644e7e6-51be-45e7-8f32-f4a9754d4dc5)
![imagen](https://github.com/southworks/botbuilder-dotnet/assets/62260472/85ef8cbe-6172-4ebd-ba35-5bbaae812ed1)