### PR TITLE
fix: Add Audience for Certificate auth to work with Skills

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Authentication/CertificateAppCredentials.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/CertificateAppCredentials.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="customHttpClient">Optional <see cref="HttpClient"/> to be used when acquiring tokens.</param>
         /// <param name="logger">Optional <see cref="ILogger"/> to gather telemetry data while acquiring and managing credentials.</param>
         public CertificateAppCredentials(X509Certificate2 clientCertificate, string appId, string channelAuthTenant = null, HttpClient customHttpClient = null, ILogger logger = null)
-            : this(clientCertificate, false, appId, channelAuthTenant, customHttpClient, logger)
+            : this(clientCertificate, appId, channelAuthTenant, string.Empty, false, customHttpClient, logger)
         {
         }
 
@@ -62,7 +62,22 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="customHttpClient">Optional <see cref="HttpClient"/> to be used when acquiring tokens.</param>
         /// <param name="logger">Optional <see cref="ILogger"/> to gather telemetry data while acquiring and managing credentials.</param>
         public CertificateAppCredentials(X509Certificate2 clientCertificate, bool sendX5c, string appId, string channelAuthTenant = null, HttpClient customHttpClient = null, ILogger logger = null)
-            : base(channelAuthTenant, customHttpClient, logger)
+            : this(clientCertificate, appId, channelAuthTenant, string.Empty, sendX5c, customHttpClient, logger)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CertificateAppCredentials"/> class.
+        /// </summary>
+        /// <param name="clientCertificate">Client certificate to be presented for authentication.</param>
+        /// <param name="appId">Microsoft application Id related to the certifiacte.</param>
+        /// <param name="channelAuthTenant">Optional. The oauth token tenant.</param>
+        /// <param name="oAuthScope">Optional. The scope for the token.</param>
+        /// <param name="sendX5c">Optional. This parameter, if true, enables application developers to achieve easy certificates roll-over in Azure AD: setting this parameter to true will send the public certificate to Azure AD along with the token request, so that Azure AD can use it to validate the subject name based on a trusted issuer policy. </param>
+        /// <param name="customHttpClient">Optional <see cref="HttpClient"/> to be used when acquiring tokens.</param>
+        /// <param name="logger">Optional <see cref="ILogger"/> to gather telemetry data while acquiring and managing credentials.</param>
+        public CertificateAppCredentials(X509Certificate2 clientCertificate, string appId, string channelAuthTenant = null, string oAuthScope = null, bool sendX5c = false, HttpClient customHttpClient = null, ILogger logger = null)
+            : base(channelAuthTenant, customHttpClient, logger, oAuthScope: oAuthScope)
         {
             if (clientCertificate == null)
             {

--- a/libraries/Microsoft.Bot.Connector/Authentication/CertificateServiceClientCredentialsFactory.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/CertificateServiceClientCredentialsFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Concurrent;
 using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -16,8 +17,13 @@ namespace Microsoft.Bot.Connector.Authentication
     /// </summary>
     public class CertificateServiceClientCredentialsFactory : ServiceClientCredentialsFactory
     {
-        private readonly CertificateAppCredentials _certificateAppCredentials;
+        private readonly X509Certificate2 _certificate;
         private readonly string _appId;
+        private readonly string _tenantId;
+        private readonly bool _sendX5c;
+        private readonly HttpClient _httpClient;
+        private readonly ILogger _logger;
+        private readonly ConcurrentDictionary<string, CertificateAppCredentials> _certificateAppCredentialsByAudience = new ConcurrentDictionary<string, CertificateAppCredentials>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CertificateServiceClientCredentialsFactory"/> class.
@@ -44,16 +50,12 @@ namespace Microsoft.Bot.Connector.Authentication
                 throw new ArgumentNullException(nameof(appId));
             }
 
+            _certificate = certificate ?? throw new ArgumentNullException(nameof(certificate));
             _appId = appId;
-
-            // Instance must be reused otherwise it will cause throttling on AAD.
-            _certificateAppCredentials = new CertificateAppCredentials(
-                certificate ?? throw new ArgumentNullException(nameof(certificate)),
-                sendX5c,
-                appId,
-                tenantId,
-                httpClient,
-                logger);
+            _tenantId = tenantId;
+            _sendX5c = sendX5c;
+            _httpClient = httpClient;
+            _logger = logger;
         }
 
         /// <inheritdoc />
@@ -78,7 +80,22 @@ namespace Microsoft.Bot.Connector.Authentication
                 throw new InvalidOperationException("Invalid Managed ID.");
             }
 
-            return Task.FromResult<ServiceClientCredentials>(_certificateAppCredentials);
+            // Instance must be reused per audience, otherwise it will cause throttling on AAD.
+            _certificateAppCredentialsByAudience.TryGetValue(audience, out var certificateAppCredentials);
+            if (certificateAppCredentials == null)
+            {
+                certificateAppCredentials = new CertificateAppCredentials(
+                    _certificate,
+                    _appId,
+                    _tenantId,
+                    audience,
+                    _sendX5c,
+                    _httpClient,
+                    _logger);
+                _certificateAppCredentialsByAudience.TryAdd(audience, certificateAppCredentials);
+            }
+
+            return Task.FromResult<ServiceClientCredentials>(certificateAppCredentials);
         }
     }
 }

