### PR TITLE
[#6741] Update projects to .Net 8

### DIFF
--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/Microsoft.Bot.Builder.FunctionalTests.csproj
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/Microsoft.Bot.Builder.FunctionalTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Configurations>Debug;Release;</Configurations>
   </PropertyGroup>

--- a/build/onebranch/ci-api-validation-steps.yml
+++ b/build/onebranch/ci-api-validation-steps.yml
@@ -2,7 +2,7 @@ steps:
 - task: DownloadPipelineArtifact@2
   displayName: 'Download BotBuilderDLLs from Artifacts'
   inputs:
-    artifactName: 'BotBuilderDLLs-Debug-Windows-netcoreapp31'
+    artifactName: 'BotBuilderDLLs-Debug-Windows-net8'
     targetPath: '$(System.ArtifactsDirectory)/OutputDlls'
 
 - task: DownloadPipelineArtifact@2

--- a/build/onebranch/ci-test-steps.yml
+++ b/build/onebranch/ci-test-steps.yml
@@ -20,22 +20,12 @@ steps:
     customCommand: 'install -g @microsoft/botframework-cli@next'
 
 - task: UseDotNet@2
-  displayName: "Install .NET Core 3.1.415"
+  displayName: "Install .NET Core 6.0"
   continueOnError: true
   inputs:
     packageType: "sdk"
-    version: 3.1.415
-  condition: and(succeeded(), eq(variables['BuildConfiguration'],'Release-Windows'), eq(variables['BuildTarget'],'netcoreapp31'))
-
-- task: DotNetCoreCLI@2
-  displayName: 'dotnet test (release) 3.1'
-  inputs:
-    command: test
-    projects: |
-     Tests/**/*Tests.csproj
-
-    arguments: '-v n  -f netcoreapp3.1 --configuration release --no-build --no-restore --filter "TestCategory!=IgnoreInAutomatedBuild&TestCategory!=FunctionalTests" --collect:"Code Coverage" --settings $(Build.SourcesDirectory)\CodeCoverage.runsettings'
-  condition: and(succeeded(), eq(variables['BuildConfiguration'],'Release-Windows'), eq(variables['BuildTarget'],'netcoreapp31'))
+    version: 6.x
+  condition: and(succeeded(), eq(variables['BuildConfiguration'],'Release-Windows'), eq(variables['BuildTarget'],'net6'))
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test (release) 6.0'
@@ -46,6 +36,16 @@ steps:
 
     arguments: '-v n  -f net6.0 --configuration release --no-build --no-restore --filter "TestCategory!=IgnoreInAutomatedBuild&TestCategory!=FunctionalTests" --collect:"Code Coverage" --settings $(Build.SourcesDirectory)\CodeCoverage.runsettings'
   condition: and(succeeded(), eq(variables['BuildConfiguration'],'Release-Windows'), eq(variables['BuildTarget'],'net6'))
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet test (release) 8.0'
+  inputs:
+    command: test
+    projects: |
+     Tests/**/*Tests.csproj
+
+    arguments: '-v n  -f net80 --configuration release --no-build --no-restore --filter "TestCategory!=IgnoreInAutomatedBuild&TestCategory!=FunctionalTests" --collect:"Code Coverage" --settings $(Build.SourcesDirectory)\CodeCoverage.runsettings'
+  condition: and(succeeded(), eq(variables['BuildConfiguration'],'Release-Windows'), eq(variables['BuildTarget'],'net8'))
 
 - powershell: |
    # This task copies the code coverage file created by dotnet test into a well known location. In all

--- a/build/onebranch/ci-test-steps.yml
+++ b/build/onebranch/ci-test-steps.yml
@@ -44,7 +44,7 @@ steps:
     projects: |
      Tests/**/*Tests.csproj
 
-    arguments: '-v n  -f net80 --configuration release --no-build --no-restore --filter "TestCategory!=IgnoreInAutomatedBuild&TestCategory!=FunctionalTests" --collect:"Code Coverage" --settings $(Build.SourcesDirectory)\CodeCoverage.runsettings'
+    arguments: '-v n  -f net8.0 --configuration release --no-build --no-restore --filter "TestCategory!=IgnoreInAutomatedBuild&TestCategory!=FunctionalTests" --collect:"Code Coverage" --settings $(Build.SourcesDirectory)\CodeCoverage.runsettings'
   condition: and(succeeded(), eq(variables['BuildConfiguration'],'Release-Windows'), eq(variables['BuildTarget'],'net8'))
 
 - powershell: |

--- a/build/onebranch/ci-test-steps.yml
+++ b/build/onebranch/ci-test-steps.yml
@@ -19,6 +19,7 @@ steps:
     verbose: false
     customCommand: 'install -g @microsoft/botframework-cli@next'
 
+- task: UseDotNet@2
   displayName: "Install .NET Core 3.1.415"
   continueOnError: true
   inputs:

--- a/build/onebranch/ci-test-steps.yml
+++ b/build/onebranch/ci-test-steps.yml
@@ -19,13 +19,21 @@ steps:
     verbose: false
     customCommand: 'install -g @microsoft/botframework-cli@next'
 
-- task: UseDotNet@2
-  displayName: "Install .NET Core 6.0"
+  displayName: "Install .NET Core 3.1.415"
   continueOnError: true
   inputs:
     packageType: "sdk"
-    version: 6.x
-  condition: and(succeeded(), eq(variables['BuildConfiguration'],'Release-Windows'), eq(variables['BuildTarget'],'net6'))
+    version: 3.1.415
+  condition: and(succeeded(), eq(variables['BuildConfiguration'],'Release-Windows'), eq(variables['BuildTarget'],'netcoreapp31'))
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet test (release) 3.1'
+  inputs:
+    command: test
+    projects: |
+     Tests/**/*Tests.csproj
+    arguments: '-v n  -f netcoreapp3.1 --configuration release --no-build --no-restore --filter "TestCategory!=IgnoreInAutomatedBuild&TestCategory!=FunctionalTests" --collect:"Code Coverage" --settings $(Build.SourcesDirectory)\CodeCoverage.runsettings'
+  condition: and(succeeded(), eq(variables['BuildConfiguration'],'Release-Windows'), eq(variables['BuildTarget'],'netcoreapp31'))
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test (release) 6.0'

--- a/build/onebranch/pr.yml
+++ b/build/onebranch/pr.yml
@@ -42,14 +42,6 @@ variables:
 stages:
 - stage: Build
   jobs:
-  - job: Debug_Windows_Configuration_31
-    variables:
-      BuildConfiguration: Debug-Windows
-      BuildTarget: 'netcoreapp31' # set the TargetFramework property for tests to use netcoreapp3.1
-    steps:
-    - template: ci-build-steps.yml
-    - template: ci-test-steps.yml
-    - template: ci-component-detection-steps.yml
   - job: Debug_Windows_Configuration_6
     variables:
       BuildConfiguration: Debug-Windows
@@ -58,10 +50,10 @@ stages:
     - template: ci-build-steps.yml
     - template: ci-test-steps.yml
     - template: ci-component-detection-steps.yml
-  - job: Release_Windows_Configuration_31
+  - job: Debug_Windows_Configuration_8
     variables:
-      BuildConfiguration: Release-Windows
-      BuildTarget: 'netcoreapp31' # set the TargetFramework property for tests to use netcoreapp3.1
+      BuildConfiguration: Debug-Windows
+      BuildTarget: 'net8' # set the TargetFramework property for tests to use net8.0
     steps:
     - template: ci-build-steps.yml
     - template: ci-test-steps.yml
@@ -70,6 +62,14 @@ stages:
     variables:
       BuildConfiguration: Release-Windows
       BuildTarget: 'net6' # set the TargetFramework property for tests to use net6.0
+    steps:
+    - template: ci-build-steps.yml
+    - template: ci-test-steps.yml
+    - template: ci-component-detection-steps.yml
+  - job: Release_Windows_Configuration_8
+    variables:
+      BuildConfiguration: Release-Windows
+      BuildTarget: 'net8' # set the TargetFramework property for tests to use net8.0
       PublishCoverage: true
     steps:
     - template: ci-build-steps.yml

--- a/build/onebranch/pr.yml
+++ b/build/onebranch/pr.yml
@@ -42,6 +42,14 @@ variables:
 stages:
 - stage: Build
   jobs:
+  - job: Debug_Windows_Configuration_31
+    variables:
+      BuildConfiguration: Debug-Windows
+      BuildTarget: 'netcoreapp31' # set the TargetFramework property for tests to use netcoreapp3.1
+    steps:
+    - template: ci-build-steps.yml
+    - template: ci-test-steps.yml
+    - template: ci-component-detection-steps.yml
   - job: Debug_Windows_Configuration_6
     variables:
       BuildConfiguration: Debug-Windows
@@ -54,6 +62,14 @@ stages:
     variables:
       BuildConfiguration: Debug-Windows
       BuildTarget: 'net8' # set the TargetFramework property for tests to use net8.0
+    steps:
+    - template: ci-build-steps.yml
+    - template: ci-test-steps.yml
+    - template: ci-component-detection-steps.yml
+  - job: Release_Windows_Configuration_31
+    variables:
+      BuildConfiguration: Release-Windows
+      BuildTarget: 'netcoreapp31' # set the TargetFramework property for tests to use netcoreapp3.1
     steps:
     - template: ci-build-steps.yml
     - template: ci-test-steps.yml

--- a/build/yaml/botbuilder-dotnet-ci-mac.yml
+++ b/build/yaml/botbuilder-dotnet-ci-mac.yml
@@ -24,9 +24,9 @@ steps:
     version: 6.0.x
 
 - task: UseDotNet@2
-  displayName: 'Use .Net Core sdk 3.1.101'
+  displayName: 'Use .Net sdk 8.0'
   inputs:
-    version: 3.1.101
+    version: 8.0.x
 
 - powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
   displayName: 'Display env vars'

--- a/build/yaml/botbuilder-dotnet-ci.yml
+++ b/build/yaml/botbuilder-dotnet-ci.yml
@@ -42,14 +42,6 @@ variables:
 stages:
 - stage: Build
   jobs:
-  - job: Debug_Windows_Configuration_31
-    variables:
-      BuildConfiguration: Debug-Windows
-      BuildTarget: 'netcoreapp31' # set the TargetFramework property for tests to use netcoreapp3.1
-    steps:
-    - template: ci-build-steps.yml
-    - template: ci-test-steps.yml
-    - template: ci-component-detection-steps.yml
   - job: Debug_Windows_Configuration_6
     variables:
       BuildConfiguration: Debug-Windows
@@ -58,10 +50,10 @@ stages:
     - template: ci-build-steps.yml
     - template: ci-test-steps.yml
     - template: ci-component-detection-steps.yml
-  - job: Release_Windows_Configuration_31
+  - job: Debug_Windows_Configuration_8
     variables:
-      BuildConfiguration: Release-Windows
-      BuildTarget: 'netcoreapp31' # set the TargetFramework property for tests to use netcoreapp3.1
+      BuildConfiguration: Debug-Windows
+      BuildTarget: 'net8' # set the TargetFramework property for tests to use net8.0
     steps:
     - template: ci-build-steps.yml
     - template: ci-test-steps.yml
@@ -70,6 +62,14 @@ stages:
     variables:
       BuildConfiguration: Release-Windows
       BuildTarget: 'net6' # set the TargetFramework property for tests to use net6.0
+    steps:
+    - template: ci-build-steps.yml
+    - template: ci-test-steps.yml
+    - template: ci-component-detection-steps.yml
+  - job: Release_Windows_Configuration_8
+    variables:
+      BuildConfiguration: Release-Windows
+      BuildTarget: 'net8' # set the TargetFramework property for tests to use net8.0
       PublishCoverage: true
     steps:
     - template: ci-build-steps.yml

--- a/build/yaml/botbuilder-dotnet-ci.yml
+++ b/build/yaml/botbuilder-dotnet-ci.yml
@@ -42,6 +42,14 @@ variables:
 stages:
 - stage: Build
   jobs:
+  - job: Debug_Windows_Configuration_31
+    variables:
+      BuildConfiguration: Debug-Windows
+      BuildTarget: 'netcoreapp31' # set the TargetFramework property for tests to use netcoreapp3.1
+    steps:
+    - template: ci-build-steps.yml
+    - template: ci-test-steps.yml
+    - template: ci-component-detection-steps.yml
   - job: Debug_Windows_Configuration_6
     variables:
       BuildConfiguration: Debug-Windows
@@ -54,6 +62,14 @@ stages:
     variables:
       BuildConfiguration: Debug-Windows
       BuildTarget: 'net8' # set the TargetFramework property for tests to use net8.0
+    steps:
+    - template: ci-build-steps.yml
+    - template: ci-test-steps.yml
+    - template: ci-component-detection-steps.yml
+  - job: Release_Windows_Configuration_31
+    variables:
+      BuildConfiguration: Release-Windows
+      BuildTarget: 'netcoreapp31' # set the TargetFramework property for tests to use netcoreapp3.1
     steps:
     - template: ci-build-steps.yml
     - template: ci-test-steps.yml

--- a/build/yaml/ci-api-validation-steps.yml
+++ b/build/yaml/ci-api-validation-steps.yml
@@ -2,7 +2,7 @@ steps:
 - task: DownloadPipelineArtifact@2
   displayName: 'Download BotBuilderDLLs from Artifacts'
   inputs:
-    artifactName: 'BotBuilderDLLs-Debug-Windows-netcoreapp31'
+    artifactName: 'BotBuilderDLLs-Debug-Windows-net8'
     targetPath: '$(System.ArtifactsDirectory)/OutputDlls'
 
 - task: DownloadPipelineArtifact@2

--- a/build/yaml/ci-test-steps.yml
+++ b/build/yaml/ci-test-steps.yml
@@ -20,22 +20,12 @@ steps:
     customCommand: 'install -g @microsoft/botframework-cli@next'
 
 - task: UseDotNet@2
-  displayName: "Install .NET Core 3.1.415"
+  displayName: "Install .NET Core 6.0"
   continueOnError: true
   inputs:
     packageType: "sdk"
-    version: 3.1.415
-  condition: and(succeeded(), eq(variables['BuildConfiguration'],'Release-Windows'), eq(variables['BuildTarget'],'netcoreapp31'))
-
-- task: DotNetCoreCLI@2
-  displayName: 'dotnet test (release) 3.1'
-  inputs:
-    command: test
-    projects: |
-     Tests/**/*Tests.csproj
-
-    arguments: '-v n  -f netcoreapp3.1 --configuration release --no-build --no-restore --filter "TestCategory!=IgnoreInAutomatedBuild&TestCategory!=FunctionalTests" --collect:"Code Coverage" --settings $(Build.SourcesDirectory)\CodeCoverage.runsettings'
-  condition: and(succeeded(), eq(variables['BuildConfiguration'],'Release-Windows'), eq(variables['BuildTarget'],'netcoreapp31'))
+    version: 6.x
+  condition: and(succeeded(), eq(variables['BuildConfiguration'],'Release-Windows'), eq(variables['BuildTarget'],'net6'))
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test (release) 6.0'
@@ -46,6 +36,16 @@ steps:
 
     arguments: '-v n  -f net6.0 --configuration release --no-build --no-restore --filter "TestCategory!=IgnoreInAutomatedBuild&TestCategory!=FunctionalTests" --collect:"Code Coverage" --settings $(Build.SourcesDirectory)\CodeCoverage.runsettings'
   condition: and(succeeded(), eq(variables['BuildConfiguration'],'Release-Windows'), eq(variables['BuildTarget'],'net6'))
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet test (release) 8.0'
+  inputs:
+    command: test
+    projects: |
+     Tests/**/*Tests.csproj
+
+    arguments: '-v n  -f net8.0 --configuration release --no-build --no-restore --filter "TestCategory!=IgnoreInAutomatedBuild&TestCategory!=FunctionalTests" --collect:"Code Coverage" --settings $(Build.SourcesDirectory)\CodeCoverage.runsettings'
+  condition: and(succeeded(), eq(variables['BuildConfiguration'],'Release-Windows'), eq(variables['BuildTarget'],'net8'))
 
 - powershell: |
    # This task copies the code coverage file created by dotnet test into a well known location. In all

--- a/build/yaml/ci-test-steps.yml
+++ b/build/yaml/ci-test-steps.yml
@@ -19,6 +19,7 @@ steps:
     verbose: false
     customCommand: 'install -g @microsoft/botframework-cli@next'
 
+- task: UseDotNet@2
   displayName: "Install .NET Core 3.1.415"
   continueOnError: true
   inputs:

--- a/build/yaml/ci-test-steps.yml
+++ b/build/yaml/ci-test-steps.yml
@@ -19,13 +19,21 @@ steps:
     verbose: false
     customCommand: 'install -g @microsoft/botframework-cli@next'
 
-- task: UseDotNet@2
-  displayName: "Install .NET Core 6.0"
+  displayName: "Install .NET Core 3.1.415"
   continueOnError: true
   inputs:
     packageType: "sdk"
-    version: 6.x
-  condition: and(succeeded(), eq(variables['BuildConfiguration'],'Release-Windows'), eq(variables['BuildTarget'],'net6'))
+    version: 3.1.415
+  condition: and(succeeded(), eq(variables['BuildConfiguration'],'Release-Windows'), eq(variables['BuildTarget'],'netcoreapp31'))
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet test (release) 3.1'
+  inputs:
+    command: test
+    projects: |
+     Tests/**/*Tests.csproj
+    arguments: '-v n  -f netcoreapp3.1 --configuration release --no-build --no-restore --filter "TestCategory!=IgnoreInAutomatedBuild&TestCategory!=FunctionalTests" --collect:"Code Coverage" --settings $(Build.SourcesDirectory)\CodeCoverage.runsettings'
+  condition: and(succeeded(), eq(variables['BuildConfiguration'],'Release-Windows'), eq(variables['BuildTarget'],'netcoreapp31'))
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test (release) 6.0'

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <PackageId>Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime</PackageId>
     <Description>Library for building Adaptive Runtime bots using the Bot Framework SDK</Description>
     <Summary>Library for building Adaptive Runtime bots using the Bot Framework SDK</Summary>
@@ -22,11 +22,11 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.csproj
@@ -22,7 +22,16 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net8.0'">
+  <!--It is necessary to separate these conditionals in order to avoid nuget restore errors with netcoreapp3.1.-->
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <PackageId>Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime</PackageId>
     <Description>Library for building Adaptive Runtime bots using the Bot Framework SDK</Description>
     <Summary>Library for building Adaptive Runtime bots using the Bot Framework SDK</Summary>
@@ -22,7 +22,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net8.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net8.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.csproj
@@ -22,11 +22,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net8.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/libraries/Microsoft.Bot.Connector/Microsoft.Bot.Connector.csproj
+++ b/libraries/Microsoft.Bot.Connector/Microsoft.Bot.Connector.csproj
@@ -23,7 +23,6 @@
   <PropertyGroup>
     <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
     <NoWarn>$(NoWarn);SX1309</NoWarn>
-    <NoWarn>$(NoWarn);NU1901</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/libraries/Microsoft.Bot.Connector/Microsoft.Bot.Connector.csproj
+++ b/libraries/Microsoft.Bot.Connector/Microsoft.Bot.Connector.csproj
@@ -23,6 +23,7 @@
   <PropertyGroup>
     <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
     <NoWarn>$(NoWarn);SX1309</NoWarn>
+    <NoWarn>$(NoWarn);NU1901</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <PackageId>Microsoft.Bot.Builder.Integration.ApplicationInsights.Core</PackageId>
     <Description>This library integrates the Microsoft Bot Builder SDK with Application Insights.</Description>
     <Summary>This library provides integration between the Microsoft Bot Builder SDK and Application Insights.</Summary>
@@ -20,7 +20,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />    
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.csproj
@@ -20,7 +20,24 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net8.0'">
+  <!--It is necessary to separate these conditionals in order to avoid nuget restore errors with netcoreapp3.1.-->
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />    
+    <!-- Force Microsoft.AspNetCore.Http to a safe version. -->
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.0" />
+  </ItemGroup>
+
+   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />    
+    <!-- Force Microsoft.AspNetCore.Http to a safe version. -->
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.0" />
+  </ItemGroup>
+
+   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />    

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.csproj
@@ -20,18 +20,10 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net8.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />    
-    <!-- Force Microsoft.AspNetCore.Http to a safe version. -->
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <!-- Force Microsoft.AspNetCore.Http to a safe version. -->
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.0" />
   </ItemGroup>

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <PackageId>Microsoft.Bot.Builder.Integration.ApplicationInsights.Core</PackageId>
     <Description>This library integrates the Microsoft Bot Builder SDK with Application Insights.</Description>
     <Summary>This library provides integration between the Microsoft Bot Builder SDK and Application Insights.</Summary>
@@ -20,7 +20,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net8.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net8.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />    

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <Description>This library integrates the Microsoft Bot Builder SDK with ASP.NET Core. It offers idiomatic configuration APIs in addition to providing all the plumbing to direct incoming bot messages to a configured bot.</Description>
     <Summary>This library provides integration between the Microsoft Bot Builder SDK and ASP.NET Core.</Summary>
   </PropertyGroup>
@@ -19,11 +19,11 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
@@ -19,14 +19,10 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net8.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-  
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <!-- Explicitly set to 5.0.1 for those built against 2.0-->
     <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <Description>This library integrates the Microsoft Bot Builder SDK with ASP.NET Core. It offers idiomatic configuration APIs in addition to providing all the plumbing to direct incoming bot messages to a configured bot.</Description>
     <Summary>This library provides integration between the Microsoft Bot Builder SDK and ASP.NET Core.</Summary>
   </PropertyGroup>
@@ -19,7 +19,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net8.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net8.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
@@ -19,7 +19,16 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net8.0'">
+  <!--It is necessary to separate these conditionals in order to avoid nuget restore errors with netcoreapp3.1.-->
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>594af4a1-e396-4609-8198-d665eb0c1f78</UserSecretsId>
   </PropertyGroup>
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.SecondaryTestBot/Microsoft.Bot.Builder.Adapters.Facebook.SecondaryTestBot.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.SecondaryTestBot/Microsoft.Bot.Builder.Adapters.Facebook.SecondaryTestBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>dae2bae8-b3c8-4b83-8b3c-4022669c7a20</UserSecretsId>
   </PropertyGroup>
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/Microsoft.Bot.Builder.Adapters.Facebook.Tests.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/Microsoft.Bot.Builder.Adapters.Facebook.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/Microsoft.Bot.Builder.Adapters.Facebook.Tests.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/Microsoft.Bot.Builder.Adapters.Facebook.Tests.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.TestBot/Microsoft.Bot.Builder.Adapters.Slack.TestBot.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.TestBot/Microsoft.Bot.Builder.Adapters.Slack.TestBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <!-- The SlackAPI package isn't signed, so supress the warning. There seems to not be a way to supress this for ONLY SlackAPI. -->
     <NoWarn>$(NoWarn),CS8002</NoWarn>
     <UserSecretsId>3c783a33-e2a5-4acd-99dd-581d563d47e3</UserSecretsId>

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/Microsoft.Bot.Builder.Adapters.Slack.Tests.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/Microsoft.Bot.Builder.Adapters.Slack.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/Microsoft.Bot.Builder.Adapters.Slack.Tests.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/Microsoft.Bot.Builder.Adapters.Slack.Tests.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.TestBot/Microsoft.Bot.Builder.Adapters.Twilio.TestBot.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.TestBot/Microsoft.Bot.Builder.Adapters.Twilio.TestBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/Microsoft.Bot.Builder.Adapters.Twilio.Tests.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/Microsoft.Bot.Builder.Adapters.Twilio.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/Microsoft.Bot.Builder.Adapters.Twilio.Tests.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/Microsoft.Bot.Builder.Adapters.Twilio.Tests.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.TestBot/Microsoft.Bot.Builder.Adapters.Webex.TestBot.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.TestBot/Microsoft.Bot.Builder.Adapters.Webex.TestBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <!-- The WebExTeams package isn't signed, so supress the warning. -->
     <NoWarn>$(NoWarn),CS8002</NoWarn>
     <UserSecretsId>63730bc1-f7d4-4b32-8efe-ce03907b3e0a</UserSecretsId>

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/Microsoft.Bot.Builder.Adapters.Webex.Tests.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/Microsoft.Bot.Builder.Adapters.Webex.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <!-- The Thrzn41.WebexTeams package isn't signed, so supress the warning. There seems to not be a way to supress this for ONLY Thrzn41.WebexTeams. -->

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/Microsoft.Bot.Builder.Adapters.Webex.Tests.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/Microsoft.Bot.Builder.Adapters.Webex.Tests.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <!-- The Thrzn41.WebexTeams package isn't signed, so supress the warning. There seems to not be a way to supress this for ONLY Thrzn41.WebexTeams. -->

--- a/tests/AdaptiveExpressions.Tests/AdaptiveExpressions.Tests.csproj
+++ b/tests/AdaptiveExpressions.Tests/AdaptiveExpressions.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/AdaptiveExpressions.Tests/AdaptiveExpressions.Tests.csproj
+++ b/tests/AdaptiveExpressions.Tests/AdaptiveExpressions.Tests.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -1048,11 +1048,7 @@ namespace AdaptiveExpressions.Tests
             Test("lastIndexOf(newGuid(), '-')", 23),
             Test("lastIndexOf(hello, '-')", -1),
             Test("lastIndexOf(nullObj, '-')", -1),
-#if NET5_0_OR_GREATER //There's a breaking change in .NET5 for this particular case. See https://docs.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/5.0/lastindexof-improved-handling-of-empty-values#change-description
             Test("lastIndexOf(hello, nullObj)", 5),
-#else
-            Test("lastIndexOf(hello, nullObj)", 4),
-#endif
             Test("lastIndexOf(json('[\"a\", \"b\", \"a\"]'), 'a')", 2),
             Test("lastIndexOf(json('[\"a\", \"b\"]'), 'c')", -1),
             Test("lastIndexOf(createArray('abc', 'def', 'ghi', 'def'), 'def')", 3),

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -1048,7 +1048,11 @@ namespace AdaptiveExpressions.Tests
             Test("lastIndexOf(newGuid(), '-')", 23),
             Test("lastIndexOf(hello, '-')", -1),
             Test("lastIndexOf(nullObj, '-')", -1),
+#if NET5_0_OR_GREATER //There's a breaking change in .NET5 for this particular case. See https://docs.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/5.0/lastindexof-improved-handling-of-empty-values#change-description
             Test("lastIndexOf(hello, nullObj)", 5),
+#else
+            Test("lastIndexOf(hello, nullObj)", 4),
+#endif
             Test("lastIndexOf(json('[\"a\", \"b\", \"a\"]'), 'a')", 2),
             Test("lastIndexOf(json('[\"a\", \"b\"]'), 'c')", -1),
             Test("lastIndexOf(createArray('abc', 'def', 'ghi', 'def'), 'def')", 3),

--- a/tests/Auth/bot-authentication/AuthenticationBot.csproj
+++ b/tests/Auth/bot-authentication/AuthenticationBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/Microsoft.Bot.Builder.AI.Luis.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/Microsoft.Bot.Builder.AI.Luis.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/Microsoft.Bot.Builder.AI.Luis.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/Microsoft.Bot.Builder.AI.Luis.Tests.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.AI.Luis.TestUtils/Microsoft.Bot.Builder.AI.Luis.TestUtils.csproj
+++ b/tests/Microsoft.Bot.Builder.AI.Luis.TestUtils/Microsoft.Bot.Builder.AI.Luis.TestUtils.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
 

--- a/tests/Microsoft.Bot.Builder.AI.Luis.TestUtils/Microsoft.Bot.Builder.AI.Luis.TestUtils.csproj
+++ b/tests/Microsoft.Bot.Builder.AI.Luis.TestUtils/Microsoft.Bot.Builder.AI.Luis.TestUtils.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
 

--- a/tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/Microsoft.Bot.Builder.AI.QnA.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/Microsoft.Bot.Builder.AI.QnA.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/Microsoft.Bot.Builder.AI.QnA.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/Microsoft.Bot.Builder.AI.QnA.Tests.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.Ai.LUISV3.tests/Microsoft.Bot.Builder.AI.LuisV3.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Ai.LUISV3.tests/Microsoft.Bot.Builder.AI.LuisV3.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.Ai.LUISV3.tests/Microsoft.Bot.Builder.AI.LuisV3.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Ai.LUISV3.tests/Microsoft.Bot.Builder.AI.LuisV3.Tests.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.ApplicationInsights.Tests/Microsoft.Bot.Builder.ApplicationInsights.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.ApplicationInsights.Tests/Microsoft.Bot.Builder.ApplicationInsights.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.ApplicationInsights.Tests/Microsoft.Bot.Builder.ApplicationInsights.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.ApplicationInsights.Tests/Microsoft.Bot.Builder.ApplicationInsights.Tests.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/Microsoft.Bot.Builder.Azure.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/Microsoft.Bot.Builder.Azure.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/Microsoft.Bot.Builder.Azure.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/Microsoft.Bot.Builder.Azure.Tests.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Profiling/Microsoft.Bot.Builder.Dialogs.Adaptive.Profiling.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Profiling/Microsoft.Bot.Builder.Dialogs.Adaptive.Profiling.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ConditionalsTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ConditionalsTests.cs
@@ -1,16 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions;
 using Microsoft.Bot.Schema;
 using Xunit;
-using dbg = System.Diagnostics;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 {
@@ -246,7 +242,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
         private void AssertExpression(OnCondition condition, string expectedExpression)
         {
             var exp = condition.GetExpression();
-            dbg.Trace.TraceInformation(exp.ToString());
+            Trace.TraceInformation(exp.ToString());
             Assert.Equal(expectedExpression, exp.ToString());
         }
     }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Configurations>Debug;Release</Configurations>
     <!-- The MockHttp package isn't signed, so supress the warning. -->

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Configurations>Debug;Release</Configurations>
     <!-- The MockHttp package isn't signed, so supress the warning. -->

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/Microsoft.Bot.Builder.Dialogs.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/Microsoft.Bot.Builder.Dialogs.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/Microsoft.Bot.Builder.Dialogs.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/Microsoft.Bot.Builder.Dialogs.Tests.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Microsoft.Bot.Builder.LanguageGeneration.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Microsoft.Bot.Builder.LanguageGeneration.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Microsoft.Bot.Builder.LanguageGeneration.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Microsoft.Bot.Builder.LanguageGeneration.Tests.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/Microsoft.Bot.Builder.TemplateManager/Microsoft.Bot.Builder.TemplateManager.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.TemplateManager/Microsoft.Bot.Builder.TemplateManager.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.TemplateManager/Microsoft.Bot.Builder.TemplateManager.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.TemplateManager/Microsoft.Bot.Builder.TemplateManager.Tests.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/Microsoft.Bot.Builder.TestBot.Json.csproj
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/Microsoft.Bot.Builder.TestBot.Json.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>TestBot</UserSecretsId>
     <Configurations>Debug;Release</Configurations>
     <!-- The Jurrasic package isn't signed, so supress the warning. -->

--- a/tests/Microsoft.Bot.Builder.TestBot.Tests/Microsoft.Bot.Builder.TestBot.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.TestBot.Tests/Microsoft.Bot.Builder.TestBot.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AssemblyName>Microsoft.Bot.Builder.TestBot.Tests</AssemblyName>
     <RootNamespace>Microsoft.BotBuilderSamples.Tests</RootNamespace>

--- a/tests/Microsoft.Bot.Builder.TestBot.Tests/Microsoft.Bot.Builder.TestBot.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.TestBot.Tests/Microsoft.Bot.Builder.TestBot.Tests.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AssemblyName>Microsoft.Bot.Builder.TestBot.Tests</AssemblyName>
     <RootNamespace>Microsoft.BotBuilderSamples.Tests</RootNamespace>

--- a/tests/Microsoft.Bot.Builder.TestBot/Microsoft.Bot.Builder.TestBot.csproj
+++ b/tests/Microsoft.Bot.Builder.TestBot/Microsoft.Bot.Builder.TestBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>f277272c-9113-411f-addd-a4acfa9701a2</UserSecretsId>
     <RootNamespace>Microsoft.BotBuilderSamples</RootNamespace>
   </PropertyGroup>

--- a/tests/Microsoft.Bot.Builder.TestBot/wwwroot/default.htm
+++ b/tests/Microsoft.Bot.Builder.TestBot/wwwroot/default.htm
@@ -5,7 +5,7 @@
     <meta charset="utf-8" />
 </head>
 <body style="font-family:'Segoe UI'">
-    <h1>TestBot using ASP.Net 6</h1>
+    <h1>TestBot using ASP.Net 8</h1>
     <p>Describe your bot here and your terms of use etc.</p>
     <p>To debug your bot using the Bot Framework Emulator, paste this URL into the Emulator window:</p>
     <div style="padding-left: 50px;" id="botBaseUrl"></div>

--- a/tests/Microsoft.Bot.Builder.TestProtocol/Microsoft.Bot.Builder.TestProtocol.csproj
+++ b/tests/Microsoft.Bot.Builder.TestProtocol/Microsoft.Bot.Builder.TestProtocol.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>1ae6e573-b022-4bd5-b6b5-7ea57e4977f8</UserSecretsId>
   </PropertyGroup>
 

--- a/tests/Microsoft.Bot.Builder.Testing.Tests/Microsoft.Bot.Builder.Testing.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Testing.Tests/Microsoft.Bot.Builder.Testing.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.Testing.Tests/Microsoft.Bot.Builder.Testing.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Testing.Tests/Microsoft.Bot.Builder.Testing.Tests.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.Tests/Microsoft.Bot.Builder.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Tests/Microsoft.Bot.Builder.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.Tests/Microsoft.Bot.Builder.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Tests/Microsoft.Bot.Builder.Tests.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.Transcripts.Tests/Microsoft.Bot.Builder.Transcripts.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Transcripts.Tests/Microsoft.Bot.Builder.Transcripts.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.Transcripts.Tests/Microsoft.Bot.Builder.Transcripts.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Transcripts.Tests/Microsoft.Bot.Builder.Transcripts.Tests.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Configuration.Tests/Microsoft.Bot.Configuration.Tests.csproj
+++ b/tests/Microsoft.Bot.Configuration.Tests/Microsoft.Bot.Configuration.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Configuration.Tests/Microsoft.Bot.Configuration.Tests.csproj
+++ b/tests/Microsoft.Bot.Configuration.Tests/Microsoft.Bot.Configuration.Tests.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Connector.Streaming.Perf/Microsoft.Bot.Connector.Streaming.Perf.csproj
+++ b/tests/Microsoft.Bot.Connector.Streaming.Perf/Microsoft.Bot.Connector.Streaming.Perf.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
 

--- a/tests/Microsoft.Bot.Connector.Streaming.Tests.Client/Microsoft.Bot.Connector.Streaming.Tests.Client.csproj
+++ b/tests/Microsoft.Bot.Connector.Streaming.Tests.Client/Microsoft.Bot.Connector.Streaming.Tests.Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Bot.Connector.Streaming.Tests.Server/Microsoft.Bot.Connector.Streaming.Tests.Server.csproj
+++ b/tests/Microsoft.Bot.Connector.Streaming.Tests.Server/Microsoft.Bot.Connector.Streaming.Tests.Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/tests/Microsoft.Bot.Connector.Streaming.Tests/Microsoft.Bot.Connector.Streaming.Tests.csproj
+++ b/tests/Microsoft.Bot.Connector.Streaming.Tests/Microsoft.Bot.Connector.Streaming.Tests.csproj
@@ -1,9 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Connector.Streaming.Tests/Microsoft.Bot.Connector.Streaming.Tests.csproj
+++ b/tests/Microsoft.Bot.Connector.Streaming.Tests/Microsoft.Bot.Connector.Streaming.Tests.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/JwtTokenExtractorTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/JwtTokenExtractorTests.cs
@@ -158,9 +158,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
             };
         }
 
