### PR TITLE
fix: Disable telemetry adaptive sampling

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Extensions/ServiceCollectionExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Extensions/ServiceCollectionExtensions.cs
@@ -209,6 +209,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Extensions
             }
             else
             {
+                telemetrySettings.Options.EnableAdaptiveSampling = false;
                 services.AddApplicationInsightsTelemetry(telemetrySettings.Options);
                 services.TryAddSingleton<IBotTelemetryClient, BotTelemetryClient>();
 

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/ServiceCollectionExtensions.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/ServiceCollectionExtensions.cs
@@ -57,7 +57,14 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
             IBotTelemetryClient telemetryClient = null;
             if (appInsightService != null)
             {
-                services.AddApplicationInsightsTelemetry(appInsightService.InstrumentationKey);
+                // Create Application Insights options and disable adaptive sampling
+                var aiOptions = new Microsoft.ApplicationInsights.AspNetCore.Extensions.ApplicationInsightsServiceOptions
+                {
+                    EnableAdaptiveSampling = false,
+                    InstrumentationKey = appInsightService.InstrumentationKey
+                };
+
+                services.AddApplicationInsightsTelemetry(aiOptions);
                 telemetryClient = new BotTelemetryClient(new TelemetryClient());
             }
             else
@@ -88,9 +95,19 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
             CreateBotTelemetry(services);
 
             IBotTelemetryClient telemetryClient = null;
+
             if (!string.IsNullOrWhiteSpace(instrumentationKey))
             {
-                services.AddApplicationInsightsTelemetry(instrumentationKey);
+                // Create Application Insights options and disable adaptive sampling
+                var aiOptions = new Microsoft.ApplicationInsights.AspNetCore.Extensions.ApplicationInsightsServiceOptions
+                {
+                    EnableAdaptiveSampling = false, 
+                    InstrumentationKey = instrumentationKey
+                };
+
+                // Add Application Insights telemetry with custom options
+                services.AddApplicationInsightsTelemetry(aiOptions);
+
                 telemetryClient = new BotTelemetryClient(new TelemetryClient());
             }
             else
@@ -122,7 +139,14 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
             // Start Application Insights
             if (instrumentationKey != null)
             {
-                services.AddApplicationInsightsTelemetry(instrumentationKey);
+                // Create Application Insights options and disable adaptive sampling
+                var aiOptions = new Microsoft.ApplicationInsights.AspNetCore.Extensions.ApplicationInsightsServiceOptions
+                {
+                    EnableAdaptiveSampling = false,
+                    InstrumentationKey = instrumentationKey
+                };
+
+                services.AddApplicationInsightsTelemetry(aiOptions);
             }
 
             // Register the BotTelemetryClient

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/ServiceCollectionExtensions.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/ServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Linq;
 using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Bot.Builder.ApplicationInsights;
 using Microsoft.Bot.Configuration;
@@ -58,7 +59,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
             if (appInsightService != null)
             {
                 // Create Application Insights options and disable adaptive sampling
-                var aiOptions = new Microsoft.ApplicationInsights.AspNetCore.Extensions.ApplicationInsightsServiceOptions
+                var aiOptions = new ApplicationInsightsServiceOptions
                 {
                     EnableAdaptiveSampling = false,
                     InstrumentationKey = appInsightService.InstrumentationKey
@@ -99,7 +100,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
             if (!string.IsNullOrWhiteSpace(instrumentationKey))
             {
                 // Create Application Insights options and disable adaptive sampling
-                var aiOptions = new Microsoft.ApplicationInsights.AspNetCore.Extensions.ApplicationInsightsServiceOptions
+                var aiOptions = new ApplicationInsightsServiceOptions
                 {
                     EnableAdaptiveSampling = false, 
                     InstrumentationKey = instrumentationKey
@@ -140,7 +141,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
             if (instrumentationKey != null)
             {
                 // Create Application Insights options and disable adaptive sampling
-                var aiOptions = new Microsoft.ApplicationInsights.AspNetCore.Extensions.ApplicationInsightsServiceOptions
+                var aiOptions = new ApplicationInsightsServiceOptions
                 {
                     EnableAdaptiveSampling = false,
                     InstrumentationKey = instrumentationKey


### PR DESCRIPTION
#minor

## Description
This PR disables the adaptive sampling used in the telemetry client to avoid skipping logs due to big amount of concurrent users and events.

## Specific Changes
<!-- Please list the changes in a concise manner. -->
  - Set to false property **_EnableAdaptiveSampling_** of telemetry settings in _ServiceCollectionExtensions_ classes.

## Testing
The following image shows the logs saved correctly in the Application Insights resource.
![image](https://github.com/user-attachments/assets/be632cd3-bb8c-4085-85d2-0c6152d280aa)