### PR TITLE
[#6741] Remove .Net Core 3.1 from projects

### DIFF
--- a/build/onebranch/ci-test-steps.yml
+++ b/build/onebranch/ci-test-steps.yml
@@ -20,21 +20,12 @@ steps:
     customCommand: 'install -g @microsoft/botframework-cli@next'
 
 - task: UseDotNet@2
-  displayName: "Install .NET Core 3.1.415"
+  displayName: "Install .NET Core 6.0"
   continueOnError: true
   inputs:
     packageType: "sdk"
-    version: 3.1.415
-  condition: and(succeeded(), eq(variables['BuildConfiguration'],'Release-Windows'), eq(variables['BuildTarget'],'netcoreapp31'))
-
-- task: DotNetCoreCLI@2
-  displayName: 'dotnet test (release) 3.1'
-  inputs:
-    command: test
-    projects: |
-     Tests/**/*Tests.csproj
-    arguments: '-v n  -f netcoreapp3.1 --configuration release --no-build --no-restore --filter "TestCategory!=IgnoreInAutomatedBuild&TestCategory!=FunctionalTests" --collect:"Code Coverage" --settings $(Build.SourcesDirectory)\CodeCoverage.runsettings'
-  condition: and(succeeded(), eq(variables['BuildConfiguration'],'Release-Windows'), eq(variables['BuildTarget'],'netcoreapp31'))
+    version: 6.x
+  condition: and(succeeded(), eq(variables['BuildConfiguration'],'Release-Windows'), eq(variables['BuildTarget'],'net6'))
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test (release) 6.0'

--- a/build/onebranch/pr.yml
+++ b/build/onebranch/pr.yml
@@ -42,14 +42,6 @@ variables:
 stages:
 - stage: Build
   jobs:
-  - job: Debug_Windows_Configuration_31
-    variables:
-      BuildConfiguration: Debug-Windows
-      BuildTarget: 'netcoreapp31' # set the TargetFramework property for tests to use netcoreapp3.1
-    steps:
-    - template: ci-build-steps.yml
-    - template: ci-test-steps.yml
-    - template: ci-component-detection-steps.yml
   - job: Debug_Windows_Configuration_6
     variables:
       BuildConfiguration: Debug-Windows
@@ -62,14 +54,6 @@ stages:
     variables:
       BuildConfiguration: Debug-Windows
       BuildTarget: 'net8' # set the TargetFramework property for tests to use net8.0
-    steps:
-    - template: ci-build-steps.yml
-    - template: ci-test-steps.yml
-    - template: ci-component-detection-steps.yml
-  - job: Release_Windows_Configuration_31
-    variables:
-      BuildConfiguration: Release-Windows
-      BuildTarget: 'netcoreapp31' # set the TargetFramework property for tests to use netcoreapp3.1
     steps:
     - template: ci-build-steps.yml
     - template: ci-test-steps.yml

--- a/build/yaml/botbuilder-dotnet-ci.yml
+++ b/build/yaml/botbuilder-dotnet-ci.yml
@@ -42,14 +42,6 @@ variables:
 stages:
 - stage: Build
   jobs:
-  - job: Debug_Windows_Configuration_31
-    variables:
-      BuildConfiguration: Debug-Windows
-      BuildTarget: 'netcoreapp31' # set the TargetFramework property for tests to use netcoreapp3.1
-    steps:
-    - template: ci-build-steps.yml
-    - template: ci-test-steps.yml
-    - template: ci-component-detection-steps.yml
   - job: Debug_Windows_Configuration_6
     variables:
       BuildConfiguration: Debug-Windows
@@ -62,14 +54,6 @@ stages:
     variables:
       BuildConfiguration: Debug-Windows
       BuildTarget: 'net8' # set the TargetFramework property for tests to use net8.0
-    steps:
-    - template: ci-build-steps.yml
-    - template: ci-test-steps.yml
-    - template: ci-component-detection-steps.yml
-  - job: Release_Windows_Configuration_31
-    variables:
-      BuildConfiguration: Release-Windows
-      BuildTarget: 'netcoreapp31' # set the TargetFramework property for tests to use netcoreapp3.1
     steps:
     - template: ci-build-steps.yml
     - template: ci-test-steps.yml

--- a/build/yaml/ci-test-steps.yml
+++ b/build/yaml/ci-test-steps.yml
@@ -20,21 +20,12 @@ steps:
     customCommand: 'install -g @microsoft/botframework-cli@next'
 
 - task: UseDotNet@2
-  displayName: "Install .NET Core 3.1.415"
+  displayName: "Install .NET Core 6.0"
   continueOnError: true
   inputs:
     packageType: "sdk"
-    version: 3.1.415
-  condition: and(succeeded(), eq(variables['BuildConfiguration'],'Release-Windows'), eq(variables['BuildTarget'],'netcoreapp31'))
-
-- task: DotNetCoreCLI@2
-  displayName: 'dotnet test (release) 3.1'
-  inputs:
-    command: test
-    projects: |
-     Tests/**/*Tests.csproj
-    arguments: '-v n  -f netcoreapp3.1 --configuration release --no-build --no-restore --filter "TestCategory!=IgnoreInAutomatedBuild&TestCategory!=FunctionalTests" --collect:"Code Coverage" --settings $(Build.SourcesDirectory)\CodeCoverage.runsettings'
-  condition: and(succeeded(), eq(variables['BuildConfiguration'],'Release-Windows'), eq(variables['BuildTarget'],'netcoreapp31'))
+    version: 6.x
+  condition: and(succeeded(), eq(variables['BuildConfiguration'],'Release-Windows'), eq(variables['BuildTarget'],'net6'))
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test (release) 6.0'

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/.template.config/template.json
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/.template.config/template.json
@@ -46,10 +46,6 @@
         "datatype": "choice",
         "choices": [
           {
-            "choice": "netcoreapp3.1",
-            "description": "Target netcoreapp3.1"
-          },
-          {
             "choice": "net6.0",
             "description": "Target net6.0"
           },

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/.template.config/template.json
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/.template.config/template.json
@@ -45,10 +45,6 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "netcoreapp3.1",
-          "description": "Target netcoreapp3.1"
-        },
-        {
           "choice": "net6.0",
           "description": "Target net6.0"
         },

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/.template.config/template.json
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/.template.config/template.json
@@ -45,10 +45,6 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "netcoreapp3.1",
-          "description": "Target netcoreapp3.1"
-        },
-        {
           "choice": "net6.0",
           "description": "Target net6.0"
         },

