### PR TITLE
Refactor Teams SSO middleware

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsStorage.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -293,7 +294,9 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
                 catch (RequestFailedException ex)
                 when (ex.Status == (int)HttpStatusCode.PreconditionFailed)
                 {
-                    throw new InvalidOperationException($"Etag conflict: {ex.Message}");
+                    var items = await ReadAsync(new[] { keyValuePair.Key }, cancellationToken).ConfigureAwait(false);
+                    var item = items.FirstOrDefault().Value as IStoreItem;
+                    throw new ETagException(blobName, storeItem?.ETag, item?.ETag, ex);
                 }
             }
         }

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
@@ -270,6 +270,13 @@ namespace Microsoft.Bot.Builder.Azure
                     }
                 }
                 catch (CosmosException ex)
+                when (ex.StatusCode == HttpStatusCode.PreconditionFailed)
+                {
+                    var items = await ReadAsync(new[] { change.Key }, cancellationToken).ConfigureAwait(false);
+                    var item = items.FirstOrDefault().Value as IStoreItem;
+                    throw new ETagException(documentChange.Id, etag, item?.ETag, ex);
+                }
+                catch (CosmosException ex)
                 {
                     // This check could potentially be performed before even attempting to upsert the item
                     // so that a request wouldn't be made to Cosmos if it's expected to fail.

--- a/libraries/Microsoft.Bot.Builder/ETagException.cs
+++ b/libraries/Microsoft.Bot.Builder/ETagException.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+
+namespace Microsoft.Bot.Builder
+{
+    /// <summary>
+    /// An exception thrown when a 412 Precondition Failed error happens.
+    /// </summary>
+    public class ETagException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ETagException"/> class.
+        /// </summary>
+        public ETagException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ETagException"/> class with an exception message.
+        /// </summary>
+        /// <param name="message">The exception message.</param>
+        public ETagException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ETagException"/> class with an exception message and inner exception.
+        /// </summary>
+        /// <param name="message">The exception message.</param>
+        /// <param name="innerException">The inner exception.</param>
+        public ETagException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ETagException"/> class with an item key, ETag, storage ETag, and inner exception.
+        /// </summary>
+        /// <param name="itemKey">The key of the storage item.</param>
+        /// <param name="itemETag">The ETag to set to the storage item.</param>
+        /// <param name="itemStorageETag">The ETag that's currently in the storage item.</param>
+        /// <param name="innerException">The inner exception.</param>
+        public ETagException(string itemKey, string itemETag, string itemStorageETag, Exception innerException = null)
+            : base(CreateMessage(itemKey, itemETag, itemStorageETag), innerException)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override string Message
+        {
+            // Add a prefix to the message to avoid breaking existing code that looks for the message starting with "Etag conflict:"
+            get
+            {
+                var conflictMessage = "Etag conflict:";
+                return base.Message.StartsWith(conflictMessage) ? base.Message : $"{conflictMessage} {base.Message}";
+            }
+        }
+
+        private static string CreateMessage(string key, string etag, string storageETag)
+        {
+            return $"Unable to write the Item to the Storage due to a 412 Precondition Failed error.\nThis could happen when the Item was already processed by another machine or thread to avoid conflicts or data loss.\n\nKey: {key}\nETag to write: {etag}\nETag in storage: {storageETag}";
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder/MemoryStorage.cs
+++ b/libraries/Microsoft.Bot.Builder/MemoryStorage.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Bot.Builder
                                 &&
                            newStoreItem.ETag != oldStateETag)
                         {
-                            throw new ArgumentException($"Etag conflict.\r\n\r\nOriginal: {newStoreItem.ETag}\r\nCurrent: {oldStateETag}");
+                            throw new ETagException(change.Key, newStoreItem?.ETag, oldStateETag);
                         }
 
                         newState["eTag"] = (_eTag++).ToString(CultureInfo.InvariantCulture);

--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsSSOTokenExchangeMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsSSOTokenExchangeMiddleware.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -53,7 +52,7 @@ namespace Microsoft.Bot.Builder.Teams
         /// <param name="connectionName">The connection name to use for the single
         /// sign on token exchange.</param>
         public TeamsSSOTokenExchangeMiddleware(IStorage storage, string connectionName)
-        {            
+        {
             if (storage == null)
             {
                 throw new ArgumentNullException(nameof(storage));


### PR DESCRIPTION
Related issue # 6861
#minor

## Description
This PR refactors the Teams SSO middleware to fix an issue with the usage of BlobsStorage.
When using BlobsStorage in the middleware, by providing an ETag to an item that will be saved for the first time, it throws an HTTP 412 error, then being captured as an ETag Exception and the conversation gets stuck.
The main reason of why this middleware was saving stuff in the storage was to avoid duplicated requests (when having more than one MS Teams client sign-in), process the first and discard the rest.

We ended up refactoring the middleware to use the storage ETag instead of custom one, and track the deduplication process per user per conversation instead of the token exchange request id that comes in the Activity.Value.

## Specific Changes
  - Changed middleware documentation to understand better what this middleware does.
  - Changed the Storage key format to `<channelId>/<conversation id>/<user id>` to avoid colliding with the same user in other conversations.
  - Added ETagException to handle HTTP 412 errors better, it also includes the "ETag conflict" text at the start to maintain compatibility.
  - Adjusted one unit test to use concurrency.

## Testing
The following image shows an example of the new implementation.
![image](https://github.com/user-attachments/assets/347f8d6a-d471-44a8-ab8b-af79d9330083)
