### PR TITLE
feat: [#6865] Provide two new invoke handlers, (message/fetchTask, message/submitAction) for Custom Feedback Loops

### DIFF
--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityHandler.cs
@@ -85,10 +85,10 @@ namespace Microsoft.Bot.Builder.Teams
 
                         case "task/submit":
                             return CreateInvokeResponse(await OnTeamsTaskModuleSubmitAsync(turnContext, SafeCast<TaskModuleRequest>(turnContext.Activity.Value), cancellationToken).ConfigureAwait(false));
-                        
+
                         case "tab/fetch":
                             return CreateInvokeResponse(await OnTeamsTabFetchAsync(turnContext, SafeCast<TabRequest>(turnContext.Activity.Value), cancellationToken).ConfigureAwait(false));
-                        
+
                         case "tab/submit":
                             return CreateInvokeResponse(await OnTeamsTabSubmitAsync(turnContext, SafeCast<TabSubmit>(turnContext.Activity.Value), cancellationToken).ConfigureAwait(false));
 
@@ -97,6 +97,13 @@ namespace Microsoft.Bot.Builder.Teams
 
                         case "config/submit":
                             return CreateInvokeResponse(await OnTeamsConfigSubmitAsync(turnContext, turnContext.Activity.Value as JObject, cancellationToken).ConfigureAwait(false));
+
+                        case "message/submitAction":
+                            await OnTeamsMessageSubmitActionAsync(turnContext, SafeCast<FeedbackResponse>(turnContext.Activity.Value), cancellationToken).ConfigureAwait(false);
+                            return CreateInvokeResponse();
+
+                        case "message/fetchTask":
+                            return CreateInvokeResponse(await OnTeamsMessageFetchTaskAsync(turnContext, cancellationToken).ConfigureAwait(false));
 
                         default:
                             return await base.OnInvokeActivityAsync(turnContext, cancellationToken).ConfigureAwait(false);
@@ -686,7 +693,7 @@ namespace Microsoft.Bot.Builder.Teams
         {
             return Task.CompletedTask;
         }
-        
+
         /// <summary>
         /// Invoked when a Channel Restored event activity is received from the connector.
         /// Channel Restored correspond to the user restoring a previously deleted channel.
@@ -992,6 +999,31 @@ namespace Microsoft.Bot.Builder.Teams
         protected virtual Task OnTeamsMessageSoftDeleteAsync(ITurnContext<IMessageDeleteActivity> turnContext, CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Invoked when a feedback loop activity is received.
+        /// </summary>
+        /// <param name="turnContext">A strongly-typed context object for this turn.</param>
+        /// <param name="feedback">A strongly-typed feedback loop object for this turn.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        protected virtual Task OnTeamsMessageSubmitActionAsync(ITurnContext<IInvokeActivity> turnContext, FeedbackResponse feedback, CancellationToken cancellationToken)
+        {
+            throw new InvokeResponseException(HttpStatusCode.NotImplemented);
+        }
+
+        /// <summary>
+        /// Invoked when a custom feedback loop activity is received to show either an AdaptiveCard or website.
+        /// </summary>
+        /// <param name="turnContext">A strongly-typed context object for this turn.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        protected virtual Task<TaskModuleContinueResponse> OnTeamsMessageFetchTaskAsync(ITurnContext<IInvokeActivity> turnContext, CancellationToken cancellationToken)
+        {
+            throw new InvokeResponseException(HttpStatusCode.NotImplemented);
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Schema/Teams/FeedbackInfo.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/FeedbackInfo.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Schema.Teams
+{
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Describes feedback loop information.
+    /// </summary>
+    public partial class FeedbackInfo
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FeedbackInfo"/> class.
+        /// </summary>
+        public FeedbackInfo()
+        {
+            CustomInit();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FeedbackInfo"/> class.
+        /// </summary>
+        /// <param name="type">Unique identifier representing a team.</param>
+        public FeedbackInfo(string type = FeedbackInfoTypes.Default)
+        {
+            Type = type;
+            CustomInit();
+        }
+
+        /// <summary>
+        /// Gets or sets the feedback loop type. Possible values include: 'default', 'custom'.
+        /// </summary>
+        /// <value>
+        /// The feedback loop type (see <see cref="FeedbackInfoTypes"/>). 
+        /// </value>
+        [JsonProperty(PropertyName = "type")]
+        public string Type { get; set; }
+
+        partial void CustomInit();
+    }
+}

--- a/libraries/Microsoft.Bot.Schema/Teams/FeedbackInfoTypes.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/FeedbackInfoTypes.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Schema.Teams
+{
+    /// <summary>
+    /// Defines feedback loop type. Depending on the type, the feedback window will have a different structure. 
+    /// </summary>
+    public static class FeedbackInfoTypes
+    {
+        /// <summary>
+        /// The type value for default feedback window form.
+        /// </summary>
+        public const string Default = "default";
+
+        /// <summary>
+        /// The type value for custom feedback window, can be either an AdaptiveCard or website.
+        /// </summary>
+        public const string Custom = "custom";
+    }
+}

--- a/libraries/Microsoft.Bot.Schema/Teams/FeedbackResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/FeedbackResponse.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Schema.Teams
+{
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Envelope for Feedback Response.
+    /// </summary>
+    public partial class FeedbackResponse
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FeedbackResponse"/> class.
+        /// </summary>
+        public FeedbackResponse()
+        {
+            CustomInit();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FeedbackResponse"/> class.
+        /// </summary>
+        /// <param name="actionName">Unique identifier representing a team.</param>
+        /// <param name="actionValue">Unique identifier representing a team2.</param>
+        /// <param name="replyToId">Unique identifier representing a team3.</param>
+        public FeedbackResponse(string actionName = default, FeedbackResponseActionValue actionValue = default, string replyToId = default)
+        {
+            ActionName = actionName;
+            ActionValue = actionValue;
+            ReplyToId = replyToId;
+            CustomInit();
+        }
+
+        /// <summary>
+        /// Gets or sets the action name.
+        /// </summary>
+        /// <value>Name of the action.</value>
+        public string ActionName { get; set; } = "feedback";
+
+        /// <summary>
+        /// Gets or sets the response for the action value.
+        /// </summary>
+        /// <value>The action value that contains the feedback reaction and message.</value>
+        [JsonProperty(PropertyName = "actionValue")]
+        public FeedbackResponseActionValue ActionValue { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ID of the message to which this message is a reply.
+        /// </summary>
+        /// <value>Value of the ID to reply.</value>
+        [JsonProperty(PropertyName = "replyToId")]
+        public string ReplyToId { get; set; }
+
+        partial void CustomInit();
+    }
+}

--- a/libraries/Microsoft.Bot.Schema/Teams/FeedbackResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/FeedbackResponse.cs
@@ -21,9 +21,9 @@ namespace Microsoft.Bot.Schema.Teams
         /// <summary>
         /// Initializes a new instance of the <see cref="FeedbackResponse"/> class.
         /// </summary>
-        /// <param name="actionName">Unique identifier representing a team.</param>
-        /// <param name="actionValue">Unique identifier representing a team2.</param>
-        /// <param name="replyToId">Unique identifier representing a team3.</param>
+        /// <param name="actionName">The name of the action.</param>
+        /// <param name="actionValue">The value of the action.</param>
+        /// <param name="replyToId">The ID of the message to which this message is a reply.</param>
         public FeedbackResponse(string actionName = default, FeedbackResponseActionValue actionValue = default, string replyToId = default)
         {
             ActionName = actionName;

--- a/libraries/Microsoft.Bot.Schema/Teams/FeedbackResponseActionValue.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/FeedbackResponseActionValue.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Schema.Teams
+{
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Envelope for Feedback ActionValue Response.
+    /// </summary>
+    public partial class FeedbackResponseActionValue
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FeedbackResponseActionValue"/> class.
+        /// </summary>
+        public FeedbackResponseActionValue()
+        {
+            CustomInit();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FeedbackResponseActionValue"/> class.
+        /// </summary>
+        /// <param name="reaction">The reaction of the feedback.</param>
+        /// <param name="feedback">The feedback content.</param>
+        public FeedbackResponseActionValue(string reaction = default, string feedback = default)
+        {
+            Reaction = reaction;
+            Feedback = feedback;
+            CustomInit();
+        }
+
+        /// <summary>
+        /// Gets or sets the reaction, either "like" or "dislike".
+        /// </summary>
+        /// <value>val.</value>
+        [JsonProperty(PropertyName = "reaction")]
+        public string Reaction { get; set; }
+
+        /// <summary>
+        /// Gets or sets the feedback content provided by the user when prompted with "What did you like/dislike?".
+        /// </summary>
+        /// <value>val.</value>
+        [JsonProperty(PropertyName = "feedback")]
+        public string Feedback { get; set; }
+
+        partial void CustomInit();
+    }
+}

--- a/libraries/Microsoft.Bot.Schema/Teams/TeamsChannelData.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TeamsChannelData.cs
@@ -108,6 +108,13 @@ namespace Microsoft.Bot.Schema.Teams
         public TeamsChannelDataSettings Settings { get; set; }
 
         /// <summary>
+        /// Gets or sets information about custom feedback buttons.
+        /// </summary>
+        /// <value>The <see cref="FeedbackInfo"/> for this <see cref="TeamsChannelData"/>.</value>
+        [JsonProperty(PropertyName = "feedbackLoop")]
+        public FeedbackInfo FeedbackLoop { get; set; }
+
+        /// <summary>
         /// Gets the OnBehalfOf list for user attribution.
         /// </summary>
         /// <value>The Teams activity OnBehalfOf list.</value>

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerNotImplementedTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerNotImplementedTests.cs
@@ -718,36 +718,7 @@ namespace Microsoft.Bot.Builder.Teams.Tests
         }
 
         [Fact]
-        public async Task TestMessageFetchTaskDefault()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.Invoke,
-                Name = "message/fetchTask"
-            };
-
-            Activity[] activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
-            {
-                activitiesToSend = arg;
-            }
-
-            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await ((IBot)bot).OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.NotNull(activitiesToSend);
-            Assert.Single(activitiesToSend);
-            Assert.IsType<InvokeResponse>(activitiesToSend[0].Value);
-            Assert.Equal(501, ((InvokeResponse)activitiesToSend[0].Value).Status);
-        }
-
-        [Fact]
-        public async Task TestMessageFetchTaskCustom()
+        public async Task TestMessageFetchTask()
         {
             // Arrange
             var activity = new Activity

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerNotImplementedTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerNotImplementedTests.cs
@@ -688,6 +688,93 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             Assert.Equal(200, ((InvokeResponse)activitiesToSend[0].Value).Status);
         }
 
+        [Fact]
+        public async Task TestMessageSubmitAction()
+        {
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.Invoke,
+                Name = "message/submitAction"
+            };
+
+            Activity[] activitiesToSend = null;
+            void CaptureSend(Activity[] arg)
+            {
+                activitiesToSend = arg;
+            }
+
+            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+            // Act
+            var bot = new TestActivityHandler();
+            await ((IBot)bot).OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.NotNull(activitiesToSend);
+            Assert.Single(activitiesToSend);
+            Assert.IsType<InvokeResponse>(activitiesToSend[0].Value);
+            Assert.Equal(200, ((InvokeResponse)activitiesToSend[0].Value).Status);
+        }
+
+        [Fact]
+        public async Task TestMessageFetchTaskDefault()
+        {
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.Invoke,
+                Name = "message/fetchTask"
+            };
+
+            Activity[] activitiesToSend = null;
+            void CaptureSend(Activity[] arg)
+            {
+                activitiesToSend = arg;
+            }
+
+            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+            // Act
+            var bot = new TestActivityHandler();
+            await ((IBot)bot).OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.NotNull(activitiesToSend);
+            Assert.Single(activitiesToSend);
+            Assert.IsType<InvokeResponse>(activitiesToSend[0].Value);
+            Assert.Equal(501, ((InvokeResponse)activitiesToSend[0].Value).Status);
+        }
+
+        [Fact]
+        public async Task TestMessageFetchTaskCustom()
+        {
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.Invoke,
+                Name = "message/fetchTask"
+            };
+
+            Activity[] activitiesToSend = null;
+            void CaptureSend(Activity[] arg)
+            {
+                activitiesToSend = arg;
+            }
+
+            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+            // Act
+            var bot = new TestActivityHandler();
+            await ((IBot)bot).OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.NotNull(activitiesToSend);
+            Assert.Single(activitiesToSend);
+            Assert.IsType<InvokeResponse>(activitiesToSend[0].Value);
+            Assert.Equal(501, ((InvokeResponse)activitiesToSend[0].Value).Status);
+        }
+
         private class TestActivityHandler : TeamsActivityHandler
         {
         }

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerTests.cs
@@ -1556,38 +1556,7 @@ namespace Microsoft.Bot.Builder.Teams.Tests
         }
 
         [Fact]