--- a/libraries/Microsoft.Bot.AdaptiveExpressions.Core/Microsoft.Bot.AdaptiveExpressions.Core.csproj
+++ b/libraries/Microsoft.Bot.AdaptiveExpressions.Core/Microsoft.Bot.AdaptiveExpressions.Core.csproj
@@ -40,7 +40,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Text.Json" Version="8.0.3" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/libraries/Microsoft.Bot.Builder.Azure.Blobs/Microsoft.Bot.Builder.Azure.Blobs.csproj
+++ b/libraries/Microsoft.Bot.Builder.Azure.Blobs/Microsoft.Bot.Builder.Azure.Blobs.csproj
@@ -21,9 +21,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Force System.Text.Encodings.Web to a safe version. -->
-    <PackageReference Include="System.Text.Json" Version="4.7.2" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <PackageId>Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime</PackageId>
     <Description>Library for building Adaptive Runtime bots using the Bot Framework SDK</Description>
     <Summary>Library for building Adaptive Runtime bots using the Bot Framework SDK</Summary>
@@ -22,11 +22,6 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
-  <!--It is necessary to separate these conditionals in order to avoid nuget restore errors with netcoreapp3.1.-->
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-  
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
@@ -36,7 +31,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.0" />

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Microsoft.Bot.Builder.Dialogs.Declarative.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Microsoft.Bot.Builder.Dialogs.Declarative.csproj
@@ -36,6 +36,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Force  System.Formats.Asn1 to a safe version. -->
+    <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.22" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NuGet.Packaging" Version="5.11.6" />