--- a/libraries/Microsoft.Bot.Connector/Authentication/CertificateServiceClientCredentialsFactory.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/CertificateServiceClientCredentialsFactory.cs
@@ -81,10 +81,9 @@ namespace Microsoft.Bot.Connector.Authentication
             }
 
             // Instance must be reused per audience, otherwise it will cause throttling on AAD.
-            _certificateAppCredentialsByAudience.TryGetValue(audience, out var certificateAppCredentials);
-            if (certificateAppCredentials == null)
+            var certificateAppCredentials = _certificateAppCredentialsByAudience.GetOrAdd(audience, (audience) =>
             {
-                certificateAppCredentials = new CertificateAppCredentials(
+                return new CertificateAppCredentials(
                     _certificate,
                     _appId,
                     _tenantId,
@@ -92,8 +91,7 @@ namespace Microsoft.Bot.Connector.Authentication
                     _sendX5c,
                     _httpClient,
                     _logger);
-                _certificateAppCredentialsByAudience.TryAdd(audience, certificateAppCredentials);
-            }
+            });
 
             return Task.FromResult<ServiceClientCredentials>(certificateAppCredentials);
         }

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/CertificateServiceClientCredentialsFactoryTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/CertificateServiceClientCredentialsFactoryTests.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         private const string TestAppId = nameof(TestAppId);
         private const string TestTenantId = nameof(TestTenantId);
         private const string TestAudience = nameof(TestAudience);
+        private const string LoginEndpoint = "https://login.microsoftonline.com";
         private readonly Mock<ILogger> logger = new Mock<ILogger>();
         private readonly Mock<X509Certificate2> certificate = new Mock<X509Certificate2>();
 
@@ -68,10 +69,29 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
             var factory = new CertificateServiceClientCredentialsFactory(certificate.Object, TestAppId);
 
             var credentials = await factory.CreateCredentialsAsync(
-                TestAppId, TestAudience, "https://login.microsoftonline.com", true, CancellationToken.None);
+                TestAppId, TestAudience, LoginEndpoint, true, CancellationToken.None);
 
             Assert.NotNull(credentials);
             Assert.IsType<CertificateAppCredentials>(credentials);
+        }
+
+        [Fact]
+        public async void ShouldCreateUniqueCredentialsByAudience()
+        {
+            var factory = new CertificateServiceClientCredentialsFactory(certificate.Object, TestAppId);
+
+            var credentials1 = await factory.CreateCredentialsAsync(
+                TestAppId, string.Empty, LoginEndpoint, true, CancellationToken.None);
+            var credentials2 = await factory.CreateCredentialsAsync(
+                TestAppId, TestAudience, LoginEndpoint, true, CancellationToken.None);
+            var credentials3 = await factory.CreateCredentialsAsync(
+                TestAppId, Guid.NewGuid().ToString(), LoginEndpoint, true, CancellationToken.None);
+            var credentials4 = await factory.CreateCredentialsAsync(
+                TestAppId, string.Empty, LoginEndpoint, true, CancellationToken.None);
+
+            Assert.NotEqual(credentials1, credentials2);
+            Assert.NotEqual(credentials1, credentials3);
+            Assert.Equal(credentials1, credentials4);
         }
 
         [Fact]
@@ -80,7 +100,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
             var factory = new CertificateServiceClientCredentialsFactory(certificate.Object, TestAppId);
 
             Assert.ThrowsAsync<InvalidOperationException>(() => factory.CreateCredentialsAsync(
-                    "InvalidAppId", TestAudience, "https://login.microsoftonline.com", true, CancellationToken.None));
+                    "InvalidAppId", TestAudience, LoginEndpoint, true, CancellationToken.None));
         }
     }
 }


### PR DESCRIPTION
#minor

## Description
This PR adds Audience to CertificateAppCredentials, so it is passed correctly when calling a Skill bot. Additionally, these changes take into consideration the PR# https://github.com/microsoft/botbuilder-dotnet/pull/ 6694, so the improvement isn't lost in the process.

## Specific Changes
  - Added missing `oAuthScope` parameter to `libraries/Microsoft.Bot.Connector/Authentication/CertificateAppCredentials.cs`.
  - Improved `libraries/Microsoft.Bot.Connector/Authentication/CertificateServiceClientCredentialsFactory.cs` by reverting the changes made in the PR# https://github.com/microsoft/botbuilder-dotnet/pull/ 6694, but maintaining the improvement.
    - It creates a new instance of `CertificateAppCredentials` per Audience, instead of having just one with the default `api.botframework`.
  - Added unit test to confirm it doesn't create new instances when the same Audience is provided.

## Testing
The following images show the new unit test passing and the Root + Skill bots working as expected.
![image](https://github.com/southworks/botbuilder-dotnet/assets/62260472/c02bea3e-3d48-4379-a049-b58f43bd233b)
![image](https://github.com/southworks/botbuilder-dotnet/assets/62260472/d781e1c5-7226-4da7-926e-c86d100b08f1)