-        public async Task TestMessageFetchTaskDefault()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.Invoke,
-                Name = "message/fetchTask"
-            };
-
-            Activity[] activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
-            {
-                activitiesToSend = arg;
-            }
-
-            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
-
-            // Act
-            var bot = new TestActivityHandler();
-            await ((IBot)bot).OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.Single(bot.Record);
-            Assert.Equal("OnTeamsMessageFetchTaskAsync", bot.Record[0]);
-            Assert.NotNull(activitiesToSend);
-            Assert.Single(activitiesToSend);
-            Assert.IsType<InvokeResponse>(activitiesToSend[0].Value);
-            Assert.Equal(200, ((InvokeResponse)activitiesToSend[0].Value).Status);
-        }
-
-        [Fact]
-        public async Task TestMessageFetchTaskCustom()
+        public async Task TestMessageFetchTask()
         {
             // Arrange
             var activity = new Activity
@@ -1613,6 +1582,7 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             Assert.Single(activitiesToSend);
             Assert.IsType<InvokeResponse>(activitiesToSend[0].Value);
             Assert.Equal(200, ((InvokeResponse)activitiesToSend[0].Value).Status);
+            Assert.Equal("http://testing", ((TaskModuleContinueResponse)((InvokeResponse)activitiesToSend[0].Value).Body).Value.Url);
         }
 
         private class NotImplementedAdapter : BotAdapter
