### PR TITLE
fix: [#XXX] Composer Bot with QnA Intent recognized triggers duplicate QnA queries

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
@@ -562,9 +562,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                     case AdaptiveEvents.ActivityReceived:
                         if (activity.Type == ActivityTypes.Message)
                         {
-                            // Avoid reprocessing recognized activity.
                             var recognized = actionContext.State.GetValue<RecognizerResult>(TurnPath.Recognized);
-                            if (recognized == null)
+                            var activityProcessed = actionContext.State.GetValue<bool>(TurnPath.ActivityProcessed);
+
+                            // Avoid reprocessing recognized activity for OnQnAMatch.
+                            var isOnQnAMatchProcessed = activityProcessed && recognized?.Intents.TryGetValue(OnQnAMatch.QnAMatchIntent, out _) == true;
+                            if (!isOnQnAMatchProcessed)
                             {
                                 // Recognize utterance (ignore handled)
                                 var recognizeUtteranceEvent = new DialogEvent

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnQnAMatch.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnQnAMatch.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         public new const string Kind = "Microsoft.OnQnAMatch";
 
         // this is a duplicate of QnAMakerRecognizer.QnAMatchIntent, but copying this here removes need to have dependency between QnA and Adaptive assemblies.
-        private const string QnAMatchIntent = "QnAMatch";
+        internal const string QnAMatchIntent = "QnAMatch";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="OnQnAMatch"/> class.

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/AdaptiveDialogTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/AdaptiveDialogTests.cs
@@ -308,6 +308,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
         }
 
         [Fact]
+        public async Task AdaptiveDialog_OnQnAMatch()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
+
+        [Fact]
         public async Task TestForEachElementReprompt()
         {
             var testFlow = new TestScript()

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AdaptiveDialogTests/AdaptiveDialog_OnQnAMatch.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AdaptiveDialogTests/AdaptiveDialog_OnQnAMatch.test.dialog
@@ -1,0 +1,74 @@
+{
+  "$schema": "../../../tests.schema",
+  "$kind": "Microsoft.Test.Script",
+  "dialog": {
+    "$kind": "Microsoft.AdaptiveDialog",
+    "id": "outer",
+    "autoEndDialog": false,
+    "recognizer": {
+      "$kind": "Microsoft.RegexRecognizer",
+      "intents": [
+        {
+          "intent": "BeginIntent",
+          "pattern": "begin"
+        },
+        {
+          "intent": "QnAMatch",
+          "pattern": "qna"
+        }
+      ]
+    },
+    "triggers": [
+      {
+        "$kind": "Microsoft.OnIntent",
+        "intent": "BeginIntent",
+        "actions": [
+          {
+            "$kind": "Microsoft.TextInput",
+            "maxTurnCount": 3,
+            "alwaysPrompt": true,
+            "allowInterruptions": false,
+            "prompt": "Which event should I emit?",
+            "validations": []
+          },
+          {
+            "$kind": "Microsoft.EmitEvent",
+            "eventName": "activityReceived",
+            "eventValue": "=turn.activity",
+            "handledProperty": "turn.eventHandled",
+            "bubbleEvent": true
+          }
+        ]
+      },
+      {
+        "$kind": "Microsoft.OnIntent",
+        "intent": "QnAMatch",
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "QnAMatch event triggered"
+          }
+        ]
+      }
+    ],
+    "defaultResultProperty": "dialog.result"
+  },
+  "script": [
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "begin"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "Which event should I emit?"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "qna"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "QnAMatch event triggered"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes # 
#minor

> [!IMPORTANT]
> CREATE ISSUE

## Description
This PR fixes an issue where QnA traces and requests to the CQA service were duplicated.
This issue was related to how the QnA Intent recognized trigger is structured, it contains a TextInput and an Emit Custom Event. Both actions emit an "activityReceived" event, the first when an activity is received as a prompt response, and the second on purpose, which both execute the "recognized" functionality that triggers the duplication.

## Specific Changes
  - Updated AdaptiveDialog to avoid reprocessing recognized activities by adding a condition if the recognized event was already processed.
  - Added unit tests to validate the new condition works.

## Testing
The following image shows how it emits the double trace, and how it behaves after the fix.
![image](https://github.com/southworks/botbuilder-dotnet/assets/62260472/7e7c8812-215b-4709-b9b9-9ae47978e08b)
