### PR TITLE
feat: Support Single Tenant authentication through BotFramework-Emulator

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Authentication/EmulatorValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/EmulatorValidation.cs
@@ -70,6 +70,18 @@ namespace Microsoft.Bot.Connector.Authentication
                 return false;
             }
 
+            var tid = token.Claims.FirstOrDefault(claim => claim.Type == "tid")?.Value != null ? '/' + token.Claims.FirstOrDefault(claim => claim.Type == "tid")?.Value + '/' : string.Empty;
+
+            //Validate if there is an existing issuer with the same tid value.
+            if (!string.IsNullOrEmpty(tid) && !ToBotFromEmulatorTokenValidationParameters.ValidIssuers.Any((issuer) => issuer.Contains(tid)))
+            {
+                //If the issuer doesn't exist, this is added using the Emulator token issuer structure.
+                //This allows use of the SingleTenant authentication through Emulator.
+                var newIssuer = "https://sts.windows.net" + tid;
+                ToBotFromEmulatorTokenValidationParameters.ValidIssuers = 
+                    ToBotFromEmulatorTokenValidationParameters.ValidIssuers.Concat(new string[] { newIssuer });
+            }
+
             // Is the token issues by a source we consider to be the emulator?
             if (!ToBotFromEmulatorTokenValidationParameters.ValidIssuers.Contains(token.Issuer))
             {


### PR DESCRIPTION
#minor

## Description
This PR includes a dynamic way to validate the access token _**issuer**_ value depending on the tenant ID used in Emulator.

## Specific Changes
  - Added logic to validate the _**tid**_ and _**issuer**_ values to allow the Single Tenant authentication in EmulatorValidation.

## Testing
The following image shows the Emulator working with a bot using Single Tenant authentication.
![image](https://github.com/southworks/botbuilder-dotnet/assets/122501764/cb8727f8-e76c-4942-830c-1ceae9eafb95)