--- a/libraries/Microsoft.Bot.Connector.Streaming/Microsoft.Bot.Connector.Streaming.csproj
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Microsoft.Bot.Connector.Streaming.csproj
@@ -31,9 +31,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.IO.Pipelines" Version="5.0.1" />
-    <PackageReference Include="System.Text.Json" Version="4.7.2" />
-    <!-- Force System.Text.Encodings.Web to a safe version. -->
-    <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <PackageId>Microsoft.Bot.Builder.Integration.ApplicationInsights.Core</PackageId>
     <Description>This library integrates the Microsoft Bot Builder SDK with Application Insights.</Description>
     <Summary>This library provides integration between the Microsoft Bot Builder SDK and Application Insights.</Summary>
@@ -20,8 +20,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
-  <!--It is necessary to separate these conditionals in order to avoid nuget restore errors with netcoreapp3.1.-->
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />    
@@ -29,15 +28,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.0" />
   </ItemGroup>
 
-   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />    
-    <!-- Force Microsoft.AspNetCore.Http to a safe version. -->
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.0" />
-  </ItemGroup>
-
-   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />    
@@ -48,14 +39,14 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <!-- Force Microsoft.AspNetCore.Http to a safe version. -->
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.0" />
-    <!-- Explicitly set dependency to the latest version, because we have a transient dependency brought by Microsoft.ApplicationInsights.AspNetCore and can't fix by updating runtime, since it's not a framework reference"-->
-    <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
     <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageReference Include="System.Net.Security" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Force System.Text.Json to a safe version. -->
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(ReleasePackageVersion)' != '' " Version="$(ReleasePackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <Description>This library integrates the Microsoft Bot Builder SDK with ASP.NET Core. It offers idiomatic configuration APIs in addition to providing all the plumbing to direct incoming bot messages to a configured bot.</Description>
     <Summary>This library provides integration between the Microsoft Bot Builder SDK and ASP.NET Core.</Summary>
   </PropertyGroup>
