### PR TITLE
fix: [#6746] Move SaveAllChanges method from SetProperty to OAuthInput

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SetProperties.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SetProperties.cs
@@ -85,9 +85,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                 dc.State.SetValue(propValue.Property.GetValue(dc.State), value);
             }
 
-            // save all state scopes to their respective botState locations.
-            await dc.Context.TurnState.Get<DialogStateManager>().SaveAllChangesAsync(cancellationToken).ConfigureAwait(false);
-
             return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SetProperty.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SetProperty.cs
@@ -89,9 +89,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 
             dc.State.SetValue(this.Property.GetValue(dc.State), value);
 
-            // save all state scopes to their respective botState locations.
-            await dc.Context.TurnState.Get<DialogStateManager>().SaveAllChangesAsync(cancellationToken).ConfigureAwait(false);
-
             return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/OAuthInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/OAuthInput.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using AdaptiveExpressions.Properties;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions;
+using Microsoft.Bot.Builder.Dialogs.Memory;
 using Microsoft.Bot.Schema;
 using Newtonsoft.Json;
 
@@ -312,7 +313,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             // Save state prior to sending OAuthCard: the invoke response for a token exchange from the root bot could come in
             // before this method ends or could land in another instance in scale-out scenarios, which means that if the state is not saved, 
             // the OAuthInput would not be at the top of the stack, and the token exchange invoke would get discarded.
-            await dc.Context.TurnState.Get<ConversationState>().SaveChangesAsync(dc.Context, false, cancellationToken).ConfigureAwait(false);
+            await dc.Context.TurnState.Get<DialogStateManager>().SaveAllChangesAsync(cancellationToken).ConfigureAwait(false);
 
             // Prepare OAuthCard
             var title = Title == null ? null : await Title.GetValueAsync(dc, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
#minor
Fixes # 6746

## Description
This PR moves the _SaveAllChanges_ functionality from the _SetProperty_ and _SetProperties_ classes to the _OAuthInput_ class.
Additionally, addressing the old issue (https://github.com/microsoft/BotFramework-Composer/issues/ 9533), that introduced this change.

## Specific Changes
  - Removed _SetProperty_ and _SetProperties_ _SaveAllChanges_ functionality, as it was causing message duplication in the Slack adapter.
  - Added the _SaveAllChanges_ functionality to the _OAuthInput_ class, before sending the _OAuthCard_ from the Skill to the Root to exchange the SSO token, and not loose state.

## Testing
The following image shows an SSO bot working, retrieving the user's state after exchanging the token, correctly.
![image](https://github.com/southworks/botbuilder-dotnet/assets/62260472/0f5c1b5c-b876-410e-9753-3a84d92e1cab)