@@ -1960,7 +1930,8 @@ namespace Microsoft.Bot.Builder.Teams.Tests
 
             protected override Task<TaskModuleContinueResponse> OnTeamsMessageFetchTaskAsync(ITurnContext<IInvokeActivity> turnContext, CancellationToken cancellationToken)
             {
-                var task = new TaskModuleContinueResponse();
+                var info = new TaskModuleTaskInfo(url: "http://testing");
+                var task = new TaskModuleContinueResponse(info);
                 Record.Add(MethodBase.GetCurrentMethod().Name);
                 return Task.FromResult(task);
             }

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/FeedbackInfoTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/FeedbackInfoTests.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class FeedbackInfoTests
+    {
+        [Fact]
+        public void FeedbackInfoInitsWithNoArgs()
+        {
+            var feedbackLoopInfo = new FeedbackInfo();
+
+            Assert.NotNull(feedbackLoopInfo);
+            Assert.IsType<FeedbackInfo>(feedbackLoopInfo);
+            Assert.Equal(FeedbackInfoTypes.Default, feedbackLoopInfo.Type);
+        }
+        
+        [Fact]
+        public void FeedbackInfoInitsDefault()
+        {
+            var feedbackLoopInfo = new FeedbackInfo(FeedbackInfoTypes.Default);
+
+            Assert.NotNull(feedbackLoopInfo);
+            Assert.IsType<FeedbackInfo>(feedbackLoopInfo);
+            Assert.Equal(FeedbackInfoTypes.Default, feedbackLoopInfo.Type);
+        }
+
+        [Fact]
+        public void FeedbackInfoInitsCustom()
+        {
+            var feedbackLoopInfo = new FeedbackInfo(FeedbackInfoTypes.Custom);
+
+            Assert.NotNull(feedbackLoopInfo);
+            Assert.IsType<FeedbackInfo>(feedbackLoopInfo);
+            Assert.Equal(FeedbackInfoTypes.Custom, feedbackLoopInfo.Type);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TeamsChannelDataTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TeamsChannelDataTests.cs
@@ -31,10 +31,12 @@ namespace Microsoft.Bot.Schema.Tests.Teams
                     Mri = Guid.NewGuid().ToString()
                 }
             };