@@ -19,22 +19,15 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
-  <!--It is necessary to separate these conditionals in order to avoid nuget restore errors with netcoreapp3.1.-->
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <!-- Explicitly set to 5.0.1 for those built against 2.0-->
-    <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.0" />
@@ -45,6 +38,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Force System.Text.Json to a safe version. -->
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
     <PackageReference Include="Microsoft.Bot.Connector.Streaming" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Connector.Streaming" Condition=" '$(ReleasePackageVersion)' != '' " Version="$(ReleasePackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Streaming" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/Microsoft.Bot.Builder.Adapters.Facebook.Tests.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/Microsoft.Bot.Builder.Adapters.Facebook.Tests.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/Microsoft.Bot.Builder.Adapters.Slack.Tests.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/Microsoft.Bot.Builder.Adapters.Slack.Tests.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/Microsoft.Bot.Builder.Adapters.Twilio.Tests.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/Microsoft.Bot.Builder.Adapters.Twilio.Tests.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/Microsoft.Bot.Builder.Adapters.Webex.Tests.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/Microsoft.Bot.Builder.Adapters.Webex.Tests.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <!-- The Thrzn41.WebexTeams package isn't signed, so supress the warning. There seems to not be a way to supress this for ONLY Thrzn41.WebexTeams. -->

--- a/tests/AdaptiveExpressions.Tests/AdaptiveExpressions.Tests.csproj
+++ b/tests/AdaptiveExpressions.Tests/AdaptiveExpressions.Tests.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -1048,11 +1048,7 @@ namespace AdaptiveExpressions.Tests
             Test("lastIndexOf(newGuid(), '-')", 23),
             Test("lastIndexOf(hello, '-')", -1),
             Test("lastIndexOf(nullObj, '-')", -1),
-#if NET5_0_OR_GREATER //There's a breaking change in .NET5 for this particular case. See https://docs.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/5.0/lastindexof-improved-handling-of-empty-values#change-description
             Test("lastIndexOf(hello, nullObj)", 5),
-#else
-            Test("lastIndexOf(hello, nullObj)", 4),
-#endif
             Test("lastIndexOf(json('[\"a\", \"b\", \"a\"]'), 'a')", 2),
             Test("lastIndexOf(json('[\"a\", \"b\"]'), 'c')", -1),
             Test("lastIndexOf(createArray('abc', 'def', 'ghi', 'def'), 'def')", 3),

--- a/tests/Microsoft.Bot.AdaptiveExpressions.Core.Tests/Microsoft.Bot.AdaptiveExpressions.Core.Tests.csproj
+++ b/tests/Microsoft.Bot.AdaptiveExpressions.Core.Tests/Microsoft.Bot.AdaptiveExpressions.Core.Tests.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/Microsoft.Bot.Builder.AI.Luis.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/Microsoft.Bot.Builder.AI.Luis.Tests.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.AI.Luis.TestUtils/Microsoft.Bot.Builder.AI.Luis.TestUtils.csproj
+++ b/tests/Microsoft.Bot.Builder.AI.Luis.TestUtils/Microsoft.Bot.Builder.AI.Luis.TestUtils.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
 

--- a/tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/Microsoft.Bot.Builder.AI.QnA.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/Microsoft.Bot.Builder.AI.QnA.Tests.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.Ai.LUISV3.tests/Microsoft.Bot.Builder.AI.LuisV3.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Ai.LUISV3.tests/Microsoft.Bot.Builder.AI.LuisV3.Tests.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.ApplicationInsights.Tests/Microsoft.Bot.Builder.ApplicationInsights.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.ApplicationInsights.Tests/Microsoft.Bot.Builder.ApplicationInsights.Tests.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/Microsoft.Bot.Builder.Azure.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/Microsoft.Bot.Builder.Azure.Tests.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Configurations>Debug;Release</Configurations>
     <!-- The MockHttp package isn't signed, so supress the warning. -->

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Flow.Tests/Microsoft.Bot.Builder.Dialogs.Flows.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Flow.Tests/Microsoft.Bot.Builder.Dialogs.Flows.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/Microsoft.Bot.Builder.Dialogs.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/Microsoft.Bot.Builder.Dialogs.Tests.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Microsoft.Bot.Builder.LanguageGeneration.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Microsoft.Bot.Builder.LanguageGeneration.Tests.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/Microsoft.Bot.Builder.TemplateManager/Microsoft.Bot.Builder.TemplateManager.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.TemplateManager/Microsoft.Bot.Builder.TemplateManager.Tests.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/.vscode/launch.json
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/.vscode/launch.json
@@ -27,7 +27,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/bin/Debug/netcoreapp3.1/Microsoft.Bot.Builder.TestBot.Json.dll",
+            "program": "${workspaceFolder}/bin/Debug/net8.0/Microsoft.Bot.Builder.TestBot.Json.dll",
             "args": [],
             "cwd": "${workspaceFolder}",
             "stopAtEntry": false,

--- a/tests/Microsoft.Bot.Builder.TestBot.Tests/Microsoft.Bot.Builder.TestBot.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.TestBot.Tests/Microsoft.Bot.Builder.TestBot.Tests.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AssemblyName>Microsoft.Bot.Builder.TestBot.Tests</AssemblyName>
     <RootNamespace>Microsoft.BotBuilderSamples.Tests</RootNamespace>

--- a/tests/Microsoft.Bot.Builder.Testing.Tests/Microsoft.Bot.Builder.Testing.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Testing.Tests/Microsoft.Bot.Builder.Testing.Tests.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.Tests/Microsoft.Bot.Builder.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Tests/Microsoft.Bot.Builder.Tests.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.Transcripts.Tests/Microsoft.Bot.Builder.Transcripts.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Transcripts.Tests/Microsoft.Bot.Builder.Transcripts.Tests.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Configuration.Tests/Microsoft.Bot.Configuration.Tests.csproj
+++ b/tests/Microsoft.Bot.Configuration.Tests/Microsoft.Bot.Configuration.Tests.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Connector.Streaming.Tests/Microsoft.Bot.Connector.Streaming.Tests.csproj
+++ b/tests/Microsoft.Bot.Connector.Streaming.Tests/Microsoft.Bot.Connector.Streaming.Tests.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/JwtTokenExtractorTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/JwtTokenExtractorTests.cs
@@ -156,9 +156,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
             };
         }
 
