### PR TITLE
[#6741] Update generators templates and VSIX to .Net 8

### DIFF
--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/.template.config/template.json
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/.template.config/template.json
@@ -46,6 +46,10 @@
         "datatype": "choice",
         "choices": [
           {
+            "choice": "netcoreapp3.1",
+            "description": "Target netcoreapp3.1"
+          },
+          {
             "choice": "net6.0",
             "description": "Target net6.0"
           },
@@ -65,7 +69,7 @@
         "isRequired": false
       },
       "ReadmeNetCorePrereqVersion": {
-        "type":"generated",
+        "type": "generated",
         "generator": "switch",
         "dataType": "string",
         "replaces": "__NETCORE_VERSION__",
@@ -113,7 +117,9 @@
         "condition": "(!SkipRestore)",
         "description": "Restore NuGet packages required by this project.",
         "manualInstructions": [
-          { "text": "Run 'dotnet restore'" }
+          {
+            "text": "Run 'dotnet restore'"
+          }
         ],
         "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
         "continueOnError": true

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/.template.config/template.json
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/.template.config/template.json
@@ -48,10 +48,14 @@
           {
             "choice": "net6.0",
             "description": "Target net6.0"
+          },
+          {
+            "choice": "net8.0",
+            "description": "Target net8.0"
           }
         ],
         "replaces": "__NETCOREAPP_VERSION__",
-        "defaultValue": "net6.0"
+        "defaultValue": "net8.0"
       },
       "IncludeTests": {
         "type": "parameter",
@@ -69,8 +73,8 @@
           "evaluator": "C++",
           "cases": [
             {
-              "condition": "(Framework==\"net6.0\")",
-              "value": "6.0"
+              "condition": "(Framework==\"net8.0\")",
+              "value": "8.0"
             }
           ]
         }

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/README.md
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/README.md
@@ -68,7 +68,7 @@ Once you created the LUIS model, update `appsettings.json` with your `LuisAppId`
 
 [Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot developers to test and debug their bots on localhost or running remotely through a tunnel.
 
-- Install the Bot Framework Emulator version 4.22.0 or greater from [here](https://github.com/Microsoft/BotFramework-Emulator/releases)
+- Install the latest v4 Bot Framework Emulator [here](https://github.com/Microsoft/BotFramework-Emulator/releases/latest)
 
 ### Connect to the bot using Bot Framework Emulator
 

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/README.md
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/README.md
@@ -68,7 +68,7 @@ Once you created the LUIS model, update `appsettings.json` with your `LuisAppId`
 
 [Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot developers to test and debug their bots on localhost or running remotely through a tunnel.
 
-- Install the Bot Framework Emulator version 4.9.0 or greater from [here](https://github.com/Microsoft/BotFramework-Emulator/releases)
+- Install the Bot Framework Emulator version 4.22.0 or greater from [here](https://github.com/Microsoft/BotFramework-Emulator/releases)
 
 ### Connect to the bot using Bot Framework Emulator
 

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/README.md
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/README.md
@@ -89,7 +89,7 @@ To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](htt
 - [Activity processing](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-concept-activity-processing?view=azure-bot-service-4.0)
 - [Azure Bot Service Introduction](https://docs.microsoft.com/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)
 - [Azure Bot Service Documentation](https://docs.microsoft.com/azure/bot-service/?view=azure-bot-service-4.0)
-- [.NET Core CLI tools](https://docs.microsoft.com/en-us/dotnet/core/tools/?tabs=netcore2x)
+- [.NET Core CLI tools](https://docs.microsoft.com/en-us/dotnet/core/tools)
 - [Azure CLI](https://docs.microsoft.com/cli/azure/?view=azure-cli-latest)
 - [Azure Portal](https://portal.azure.com)
 - [Language Understanding using LUIS](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/)

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/.template.config/template.json
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/.template.config/template.json
@@ -45,6 +45,10 @@
       "datatype": "choice",
       "choices": [
         {
+          "choice": "netcoreapp3.1",
+          "description": "Target netcoreapp3.1"
+        },
+        {
           "choice": "net6.0",
           "description": "Target net6.0"
         },
@@ -57,7 +61,7 @@
       "defaultValue": "net8.0"
     },
     "ReadmeNetCorePrereqVersion": {
-      "type":"generated",
+      "type": "generated",
       "generator": "switch",
       "dataType": "string",
       "replaces": "__NETCORE_VERSION__",
@@ -82,7 +86,12 @@
   "sources": [
     {
       "modifiers": [
-        {"exclude": [ "**/NuGet.Config", "**/.DS_Store" ]}
+        {
+          "exclude": [
+            "**/NuGet.Config",
+            "**/.DS_Store"
+          ]
+        }
       ]
     }
   ],
@@ -91,7 +100,9 @@
       "condition": "(!SkipRestore)",
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [
-        { "text": "Run 'dotnet restore'" }
+        {
+          "text": "Run 'dotnet restore'"
+        }
       ],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
       "continueOnError": true

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/.template.config/template.json
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/.template.config/template.json
@@ -47,10 +47,14 @@
         {
           "choice": "net6.0",
           "description": "Target net6.0"
+        },
+        {
+          "choice": "net8.0",
+          "description": "Target net8.0"
         }
       ],
       "replaces": "__NETCOREAPP_VERSION__",
-      "defaultValue": "net6.0"
+      "defaultValue": "net8.0"
     },
     "ReadmeNetCorePrereqVersion": {
       "type":"generated",
@@ -61,8 +65,8 @@
         "evaluator": "C++",
         "cases": [
           {
-            "condition": "(Framework==\"net6.0\")",
-            "value": "6.0"
+            "condition": "(Framework==\"net8.0\")",
+            "value": "8.0"
           }
         ]
       }

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/README.md
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/README.md
@@ -62,7 +62,7 @@ To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](htt
 - [Activity processing](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-concept-activity-processing?view=azure-bot-service-4.0)
 - [Azure Bot Service Introduction](https://docs.microsoft.com/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)
 - [Azure Bot Service Documentation](https://docs.microsoft.com/azure/bot-service/?view=azure-bot-service-4.0)
-- [.NET Core CLI tools](https://docs.microsoft.com/en-us/dotnet/core/tools/?tabs=netcore2x)
+- [.NET Core CLI tools](https://docs.microsoft.com/en-us/dotnet/core/tools)
 - [Azure CLI](https://docs.microsoft.com/cli/azure/?view=azure-cli-latest)
 - [Azure Portal](https://portal.azure.com)
 - [Language Understanding using LUIS](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/)

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/README.md
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/README.md
@@ -43,7 +43,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 [Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot developers to test and debug their bots on localhost or running remotely through a tunnel.
 
-- Install the Bot Framework Emulator version 4.22.0 or greater from [here](https://github.com/Microsoft/BotFramework-Emulator/releases)
+- Install the latest v4 Bot Framework Emulator [here](https://github.com/Microsoft/BotFramework-Emulator/releases/latest)
 
 ### Connect to the bot using Bot Framework Emulator
 

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/README.md
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/README.md
@@ -43,7 +43,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 [Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot developers to test and debug their bots on localhost or running remotely through a tunnel.
 
-- Install the Bot Framework Emulator version 4.9.0 or greater from [here](https://github.com/Microsoft/BotFramework-Emulator/releases)
+- Install the Bot Framework Emulator version 4.22.0 or greater from [here](https://github.com/Microsoft/BotFramework-Emulator/releases)
 
 ### Connect to the bot using Bot Framework Emulator
 

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/.template.config/template.json
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/.template.config/template.json
@@ -45,6 +45,10 @@
       "datatype": "choice",
       "choices": [
         {
+          "choice": "netcoreapp3.1",
+          "description": "Target netcoreapp3.1"
+        },
+        {
           "choice": "net6.0",
           "description": "Target net6.0"
         },
@@ -57,7 +61,7 @@
       "defaultValue": "net8.0"
     },
     "ReadmeNetCorePrereqVersion": {
-      "type":"generated",
+      "type": "generated",
       "generator": "switch",
       "dataType": "string",
       "replaces": "__NETCORE_VERSION__",
@@ -82,7 +86,12 @@
   "sources": [
     {
       "modifiers": [
-        {"exclude": [ "**/NuGet.Config", "**/.DS_Store" ]}
+        {
+          "exclude": [
+            "**/NuGet.Config",
+            "**/.DS_Store"
+          ]
+        }
       ]
     }
   ],
@@ -91,7 +100,9 @@
       "condition": "(!SkipRestore)",
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [
-        { "text": "Run 'dotnet restore'" }
+        {
+          "text": "Run 'dotnet restore'"
+        }
       ],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
       "continueOnError": true

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/.template.config/template.json
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/.template.config/template.json
@@ -47,10 +47,14 @@
         {
           "choice": "net6.0",
           "description": "Target net6.0"
+        },
+        {
+          "choice": "net8.0",
+          "description": "Target net8.0"
         }
       ],
       "replaces": "__NETCOREAPP_VERSION__",
-      "defaultValue": "net6.0"
+      "defaultValue": "net8.0"
     },
     "ReadmeNetCorePrereqVersion": {
       "type":"generated",
@@ -61,8 +65,8 @@
         "evaluator": "C++",
         "cases": [
           {
-            "condition": "(Framework==\"net6.0\")",
-            "value": "6.0"
+            "condition": "(Framework==\"net8.0\")",
+            "value": "8.0"
           }
         ]
       }

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/README.md
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/README.md
@@ -62,7 +62,7 @@ To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](htt
 - [Activity processing](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-concept-activity-processing?view=azure-bot-service-4.0)
 - [Azure Bot Service Introduction](https://docs.microsoft.com/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)
 - [Azure Bot Service Documentation](https://docs.microsoft.com/azure/bot-service/?view=azure-bot-service-4.0)
-- [.NET Core CLI tools](https://docs.microsoft.com/en-us/dotnet/core/tools/?tabs=netcore2x)
+- [.NET Core CLI tools](https://docs.microsoft.com/en-us/dotnet/core/tools)
 - [Azure CLI](https://docs.microsoft.com/cli/azure/?view=azure-cli-latest)
 - [Azure Portal](https://portal.azure.com)
 - [Language Understanding using LUIS](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/)

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/README.md
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/README.md
@@ -43,7 +43,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 [Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot developers to test and debug their bots on localhost or running remotely through a tunnel.
 
-- Install the Bot Framework Emulator version 4.22.0 or greater from [here](https://github.com/Microsoft/BotFramework-Emulator/releases)
+- Install the latest v4 Bot Framework Emulator [here](https://github.com/Microsoft/BotFramework-Emulator/releases/latest)
 
 ### Connect to the bot using Bot Framework Emulator
 

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/README.md
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/README.md
@@ -43,7 +43,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 [Bot Framework Emulator](https://github.com/microsoft/botframework-emulator) is a desktop application that allows bot developers to test and debug their bots on localhost or running remotely through a tunnel.
 
-- Install the Bot Framework Emulator version 4.9.0 or greater from [here](https://github.com/Microsoft/BotFramework-Emulator/releases)
+- Install the Bot Framework Emulator version 4.22.0 or greater from [here](https://github.com/Microsoft/BotFramework-Emulator/releases)
 
 ### Connect to the bot using Bot Framework Emulator
 

--- a/generators/dotnet-templates/README.md
+++ b/generators/dotnet-templates/README.md
@@ -255,7 +255,7 @@ The `nuget pack` command will build a package using a filename convention that i
 Given the example above with `.nuspec` `version` of 4.22.0, running `nuget pack Microsoft.BotFramework.CSharp.EchoBot` will create a NuGet package named `Microsoft.Bot.Framework.CSharp.EchoBot.4.22.0.nupkg`. We'll use this NuGet package name in subsequent steps.
 
 ```bash
-# install the locally built .nupkg (EchoBot template, assuming 4.9.0 version tag)
+# install the locally built .nupkg (EchoBot template, assuming 4.22.0 version tag)
 dotnet new install ./Microsoft.Bot.Framework.CSharp.EchoBot.4.22.0.nupkg
 ```
 

--- a/generators/dotnet-templates/README.md
+++ b/generators/dotnet-templates/README.md
@@ -3,7 +3,7 @@
 using core AI capabilities.
 
 ## About
-.NET Core Templates will help you to quickly build new conversational AI bots using [Bot Framework v4][1].  As of May 2020, these templates and the code they generate **require** [.NET Core 3.1][60].
+.NET Core Templates will help you to quickly build new conversational AI bots using [Bot Framework v4][1]. As of March 2024, these templates and the code they generate **require** [.NET Core 8.0][60].
 
 ## Templates
 There are three different template options.  The table below can help guide which template is right for you.
@@ -58,7 +58,7 @@ The Empty Bot template is the minimal skeleton code for a bot.  It provides a st
 
 
 ## Installation
-1.  Install [.NET Core SDK][4] version 3.1 or higher
+1.  Install [.NET Core SDK][4] version 8.0 or higher
 	```bash
 	# determine dotnet version
 	dotnet --version
@@ -97,17 +97,17 @@ The above installation steps will install all three Bot Framework templates.  If
 
 ```bash
 # Install EchoBot template
-dotnet new -i Microsoft.Bot.Framework.CSharp.EchoBot
+dotnet new install Microsoft.Bot.Framework.CSharp.EchoBot
 ```
 
 ```bash
 # Install CoreBot template
-dotnet new -i Microsoft.Bot.Framework.CSharp.CoreBot
+dotnet new install Microsoft.Bot.Framework.CSharp.CoreBot
 ```
 
 ```bash
 # Install EmptyBot template
-dotnet new -i Microsoft.Bot.Framework.CSharp.EmptyBot
+dotnet new install Microsoft.Bot.Framework.CSharp.EmptyBot
 ```
 
 
@@ -204,7 +204,7 @@ You can get the latest development builds from the [BotBuilder MyGet][51] feed. 
 To install the latest development build:
 ```bash
 # install the development build of Echo Bot template
-dotnet new -i Microsoft.Bot.Framework.CSharp.EchoBot --nuget-source https://botbuilder.myget.org/F/aitemplates/api/v3/index.json
+dotnet new install Microsoft.Bot.Framework.CSharp.EchoBot --nuget-source https://botbuilder.myget.org/F/aitemplates/api/v3/index.json
 ```
 
 To see a list of currently installed templates:
@@ -216,7 +216,7 @@ dotnet new --list
 To uninstall the development build:
 ```bash
 # uninstall the development build of Echo Bot template
-dotnet new -u Microsoft.Bot.Framework.CSharp.EchoBot
+dotnet new uninstall Microsoft.Bot.Framework.CSharp.EchoBot
 ```
 
 ## Creating a Local Development Environment
@@ -256,7 +256,7 @@ Given the example above with `.nuspec` `version` of 4.22.0, running `nuget pack 
 
 ```bash
 # install the locally built .nupkg (EchoBot template, assuming 4.9.0 version tag)
-dotnet new -i ./Microsoft.Bot.Framework.CSharp.EchoBot.4.22.0.nupkg
+dotnet new install ./Microsoft.Bot.Framework.CSharp.EchoBot.4.22.0.nupkg
 ```
 
 To see a list of currently installed templates.  With this command you should now see the locally build and installed NuGet package.
@@ -274,7 +274,7 @@ Build and test the newly generated project.
 
 ```bash
 # uninstall the locally built .nupkg (EchoBot template)
-dotnet new -u Microsoft.Bot.Framework.CSharp.EchoBot
+dotnet new uninstall Microsoft.Bot.Framework.CSharp.EchoBot
 ```
 
 ## Logging Issues and Providing Feedback

--- a/generators/dotnet-templates/README.md
+++ b/generators/dotnet-templates/README.md
@@ -58,7 +58,7 @@ The Empty Bot template is the minimal skeleton code for a bot.  It provides a st
 
 
 ## Installation
-1.  Install [.NET Core SDK][4] version 8.0 or higher
+1.  Install [.NET Core SDK][60] version 8.0 or higher
 	```bash
 	# determine dotnet version
 	dotnet --version

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/README.md
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/README.md
@@ -96,7 +96,7 @@ Select template of choice from Bot Builder v4 templates, then click **OK**.
 
 ### .NET Core CLI
 
-* Install the [.NET Core CLI tools](https://docs.microsoft.com/en-us/dotnet/core/tools/?tabs=netcore2x).
+* Install the [.NET Core CLI tools](https://docs.microsoft.com/en-us/dotnet/core/tools).
 * Using the command line, navigate to your project's root folder.
 * Type `dotnet run`.
 

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/CoreBot.csproj
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/CoreBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/CoreBot.vstemplate
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/CoreBot.vstemplate
@@ -1,6 +1,6 @@
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Project">
   <TemplateData>
-    <Name>Core Bot (Bot Framework v4 - .NET Core 3.1)</Name>
+    <Name>Core Bot (Bot Framework v4 - .NET Core 8.0)</Name>
     <Description>Core Bot Template for Bot Framework v4.  Our most feature rich template, it shows how to use LUIS and multi-turn conversational patterns.
     </Description>
     <ProjectType>CSharp</ProjectType>

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/README.md
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/README.md
@@ -19,7 +19,7 @@ This bot uses [LUIS](https://www.luis.ai), an AI based cognitive service, to imp
 
 ### Install .NET CLI
 
-- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 8.0
 
   ```bash
   # determine dotnet version
@@ -92,7 +92,7 @@ To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](htt
 - [Activity processing](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-concept-activity-processing?view=azure-bot-service-4.0)
 - [Azure Bot Service Introduction](https://docs.microsoft.com/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)
 - [Azure Bot Service Documentation](https://docs.microsoft.com/azure/bot-service/?view=azure-bot-service-4.0)
-- [.NET Core CLI tools](https://docs.microsoft.com/en-us/dotnet/core/tools/?tabs=netcore2x)
+- [.NET Core CLI tools](https://docs.microsoft.com/en-us/dotnet/core/tools)
 - [Azure CLI](https://docs.microsoft.com/cli/azure/?view=azure-cli-latest)
 - [Azure Portal](https://portal.azure.com)
 - [Language Understanding using LUIS](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/)

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot.tests/CoreBot.Tests.csproj
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot.tests/CoreBot.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot/CoreBot.csproj
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot/CoreBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot/CoreBot.vstemplate
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot/CoreBot.vstemplate
@@ -72,10 +72,17 @@
       <ProjectItem ReplaceParameters="true">Startup.cs</ProjectItem>
 
       <Folder Name="DeploymentTemplates" TargetFolderName="DeploymentTemplates">
-        <ProjectItem ReplaceParameters="false">template-with-new-rg.json</ProjectItem>
-        <ProjectItem ReplaceParameters="false">template-with-preexisting-rg.json</ProjectItem>
-        <ProjectItem ReplaceParameters="false">new-rg-parameters.json</ProjectItem>
-        <ProjectItem ReplaceParameters="false">preexisting-rg-parameters.json</ProjectItem>
+        <ProjectItem ReplaceParameters="false">DeployUseExistResourceGroup\template-AzureBot-with-rg.json</ProjectItem>
+        <ProjectItem ReplaceParameters="false">DeployUseExistResourceGroup\template-BotApp-with-rg.json</ProjectItem>
+        <ProjectItem ReplaceParameters="false">DeployUseExistResourceGroup\parameters-for-template-AzureBot-with-rg.json</ProjectItem>
+        <ProjectItem ReplaceParameters="false">DeployUseExistResourceGroup\parameters-for-template-BotApp-with-rg.json</ProjectItem>
+        <ProjectItem ReplaceParameters="false">DeployUseExistResourceGroup\readme.md</ProjectItem>
+
+        <ProjectItem ReplaceParameters="false">DeployWithNewResourceGroup\template-AzureBot-new-rg.json</ProjectItem>
+        <ProjectItem ReplaceParameters="false">DeployWithNewResourceGroup\template-BotApp-new-rg.json</ProjectItem>
+        <ProjectItem ReplaceParameters="false">DeployWithNewResourceGroup\parameters-for-template-AzureBot-new-rg.json</ProjectItem>
+        <ProjectItem ReplaceParameters="false">DeployWithNewResourceGroup\parameters-for-template-BotApp-new-rg.json</ProjectItem>
+        <ProjectItem ReplaceParameters="false">DeployWithNewResourceGroup\readme.md</ProjectItem>
       </Folder>
 
     </Project>

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot/README.md
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot/README.md
@@ -19,7 +19,7 @@ This bot uses [LUIS](https://www.luis.ai), an AI based cognitive service, to imp
 
 ### Install .NET CLI
 
-- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 8.0
 
   ```bash
   # determine dotnet version
@@ -89,7 +89,7 @@ To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](htt
 - [Activity processing](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-concept-activity-processing?view=azure-bot-service-4.0)
 - [Azure Bot Service Introduction](https://docs.microsoft.com/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)
 - [Azure Bot Service Documentation](https://docs.microsoft.com/azure/bot-service/?view=azure-bot-service-4.0)
-- [.NET Core CLI tools](https://docs.microsoft.com/en-us/dotnet/core/tools/?tabs=netcore2x)
+- [.NET Core CLI tools](https://docs.microsoft.com/en-us/dotnet/core/tools)
 - [Azure CLI](https://docs.microsoft.com/cli/azure/?view=azure-cli-latest)
 - [Azure Portal](https://portal.azure.com)
 - [Language Understanding using LUIS](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/)

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBotWithTests.vstemplate
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBotWithTests.vstemplate
@@ -1,6 +1,6 @@
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="ProjectGroup">
   <TemplateData>
-    <Name>Core Bot with Tests (Bot Framework v4 - .NET 6.0)</Name>
+    <Name>Core Bot with Tests (Bot Framework v4 - .NET 8.0)</Name>
     <Description>Core Bot Template with Unit Tests for Bot Framework v4.  Same features as Core Bot, plus a full unit test project.
     </Description>
     <ProjectType>CSharp</ProjectType>

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/EchoBot.csproj
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/EchoBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/EchoBot.vstemplate
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/EchoBot.vstemplate
@@ -1,6 +1,6 @@
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Project">
   <TemplateData>
-    <Name>Echo Bot (Bot Framework v4 - .NET Core 3.1)</Name>
+    <Name>Echo Bot (Bot Framework v4 - .NET Core 8.0)</Name>
     <Description>Echo Bot Template for Bot Framework v4.  A good template if you want a little more than "Hello World!".  Echo Bot simply "echoes" back to the user anything the user says to the bot.
     </Description>
     <ProjectType>CSharp</ProjectType>

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/README.md
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 8.0
 
   ```bash
   # determine dotnet version
@@ -62,7 +62,7 @@ To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](htt
 - [Activity processing](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-concept-activity-processing?view=azure-bot-service-4.0)
 - [Azure Bot Service Introduction](https://docs.microsoft.com/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)
 - [Azure Bot Service Documentation](https://docs.microsoft.com/azure/bot-service/?view=azure-bot-service-4.0)
-- [.NET Core CLI tools](https://docs.microsoft.com/en-us/dotnet/core/tools/?tabs=netcore2x)
+- [.NET Core CLI tools](https://docs.microsoft.com/en-us/dotnet/core/tools)
 - [Azure CLI](https://docs.microsoft.com/cli/azure/?view=azure-cli-latest)
 - [Azure Portal](https://portal.azure.com)
 - [Language Understanding using LUIS](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/)

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/EmptyBot.csproj
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/EmptyBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/EmptyBot.vstemplate
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/EmptyBot.vstemplate
@@ -1,6 +1,6 @@
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Project">
   <TemplateData>
-    <Name>Empty Bot (Bot Framework v4 - .NET Core 3.1)</Name>
+    <Name>Empty Bot (Bot Framework v4 - .NET Core 8.0)</Name>
     <Description>Empty Bot Template for Bot Framework v4.  A good template if you want a skeleton project or want to take sample code from the documentation and paste it into a minimal bot in order to learn.
     </Description>
     <ProjectType>CSharp</ProjectType>

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/README.md
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
+- [.NET SDK](https://dotnet.microsoft.com/download) version 8.0
 
   ```bash
   # determine dotnet version
@@ -62,7 +62,7 @@ To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](htt
 - [Activity processing](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-concept-activity-processing?view=azure-bot-service-4.0)
 - [Azure Bot Service Introduction](https://docs.microsoft.com/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)
 - [Azure Bot Service Documentation](https://docs.microsoft.com/azure/bot-service/?view=azure-bot-service-4.0)
-- [.NET Core CLI tools](https://docs.microsoft.com/en-us/dotnet/core/tools/?tabs=netcore2x)
+- [.NET Core CLI tools](https://docs.microsoft.com/en-us/dotnet/core/tools)
 - [Azure CLI](https://docs.microsoft.com/cli/azure/?view=azure-cli-latest)
 - [Azure Portal](https://portal.azure.com)
 - [Language Understanding using LUIS](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/)


### PR DESCRIPTION
Fixes # 6741
#minor

## Description
This PR updates all generators from `net6` to `net8`.

## Specific Changes
  - `Templates` 
    - Updates all related files where the `net6` configuration appear, changing it to `net8`.
    - Default template installation to `net8`, but leave `net6` and `net8` as supported options. Since we maintained both in the SDK.
  - `VSIX`
    - Updates all related files to target `net8`.
    - Fixed an issue when generating the `CoreBotWithTests` sample failed because it was referencing nonexistent files.

## Testing
The following images show all three bots working and the update reference in the VSIX samples.
![imagen](https://github.com/southworks/botbuilder-dotnet/assets/62260472/64048863-9717-4267-8733-ad79ba26427a)
![imagen](https://github.com/southworks/botbuilder-dotnet/assets/62260472/3b82f513-eb24-466c-82b1-487a4dcb60b1)
![imagen](https://github.com/southworks/botbuilder-dotnet/assets/62260472/740d2587-364a-4b54-8af1-6df14a01ddb9)
![imagen](https://github.com/southworks/botbuilder-dotnet/assets/62260472/38d14ef5-880c-45d3-8dcd-71644f483844)