+            var feedback = new FeedbackInfo(FeedbackInfoTypes.Default);
             var channelData = new TeamsChannelData(channel, eventType, team, notification, tenant, onBehalfOf)
             {
                 Meeting = meeting,
-                Settings = settings
+                Settings = settings,
+                FeedbackLoop = feedback
             };
 
             Assert.NotNull(channelData);
@@ -47,6 +49,7 @@ namespace Microsoft.Bot.Schema.Tests.Teams
             Assert.Equal(settings, channelData.Settings);
             Assert.Equal(channel, channelData.Settings.SelectedChannel);
             Assert.Equal(onBehalfOf, channelData.OnBehalfOf);
+            Assert.Equal(feedback, channelData.FeedbackLoop);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes # 6865
#minor

## Description
This PR introduces two new Teams handlers, submitAction and fetchTask, alongside with the respective feedback loop classes.

## Specific Changes
  - Added submitAction and fetchTask handlers for teams.
  - Added new classes for strong-type the new handlers' data.
  - Added new class for TeamsChannelData to enable feedback loops.
  - Added unit tests for the new handlers.

## Testing
The following image shows a teams sample working with the new submitAction handler, fetchTask couldn't be tested since it is only available in ring0.
![img](https://github.com/user-attachments/assets/e9b0cb69-b00c-4bc2-a17a-a73aa9356fc3)