-#if NET5_0_OR_GREATER
         [SupportedOSPlatform("windows")]
-#endif
         private static X509Certificate2 CreateSelfSignedCertificate(string cn, DateTimeOffset from, DateTimeOffset to)
         {
             var parameters = new CspParameters(24, "Microsoft Enhanced RSA and AES Cryptographic Provider")
@@ -184,9 +182,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
             return cert;
         }
 
-#if NET5_0_OR_GREATER
         [SupportedOSPlatform("windows")]
-#endif
         private static void DeleteKeyContainer(string cn)
         {
             // %APPDATA%\Microsoft\Crypto\RSA

--- a/tests/Microsoft.Bot.Connector.Tests/Microsoft.Bot.Connector.Tests.csproj
+++ b/tests/Microsoft.Bot.Connector.Tests/Microsoft.Bot.Connector.Tests.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Schema.Tests/Microsoft.Bot.Schema.Tests.csproj
+++ b/tests/Microsoft.Bot.Schema.Tests/Microsoft.Bot.Schema.Tests.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Streaming.Tests/Microsoft.Bot.Streaming.Tests.csproj
+++ b/tests/Microsoft.Bot.Streaming.Tests/Microsoft.Bot.Streaming.Tests.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/Parsers/Microsoft.Bot.Builder.Parsers.LU.Tests/Microsoft.Bot.Builder.Parsers.LU.Tests.csproj
+++ b/tests/Parsers/Microsoft.Bot.Builder.Parsers.LU.Tests/Microsoft.Bot.Builder.Parsers.LU.Tests.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/Microsoft.Bot.ApplicationInsights.Core.Tests.csproj
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/Microsoft.Bot.ApplicationInsights.Core.Tests.csproj
@@ -1,19 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
-
-  <!--It is necessary to separate these conditionals in order to avoid nuget restore errors with netcoreapp3.1.-->
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.6" />
-  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.4" />

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests.csproj
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>


### PR DESCRIPTION
Related issue: # 6741
#minor

## Description
This PR removes `netcoreapp3.1` from the projects and pipelines, and fixes System.Text.Json https://github.com/microsoft/botbuilder-dotnet/security/dependabot/41 (CVE-2024-30105) and System.Formats.Asn1 security issues.

## Specific Changes
  - Removed all `netcoreapp3.1` configurations from all projects.
  - Removed `netcoreapp3.1` from CI pipelines.
  - Removed `netcoreapp3.1` conditionals in the code.
  - Removed `System.Text.Json` and `System.Text.Encodings.Web` packages from `Azure.Blobs`, `Adaptive.Runtime`, `Connector.Streaming`.
  - Updated remaining `System.Text.Json` to latest `8.0.4` version.
  - Updated `System.Formats.Asn1` to latest `8.0.1` version due to vulnerability issue.

## Testing
The following image shows the pipeline tests passing, and no errors/warnings for System.Text.Json.
![image](https://github.com/southworks/botbuilder-dotnet/assets/62260472/1a1cc1b5-7d93-493b-ab8e-0c2e1974131d)
![image](https://github.com/southworks/botbuilder-dotnet/assets/62260472/46a5e121-15dc-43cf-aa08-d185379d6c80)