### PR TITLE
[#6825] Update packages to latest version that support .NET 6

### DIFF
--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/Microsoft.Bot.Builder.FunctionalTests.csproj
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/Microsoft.Bot.Builder.FunctionalTests.csproj
@@ -16,8 +16,8 @@
     <PackageReference Include="Microsoft.Bot.Connector.DirectLine" Version="3.0.2" />
     <PackageReference Include="Microsoft.CognitiveServices.Speech" Version="1.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.5.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.5.1" />
     <PackageReference Include="NAudio" Version="2.2.1" />
     <PackageReference Include="Twilio" Version="5.37.2" />
   </ItemGroup>

--- a/libraries/AdaptiveExpressions/AdaptiveExpressions.csproj
+++ b/libraries/AdaptiveExpressions/AdaptiveExpressions.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Antlr4.Runtime.Standard" Version="4.11.1" />
+    <PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.3.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/libraries/Directory.Build.props
+++ b/libraries/Directory.Build.props
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/libraries/Microsoft.Bot.AdaptiveExpressions.Core/Microsoft.Bot.AdaptiveExpressions.Core.csproj
+++ b/libraries/Microsoft.Bot.AdaptiveExpressions.Core/Microsoft.Bot.AdaptiveExpressions.Core.csproj
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Antlr4.Runtime.Standard" Version="4.11.1" />
-    <PackageReference Include="JsonPath.Net" Version="1.1.2" />
+    <PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
+    <PackageReference Include="JsonPath.Net" Version="1.1.4" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.3.2" />
     <PackageReference Include="PolySharp" Version="1.14.1">

--- a/libraries/Microsoft.Bot.Builder.Azure.Blobs/Microsoft.Bot.Builder.Azure.Blobs.csproj
+++ b/libraries/Microsoft.Bot.Builder.Azure.Blobs/Microsoft.Bot.Builder.Azure.Blobs.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <!-- Force System.Text.Json to a safe version. -->
     <PackageReference Include="System.Text.Json" Version="8.0.4" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.20.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.21.1" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />

--- a/libraries/Microsoft.Bot.Builder.Azure.Queues/Microsoft.Bot.Builder.Azure.Queues.csproj
+++ b/libraries/Microsoft.Bot.Builder.Azure.Queues/Microsoft.Bot.Builder.Azure.Queues.csproj
@@ -34,7 +34,7 @@
     <!-- Force System.Text.Json to a safe version. -->
     <PackageReference Include="System.Text.Json" Version="8.0.4" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
-    <PackageReference Include="Azure.Storage.Queues" Version="12.18.0" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.19.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PreviewPackageVersion)' == '' " Version="$(LocalPackageVersion)" />

--- a/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
+++ b/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     <!-- Force Microsoft.Bcl.AsyncInterfaces to a newer version. Since Microsoft.Azure.Cosmos has 1.1.1 version, which causes MSB3277 warnings. -->
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.41.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.42.0" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="9.4.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.csproj
@@ -48,7 +48,7 @@
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Condition=" '$(ReleasePackageVersion)' != '' " Version="$(ReleasePackageVersion)" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AdaptiveExpressions\AdaptiveExpressions.csproj" />

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Microsoft.Bot.Builder.LanguageGeneration.csproj
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Microsoft.Bot.Builder.LanguageGeneration.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Antlr4.Runtime.Standard" Version="4.11.1" />
+    <PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="AdaptiveExpressions" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="AdaptiveExpressions" Condition=" '$(ReleasePackageVersion)' != '' " Version="$(ReleasePackageVersion)" />

--- a/libraries/Microsoft.Bot.Connector/Microsoft.Bot.Connector.csproj
+++ b/libraries/Microsoft.Bot.Connector/Microsoft.Bot.Connector.csproj
@@ -29,8 +29,8 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="7.6.3" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.63.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.0.1" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.Bot.Schema" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />

--- a/libraries/Parsers/Microsoft.Bot.Builder.Parsers.LU/Microsoft.Bot.Builder.Parsers.LU.csproj
+++ b/libraries/Parsers/Microsoft.Bot.Builder.Parsers.LU/Microsoft.Bot.Builder.Parsers.LU.csproj
@@ -28,7 +28,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Antlr4.Runtime.Standard" Version="4.11.1" />
+    <PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi.csproj
@@ -47,14 +47,14 @@
   <ItemGroup>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Web" />