-#if NET5_0_OR_GREATER
         [SupportedOSPlatform("windows")]
-#endif
         private static X509Certificate2 CreateSelfSignedCertificate(string cn, DateTimeOffset from, DateTimeOffset to)
         {
             var parameters = new CspParameters(24, "Microsoft Enhanced RSA and AES Cryptographic Provider")
@@ -186,9 +184,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
             return cert;
         }
 
-#if NET5_0_OR_GREATER
         [SupportedOSPlatform("windows")]
-#endif
         private static void DeleteKeyContainer(string cn)
         {
             // %APPDATA%\Microsoft\Crypto\RSA

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/JwtTokenExtractorTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/JwtTokenExtractorTests.cs
@@ -11,7 +11,6 @@ using System.Runtime.Versioning;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
@@ -158,7 +157,9 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
             };
         }
 
+#if NET5_0_OR_GREATER
         [SupportedOSPlatform("windows")]
+#endif
         private static X509Certificate2 CreateSelfSignedCertificate(string cn, DateTimeOffset from, DateTimeOffset to)
         {
             var parameters = new CspParameters(24, "Microsoft Enhanced RSA and AES Cryptographic Provider")
@@ -184,7 +185,9 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
             return cert;
         }
 
+#if NET5_0_OR_GREATER
         [SupportedOSPlatform("windows")]
