### PR TITLE
Fix error when building activity with non-string text

### DIFF
--- a/libraries/Microsoft.Bot.Builder/ActivityFactory.cs
+++ b/libraries/Microsoft.Bot.Builder/ActivityFactory.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Bot.Schema;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder
@@ -124,6 +125,12 @@ namespace Microsoft.Bot.Builder
 
                 switch (property.ToLowerInvariant())
                 {
+                    case "text":
+                        activity["text"] = value.Type == JTokenType.String ? value : value.ToString(Formatting.None);
+                        break;
+                    case "speak":
+                        activity["speak"] = value.Type == JTokenType.String ? value : value.ToString(Formatting.None);
+                        break;
                     case "attachments":
                         activity["attachments"] = JArray.FromObject(GetAttachments(value));
                         break;

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/ActivityFactoryTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/ActivityFactoryTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Bot.Builder.Dialogs.Declarative;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Bot.Builder.LanguageGeneration;
 using Microsoft.Bot.Schema;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
@@ -59,6 +60,27 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var activity = ActivityFactory.FromObject(lgResult);
             Assert.Equal(0, activity.Attachments.Count);
             Assert.Equal("{\"lgType\":\"Acti\",\"key\":\"value\"}", activity.Text.Replace("\r\n", string.Empty).Replace("\n", string.Empty).Replace(" ", string.Empty));
+        }
+
+        [Fact]
+        public void TestTextActivityArrayType()
+        {
+            var textArray = new JArray
+            {
+                new JObject(new JProperty("user", "userName"))
+            };
+
+            var text = textArray.ToString(Formatting.None);
+
+            dynamic data = new JObject();
+            data.text = textArray;
+
+            var lgResult = templates.Evaluate("messageActivity", data);
+            var activity = ActivityFactory.FromObject(lgResult);
+
+            Assert.Equal(ActivityTypes.Message, activity.Type);
+            Assert.Equal(text, activity.Text);
+            Assert.Equal(text, activity.Speak);
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/lg/NormalStructuredLG.lg
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/lg/NormalStructuredLG.lg
@@ -129,6 +129,12 @@
     Type = handoff
 ]
 
+# messageActivity(text)
+[Activity
+    Text = ${text}
+    Speak = ${text}
+]
+
 # messageActivityAll(title, text)
 [Activity
     Text = ${text}


### PR DESCRIPTION
#minor
**Related _BF-Composer Issue:_** https ://github.com/microsoft/BotFramework-Composer/issues/ 9692


## Description
This PR adds a validation to avoid sending object values as the activity's _text_ and _speak_. 
With this change, we are matching JS implementation.

## Specific Changes
- Added a validation for the text and speak properties in the **_BuildActivity_** method of the _ActivityFactory_ class.
- Added a unit test to cover this case in **_ActivityFactoryTests_**.
- Added a new _messageActivity_ template to use in the new test. 

## Testing
These images show how the property was displayed before and after the fix.
![image](https://github.com/southworks/botbuilder-dotnet/assets/44245136/565d99dd-807e-42f3-98f5-be6982784370)