-    <Reference Include="Microsoft.AI.Agent.Intercept, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.AI.DependencyCollector, Version=2.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.AI.PerfCounterCollector, Version=2.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.AI.ServerTelemetryChannel, Version=2.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.AI.Web, Version=2.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.AI.WindowsServer, Version=2.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.AI.Agent.Intercept" />
+    <Reference Include="Microsoft.AI.DependencyCollector" />
+    <Reference Include="Microsoft.AI.PerfCounterCollector" />
+    <Reference Include="Microsoft.AI.ServerTelemetryChannel" />
+    <Reference Include="Microsoft.AI.Web" />
+    <Reference Include="Microsoft.AI.WindowsServer" />
+    <Reference Include="Microsoft.ApplicationInsights" />
+    <Reference Include="Microsoft.AspNet.TelemetryCorrelation" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Diagnostics.DiagnosticSource" />

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.TestBot/Microsoft.Bot.Builder.Adapters.Twilio.TestBot.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.TestBot/Microsoft.Bot.Builder.Adapters.Twilio.TestBot.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.7" />
   </ItemGroup>
 
 </Project>

--- a/tests/AdaptiveExpressions.Tests/AdaptiveExpressions.Tests.csproj
+++ b/tests/AdaptiveExpressions.Tests/AdaptiveExpressions.Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Antlr4.Runtime.Standard" Version="4.11.1" />
+    <PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/tests/Microsoft.Bot.AdaptiveExpressions.Core.AOT.Tests/Microsoft.Bot.AdaptiveExpressions.Core.AOT.Tests.csproj
+++ b/tests/Microsoft.Bot.AdaptiveExpressions.Core.AOT.Tests/Microsoft.Bot.AdaptiveExpressions.Core.AOT.Tests.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Antlr4.Runtime.Standard" Version="4.11.1" />
+    <PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/tests/Microsoft.Bot.AdaptiveExpressions.Core.Tests/Microsoft.Bot.AdaptiveExpressions.Core.Tests.csproj
+++ b/tests/Microsoft.Bot.AdaptiveExpressions.Core.Tests/Microsoft.Bot.AdaptiveExpressions.Core.Tests.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Antlr4.Runtime.Standard" Version="4.11.1" />
+    <PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/Microsoft.Bot.Builder.AI.Luis.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/Microsoft.Bot.Builder.AI.Luis.Tests.csproj
@@ -18,7 +18,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Microsoft.Bot.Builder.AI.Luis.TestUtils/Microsoft.Bot.Builder.AI.Luis.TestUtils.csproj
+++ b/tests/Microsoft.Bot.Builder.AI.Luis.TestUtils/Microsoft.Bot.Builder.AI.Luis.TestUtils.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.5.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/LanguageServiceTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/LanguageServiceTests.cs
@@ -1138,7 +1138,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
             }
 
             Assert.Equal(2, result.InnerExceptions.Count);