+#endif
         private static void DeleteKeyContainer(string cn)
         {
             // %APPDATA%\Microsoft\Crypto\RSA

--- a/tests/Microsoft.Bot.Connector.Tests/BaseTest.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/BaseTest.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Bot.Connector.Tests
     ///
     ///    To re-record:
     ///      1. All from live/unmocked, except set HttpRecorderMode to Record.
-    ///      2. Once done recording, copy recording sessions from ...Microsoft.Bot.Connector.Tests\bin\Debug\netcoreapp3.1\SessionRecords
+    ///      2. Once done recording, copy recording sessions from ...Microsoft.Bot.Connector.Tests\bin\Debug\net8.0\SessionRecords
     ///             to ...Microsoft.Bot.Connector.Tests\SessionRecords.
     /// </summary>
     public class BaseTest

--- a/tests/Microsoft.Bot.Connector.Tests/Microsoft.Bot.Connector.Tests.csproj
+++ b/tests/Microsoft.Bot.Connector.Tests/Microsoft.Bot.Connector.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Connector.Tests/Microsoft.Bot.Connector.Tests.csproj
+++ b/tests/Microsoft.Bot.Connector.Tests/Microsoft.Bot.Connector.Tests.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Schema.Tests/Microsoft.Bot.Schema.Tests.csproj
+++ b/tests/Microsoft.Bot.Schema.Tests/Microsoft.Bot.Schema.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Schema.Tests/Microsoft.Bot.Schema.Tests.csproj
+++ b/tests/Microsoft.Bot.Schema.Tests/Microsoft.Bot.Schema.Tests.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Streaming.Tests/Microsoft.Bot.Streaming.Tests.csproj
+++ b/tests/Microsoft.Bot.Streaming.Tests/Microsoft.Bot.Streaming.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/Microsoft.Bot.Streaming.Tests/Microsoft.Bot.Streaming.Tests.csproj
+++ b/tests/Microsoft.Bot.Streaming.Tests/Microsoft.Bot.Streaming.Tests.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/Parsers/Microsoft.Bot.Builder.Parsers.LU.Tests/Microsoft.Bot.Builder.Parsers.LU.Tests.csproj
+++ b/tests/Parsers/Microsoft.Bot.Builder.Parsers.LU.Tests/Microsoft.Bot.Builder.Parsers.LU.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Parsers/Microsoft.Bot.Builder.Parsers.LU.Tests/Microsoft.Bot.Builder.Parsers.LU.Tests.csproj
+++ b/tests/Parsers/Microsoft.Bot.Builder.Parsers.LU.Tests/Microsoft.Bot.Builder.Parsers.LU.Tests.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Skills/Bot1/Bot1.csproj
+++ b/tests/Skills/Bot1/Bot1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Skills/Bot2/Bot2.csproj
+++ b/tests/Skills/Bot2/Bot2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Skills/Bot3/Bot3.csproj
+++ b/tests/Skills/Bot3/Bot3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Skills/Child/Child.csproj
+++ b/tests/Skills/Child/Child.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>f277272c-9113-411f-addd-a4acfa9701a2</UserSecretsId>
     <RootNamespace>Microsoft.BotBuilderSamples</RootNamespace>
   </PropertyGroup>

--- a/tests/Skills/Parent/Parent.csproj
+++ b/tests/Skills/Parent/Parent.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>f277272c-9113-411f-addd-a4acfa9701a2</UserSecretsId>
     <RootNamespace>Microsoft.BotBuilderSamples</RootNamespace>
   </PropertyGroup>

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/Microsoft.Bot.ApplicationInsights.Core.Tests.csproj
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/Microsoft.Bot.ApplicationInsights.Core.Tests.csproj
@@ -1,24 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.6" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.4" />
-  </ItemGroup>
-  
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/Microsoft.Bot.ApplicationInsights.Core.Tests.csproj
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/Microsoft.Bot.ApplicationInsights.Core.Tests.csproj
@@ -1,17 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.6" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.4" />
+  </ItemGroup>
+
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/Microsoft.Bot.ApplicationInsights.Core.Tests.csproj
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/Microsoft.Bot.ApplicationInsights.Core.Tests.csproj
@@ -10,11 +10,16 @@
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
 
+  <!--It is necessary to separate these conditionals in order to avoid nuget restore errors with netcoreapp3.1.-->
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.6" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net8.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.4" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.4" />
   </ItemGroup>
 

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests.csproj
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests.csproj
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>


### PR DESCRIPTION
Addresses # 6741
#minor

## Description
This PR updates the test projects, the test bots, and the CI pipelines to target .NET 8.
All these changes need to be done in one PR for the build checks to pass. 
We divided the changes into three commits to ease the review:

- Updated test projects ([7c65b52b127903bd74e0871c781d3dc551230646](https://github.com/southworks/botbuilder-dotnet/commit/7c65b52b127903bd74e0871c781d3dc551230646))
- Updated test bots ([405c6fdccaa455007f68ce29fa82321257a9e0dd](https://github.com/southworks/botbuilder-dotnet/commit/405c6fdccaa455007f68ce29fa82321257a9e0dd))
- Updated CI yamls ([ebbbf5d0433e58343d26acdeef3f2ca3c7cf5b8d](https://github.com/southworks/botbuilder-dotnet/commit/ebbbf5d0433e58343d26acdeef3f2ca3c7cf5b8d))

_Note: The FunctionalTests pipelines will be updated in a separate PR._

## Specific Changes
- **For the test projects:**
   - Update projects to target net8.0 as well as net6.0.
   - Removed any conditions considering frameworks lower than .NET5.
   - Fixed [CS8981](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/warning-waves#cs8981---the-type-name-only-contains-lower-cased-ascii-characters) issue in Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ConditionalsTests

- **For the bots projects:**
   - Updated all the bots to target .NET8 instead of .NET6.

- **For the CI pipelines yamls:**
   - Added steps to build and test targeting .NET8.
   - Removed steps to build and test targeting netcoreapp3.1.

## Testing
This image shows the TestBot bots working as expected after the update.
![image](https://github.com/southworks/botbuilder-dotnet/assets/44245136/ce755eb9-ccd4-41ee-a3bc-31a4802b755b)

Here we can see the CI pipeline working after the changes.
![image](https://github.com/southworks/botbuilder-dotnet/assets/44245136/30cb656a-b184-4891-bcc3-9336234041d1)
