### PR TITLE
[#4037] Add ComponentRegistration for memory scopes

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogStateManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogStateManager.cs
@@ -40,6 +40,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
         /// <param name="configuration">Configuration for the dialog state manager. Default is <c>null</c>.</param>
         public DialogStateManager(DialogContext dc, DialogStateManagerConfiguration configuration = null)
         {
+            ComponentRegistration.Add(new DialogsComponentRegistration());
+
             _dialogContext = dc ?? throw new ArgumentNullException(nameof(dc));
             Configuration = configuration ?? dc.Context.TurnState.Get<DialogStateManagerConfiguration>();
             if (Configuration == null)


### PR DESCRIPTION
Fixes # 4037
#minor

## Description
This PR adds the ComponentRegistration class to register the memory scopes (turn, this, etc.) in the dialog state manager.
_Note: this change is already applied in botbuilder-js, now botbuilder-dotnet does the same._

## Specific Changes
  - Added ComponentRegistration to DialogStateManager to register dialog memory scopes.

## Testing
The following image shows the CQA bot working correctly.
![imagen](https://github.com/user-attachments/assets/4e3d0e31-0c1d-41c9-8754-f81f9394d87d)