-            Assert.All(result.InnerExceptions, (e) => Assert.IsType<HttpRequestException>(e));
+            Assert.All(result.InnerExceptions, (e) => Assert.IsType<MockHttpMatchException>(e));
         }
 
         /// <summary>

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/Microsoft.Bot.Builder.AI.QnA.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/Microsoft.Bot.Builder.AI.QnA.Tests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Microsoft.Bot.Builder.Ai.LUISV3.tests/Microsoft.Bot.Builder.AI.LuisV3.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Ai.LUISV3.tests/Microsoft.Bot.Builder.AI.LuisV3.Tests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests.csproj
@@ -41,7 +41,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/TestScriptTests/TestScriptTests_HttpRequestMock.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/TestScriptTests/TestScriptTests_HttpRequestMock.test.dialog
@@ -17,7 +17,7 @@
                 "actions": [
                     {
                         "$kind": "Microsoft.HttpRequest",
-                        "responseType": "Json",
+                        "responseType": "json",
                         "method": "GET",
                         "url": "http://127.0.0.1",
                         "resultProperty": "dialog.result"
@@ -28,7 +28,7 @@
                     },
                     {
                         "$kind": "Microsoft.HttpRequest",
-                        "responseType": "Json",
+                        "responseType": "json",
                         "method": "GET",
                         "url": "http://127.0.0.1",
                         "resultProperty": "dialog.result"
@@ -39,7 +39,7 @@
                     },
                     {
                         "$kind": "Microsoft.HttpRequest",
-                        "responseType": "Json",
+                        "responseType": "json",
                         "method": "GET",
                         "url": "http://127.0.0.1",
                         "resultProperty": "dialog.result"
@@ -50,7 +50,7 @@
                     },
                     {
                         "$kind": "Microsoft.HttpRequest",
-                        "responseType": "Json",
+                        "responseType": "json",
                         "method": "GET",
                         "url": "http://127.0.0.1",
                         "resultProperty": "dialog.result"
@@ -61,7 +61,7 @@
                     },
                     {
                         "$kind": "Microsoft.HttpRequest",
-                        "responseType": "Json",
+                        "responseType": "json",
                         "method": "GET",
                         "url": "http://127.0.0.1",
                         "resultProperty": "dialog.result"
@@ -72,7 +72,7 @@
                     },
                     {
                         "$kind": "Microsoft.HttpRequest",
-                        "responseType": "Json",
+                        "responseType": "json",
                         "method": "POST",
                         "url": "http://127.0.0.1",
                         "resultProperty": "dialog.result"
@@ -83,7 +83,7 @@
                     },
                     {
                         "$kind": "Microsoft.HttpRequest",
-                        "responseType": "Json",
+                        "responseType": "json",
                         "method": "GET",
                         "url": "http://127.0.0.1",
                         "resultProperty": "dialog.result"
@@ -94,7 +94,7 @@
                     },
                     {
                         "$kind": "Microsoft.HttpRequest",
-                        "responseType": "Json",
+                        "responseType": "json",
                         "method": "GET",
                         "url": "http://127.0.0.1",
                         "resultProperty": "dialog.result"
@@ -105,7 +105,7 @@
                     },
                     {
                         "$kind": "Microsoft.HttpRequest",
-                        "responseType": "Json",
+                        "responseType": "json",
                         "method": "POST",
                         "url": "http://127.0.0.1",
                         "resultProperty": "dialog.result"
@@ -116,7 +116,7 @@
                     },
                     {
                         "$kind": "Microsoft.HttpRequest",
-                        "responseType": "Json",
+                        "responseType": "json",
                         "method": "POST",
                         "url": "http://127.0.0.1",
                         "resultProperty": "dialog.result"
@@ -127,7 +127,7 @@
                     },
                     {
                         "$kind": "Microsoft.HttpRequest",
-                        "responseType": "Json",
+                        "responseType": "json",
                         "method": "POST",
                         "url": "http://127.0.0.2",
                         "resultProperty": "dialog.result"
@@ -138,7 +138,7 @@
                     },
                     {
                         "$kind": "Microsoft.HttpRequest",
-                        "responseType": "Json",
+                        "responseType": "json",
                         "method": "PATCH",
                         "url": "http://127.0.0.1",
                         "body": "full body or partial body",
@@ -150,7 +150,7 @@
                     },
                     {
                         "$kind": "Microsoft.HttpRequest",
-                        "responseType": "Json",
+                        "responseType": "json",
                         "method": "PATCH",
                         "body": "full body",
                         "url": "http://127.0.0.1",
@@ -162,7 +162,7 @@
                     },
                     {
                         "$kind": "Microsoft.HttpRequest",
-                        "responseType": "Json",
+                        "responseType": "json",
                         "method": "POST",
                         "body": "gzip body",
                         "url": "http://127.0.0.1",

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.13" />
+    <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Flow.Tests/Microsoft.Bot.Builder.Dialogs.Flows.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Flow.Tests/Microsoft.Bot.Builder.Dialogs.Flows.Tests.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.5.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.5.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/Microsoft.Bot.Builder.TestBot.Json.csproj
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/Microsoft.Bot.Builder.TestBot.Json.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jint" Version="3.1.5" />
+    <PackageReference Include="Jint" Version="4.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.7" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.10.0" />
   </ItemGroup>

--- a/tests/Microsoft.Bot.Connector.Streaming.Perf/Microsoft.Bot.Connector.Streaming.Perf.csproj
+++ b/tests/Microsoft.Bot.Connector.Streaming.Perf/Microsoft.Bot.Connector.Streaming.Perf.csproj
@@ -8,7 +8,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Bot.Connector.Streaming.Tests/Microsoft.Bot.Connector.Streaming.Tests.csproj
+++ b/tests/Microsoft.Bot.Connector.Streaming.Tests/Microsoft.Bot.Connector.Streaming.Tests.csproj
@@ -27,14 +27,14 @@
     <PackageReference Include="Microsoft.CodeCoverage" Version="17.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="NunitXml.TestLogger" Version="3.1.20" />
-    <PackageReference Include="ReportGenerator" Version="5.3.7" />
+    <PackageReference Include="NunitXml.TestLogger" Version="4.0.254" />
+    <PackageReference Include="ReportGenerator" Version="5.3.8" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="XunitXml.TestLogger" Version="3.1.20" />    
+    <PackageReference Include="XunitXml.TestLogger" Version="4.0.254" />    
   </ItemGroup>
 
   <ItemGroup>        

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/ManagedIdentityAuthenticatorTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/ManagedIdentityAuthenticatorTests.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Moq.Protected;
 using Newtonsoft.Json.Linq;
@@ -75,29 +76,15 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         public void DefaultRetryOnException()
         {
             var maxRetries = 10;
-            var callsToAcquireToken = 0;
-            var actualCallsToAcquireToken = 0;
+            var mockLogger = new Mock<ILogger>();
             var mockHttpMessageHandler = new Mock<HttpMessageHandler>();
             mockHttpMessageHandler.Protected()
                 .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
-                .ReturnsAsync(() => 
-                {
-                    // ManagedCredentialsClient is apparently auto-retrying failed requests once.
-                    // Resolution unclear.
-                    // For now, count the number of times WE think it's be called.
-                    actualCallsToAcquireToken++;
-
-                    if (actualCallsToAcquireToken % 2 != 0)
-                    {
-                        callsToAcquireToken++;
-                    }
-
-                    return new HttpResponseMessage(HttpStatusCode.TooManyRequests);
-                });
+                .ReturnsAsync(() => new HttpResponseMessage(HttpStatusCode.TooManyRequests));
 
             var httpClient = new HttpClient(mockHttpMessageHandler.Object);
 
-            var sut = new ManagedIdentityAuthenticator(appId(nameof(DefaultRetryOnException)), audience(nameof(DefaultRetryOnException)), httpClient);
+            var sut = new ManagedIdentityAuthenticator(appId(nameof(DefaultRetryOnException)), audience(nameof(DefaultRetryOnException)), httpClient, mockLogger.Object);
 
             try
             {
@@ -109,7 +96,14 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
             }
             finally
             {
-                Assert.Equal(maxRetries + 1, callsToAcquireToken);
+                mockLogger.Verify(
+                   x => x.Log(
+                       LogLevel.Error,
+                       It.IsAny<EventId>(),
+                       It.Is<It.IsAnyType>((o, t) => o.ToString().Contains("Exception when trying to acquire token using MSI!")),
+                       It.IsAny<Exception>(),
+                       (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()),
+                   Times.Exactly(maxRetries + 1));
             }
         }
 

--- a/tests/Microsoft.Bot.Connector.Tests/Microsoft.Bot.Connector.Tests.csproj
+++ b/tests/Microsoft.Bot.Connector.Tests/Microsoft.Bot.Connector.Tests.csproj
@@ -13,12 +13,12 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.Azure.Test.HttpRecorder" Version="1.13.3" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.6.3" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.6.3" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Microsoft.Bot.Streaming.Tests/Microsoft.Bot.Streaming.Tests.csproj
+++ b/tests/Microsoft.Bot.Streaming.Tests/Microsoft.Bot.Streaming.Tests.csproj
@@ -22,14 +22,14 @@
     <PackageReference Include="Microsoft.CodeCoverage" Version="17.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="NunitXml.TestLogger" Version="3.1.20" />
-    <PackageReference Include="ReportGenerator" Version="5.3.7" />
+    <PackageReference Include="NunitXml.TestLogger" Version="4.0.254" />
+    <PackageReference Include="ReportGenerator" Version="5.3.8" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="XunitXml.TestLogger" Version="3.1.20" />    
+    <PackageReference Include="XunitXml.TestLogger" Version="4.0.254" />    
   </ItemGroup>
 
   <ItemGroup>        

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.WebApi.Tests/Microsoft.Bot.ApplicationInsights.WebApi.Tests.csproj
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.WebApi.Tests/Microsoft.Bot.ApplicationInsights.WebApi.Tests.csproj
@@ -99,16 +99,16 @@
       <Version>5.3.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeCoverage">
-      <Version>16.3.0</Version>
+      <Version>17.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk">
-      <Version>16.1.1</Version>
+      <Version>17.10.0</Version>
     </PackageReference>
     <PackageReference Include="Moq">
-      <Version>4.13.1</Version>
+      <Version>4.20.70</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.4.1</Version>
+      <Version>2.9.0</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
       <Version>2.8.2</Version>

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi.Tests/Microsoft.Bot.Builder.Integration.AspNet.WebApi.Tests.csproj
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi.Tests/Microsoft.Bot.Builder.Integration.AspNet.WebApi.Tests.csproj
@@ -107,10 +107,10 @@
       <Version>6.12.0</Version>
     </PackageReference>
     <PackageReference Include="Moq">
-      <Version>4.13.1</Version>
+      <Version>4.20.70</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.4.1</Version>
+      <Version>2.9.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />


### PR DESCRIPTION
Fixes # 6825
#minor

## Description
This PR updates multiple dependencies to their latest version that support .NET 6 as minimum. Additionally, it fixes some of the breaking changes generated by these updates in the unit tests due to package protected methods, different type of Exceptions, and JSON schemas typos.

## Specific Changes
  - Updated the following dependencies to newer version:
    - `MSTest.TestAdapter` from `3.4.3` to `3.5.1`.
    - `MSTest.TestFramework` from `3.4.3` to `3.5.1`.
    - `Antlr4.Runtime.Standard` from `4.11.1` to `4.13.1`.
    - `Microsoft.SourceLink.GitHub` from `1.0.0` to `8.0.0`.
    - `JsonPath.Net` from `1.1.2` to `1.1.4`.
    - `Azure.Storage.Blobs` from `12.20.0` to `12.21.1`.
    - `Azure.Storage.Queues` from `12.18.0` to `12.19.1`.
    - `Microsoft.Azure.Cosmos` from `3.41.0` to `3.42.0`.
    - `RichardSzalay.MockHttp` from `6.0.0` to `7.0.0`.
    - `Microsoft.Identity.Client` from `4.61.3` to `4.63.0`.
    - `Microsoft.IdentityModel.Protocols.OpenIdConnect` from `7.6.3` to `8.0.1`.
    - `Microsoft.AspNetCore.Mvc.NewtonsoftJson` from `8.0.2` to `8.0.7`.
    - `Newtonsoft.Json.Schema` from `3.0.13` to `4.0.1`.
    - `Jint` from `3.1.5` to `4.0.0`.
    - `BenchmarkDotNet` from `0.13.12` to `0.14.0`.
    - `NunitXml.TestLogger` from `3.1.20` to `4.0.254`.
    - `XunitXml.TestLogger` from `3.1.20` to `4.0.254`.
    - `Microsoft.IdentityModel.Tokens` from `7.6.3` to `8.0.1`.
    - `System.IdentityModel.Tokens.Jwt` from `7.6.3` to `8.0.1`.
  - Fixed warnings, mostly related to WebApi package version mismatch.
  - Fixed breaking changes that made unit tests fail.
    - JSON Schema validating correctly, it detected a .dialog file having a typo.
    - MockHttp changed request exception.
    - Azure Identity changed the retry system, causing the unit test based on that to fail.

## Testing
The following images show the CI pipeline.
![imagen](https://github.com/user-attachments/assets/bbe3389c-6ca0-405b-a1f9-af303ddbce93)
