### PR TITLE
[#6825] Update and fix WebexTeams issues

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/Microsoft.Bot.Builder.Adapters.Webex.csproj
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/Microsoft.Bot.Builder.Adapters.Webex.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Thrzn41.WebexTeams" Version="1.6.2" />
+    <PackageReference Include="Thrzn41.WebexTeams" Version="1.8.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Condition=" '$(ReleasePackageVersion)' != '' " Version="$(ReleasePackageVersion)" />
   </ItemGroup>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexClientWrapper.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="target">Target for the message.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>The created message id.</returns>
-        public virtual async Task<string> CreateMessageWithAttachmentsAsync(string recipient, string text, IList<Attachment> attachments, MessageTextType messageType = MessageTextType.Text, MessageTarget target = MessageTarget.PersonId, CancellationToken cancellationToken = default)
+        public virtual async Task<string> CreateMessageWithAttachmentsAsync(string recipient, string text, IList<Schema.Attachment> attachments, MessageTextType messageType = MessageTextType.Text, MessageTarget target = MessageTarget.PersonId, CancellationToken cancellationToken = default)
         {
             Message result;
 

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexHelper.cs
@@ -213,11 +213,11 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// </summary>
         /// <param name="message">The message with the files to process.</param>
         /// <returns>A list of attachments containing the message's files.</returns>
-        public static List<Attachment> HandleMessageAttachments(Message message)
+        public static List<Schema.Attachment> HandleMessageAttachments(Message message)
         {
-            var attachmentsList = new List<Attachment>();
+            var attachmentsList = new List<Schema.Attachment>();
 
-            var attachment = new Attachment
+            var attachment = new Schema.Attachment
             {
                 // Currently Webex API takes only one attachment
                 ContentUrl = message.FileUris[0].AbsoluteUri,

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.TestBot/Bots/EchoBot.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.TestBot/Bots/EchoBot.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.TestBot.Bots
                 var activity = MessageFactory.Text($" I got {turnContext.Activity.Attachments.Count} attachments");
                 foreach (var attachment in turnContext.Activity.Attachments)
                 {
-                    var image = new Attachment(
+                    var image = new Schema.Attachment(
                         "image/png",
                         "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQtB3AwMUeNoq4gUBGe6Ocj8kyh3bXa9ZbV7u1fVKQoyKFHdkqU");
 
@@ -79,10 +79,10 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.TestBot.Bots
             }
         }
 
-        private static Attachment CreateAdaptiveCardAttachment(string filePath)
+        private static Schema.Attachment CreateAdaptiveCardAttachment(string filePath)
         {
             var adaptiveCardJson = File.ReadAllText(filePath);
-            var adaptiveCardAttachment = new Attachment()
+            var adaptiveCardAttachment = new Schema.Attachment()
             {
                 ContentType = "application/vnd.microsoft.card.adaptive",
                 Content = JsonConvert.DeserializeObject(adaptiveCardJson, new JsonSerializerSettings { MaxDepth = null }),

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/WebexAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/WebexAdapterTests.cs
@@ -285,9 +285,9 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
             activity.Object.Type = "message";
             activity.Object.Recipient = new ChannelAccount(id: "MockId");
             activity.Object.Text = "Hello, Bot!";
-            activity.Object.Attachments = new List<Attachment>
+            activity.Object.Attachments = new List<Schema.Attachment>
             {
-                new Attachment("image/png", "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQtB3AwMUeNoq4gUBGe6Ocj8kyh3bXa9ZbV7u1fVKQoyKFHdkqU"),
+                new Schema.Attachment("image/png", "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQtB3AwMUeNoq4gUBGe6Ocj8kyh3bXa9ZbV7u1fVKQoyKFHdkqU"),
             };
 
             var turnContext = new TurnContext(webexAdapter, activity.Object);
@@ -303,7 +303,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         {
             const string expectedResponseId = "Mocked Response Id";
             var webexApi = new Mock<WebexClientWrapper>(_testOptions);
-            webexApi.Setup(x => x.CreateMessageWithAttachmentsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IList<Attachment>>(), It.IsAny<MessageTextType>(), It.IsAny<MessageTarget>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(expectedResponseId));
+            webexApi.Setup(x => x.CreateMessageWithAttachmentsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IList<Schema.Attachment>>(), It.IsAny<MessageTextType>(), It.IsAny<MessageTarget>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(expectedResponseId));
 
             var webexAdapter = new WebexAdapter(webexApi.Object, _adapterOptions);
 
@@ -311,9 +311,9 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
             activity.Object.Type = "message";
             activity.Object.Recipient = new ChannelAccount(id: "MockId");
             activity.Object.Text = "Hello, Bot!";
-            activity.Object.Attachments = new List<Attachment>
+            activity.Object.Attachments = new List<Schema.Attachment>
             {
-                new Attachment("application/vnd.microsoft.card.adaptive"),
+                new Schema.Attachment("application/vnd.microsoft.card.adaptive"),
             };
 
             var turnContext = new TurnContext(webexAdapter, activity.Object);
@@ -328,7 +328,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         {
             const string expectedResponseId = "Mocked Response Id";
             var webexApi = new Mock<WebexClientWrapper>(_testOptions);
-            webexApi.Setup(x => x.CreateMessageWithAttachmentsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IList<Attachment>>(), It.IsAny<MessageTextType>(), It.IsAny<MessageTarget>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(expectedResponseId));
+            webexApi.Setup(x => x.CreateMessageWithAttachmentsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IList<Schema.Attachment>>(), It.IsAny<MessageTextType>(), It.IsAny<MessageTarget>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(expectedResponseId));
 
             var webexAdapter = new WebexAdapter(webexApi.Object, _adapterOptions);
 


### PR DESCRIPTION
Addresses # 6825
#minor

## Description
This PR updates the `Thrzn41.WebexTeams` package from `1.6.2` to `1.8.1`, and fixes the error `[CS0104](https://learn.microsoft.com/en-us/dotnet/csharp/misc/cs0104): 'Attachment' is an ambiguous reference between 'Microsoft.Bot.Schema.Attachment' and 'Thrzn41.WebexTeams.Version1.Attachment'`.

## Specific Changes
  - Updated `Thrzn41.WebexTeams` package from `1.6.2` to `1.8.1`.
  - Updated `Attachment` references to be `Schema.Attachment` due to ambiguous reference between BotBuilder and WebexTeams packages.

## Testing
The following image shows the unit tests and CI pipeline passing successfully.
![image](https://github.com/user-attachments/assets/bb0b090f-fc8b-4c91-af0a-879f90b3e426)
