### PR TITLE
Fix create parity issue github action

### DIFF
--- a/.github/workflows/create-botbuilder-parity-issues.yml
+++ b/.github/workflows/create-botbuilder-parity-issues.yml
@@ -55,11 +55,11 @@ jobs:
     steps:
       - run: echo "::notice ::Creating issue for ${{ matrix.repo }}"
         if: |
-          contains(github.event.pull_request.labels.*.name, 'Automation: Parity all') == true || contains(github.event.pull_request.labels.*.name, format('Automation: parity with {0}', matrix.repo)) == true
+          contains(github.event.pull_request.labels.*.name, 'Automation: Parity all') == true || contains(github.event.pull_request.labels.*.name, format('Automation: Parity with {0}', matrix.repo)) == true
 
       - uses: joshgummersall/dispatch-workflow@main
         if: |
-          contains(github.event.pull_request.labels.*.name, 'Automation: Parity all') == true || contains(github.event.pull_request.labels.*.name, format('Automation: parity with {0}', matrix.repo)) == true
+          contains(github.event.pull_request.labels.*.name, 'Automation: Parity all') == true || contains(github.event.pull_request.labels.*.name, format('Automation: Parity with {0}', matrix.repo)) == true
         with:
           encoded: "true"
           inputs: |


### PR DESCRIPTION
#minor

## Description
This PR fixes the create parity issue github action by matching the PR labels correctly.

## Specific Changes
- Changed `parity` to title case `Parity`.

## Testing
The following image shows the "Bad credentials" error from our fork repository, meaning that is thrown after the condition is correctly met.
![imagen](https://github.com/user-attachments/assets/17337e49-9261-4331-a8b5-fbfc7af60cb4)
