### PR TITLE
[#6889] CQA to support TokenCredential instead of key (Closed)

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.QnA/AssemblyInfo.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/AssemblyInfo.cs
@@ -8,4 +8,5 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Microsoft.Bot.Builder.AI.QnA.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
 #else
 [assembly: InternalsVisibleTo("Microsoft.Bot.Builder.AI.QnA.Tests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 #endif

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/CustomQuestionAnswering.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/CustomQuestionAnswering.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
                 throw new ArgumentException(nameof(endpoint.EndpointKey));
             }
 
-            _languageServiceHelper = new LanguageServiceUtils(TelemetryClient, _httpClient, endpoint, options);
+            _languageServiceHelper = new LanguageServiceUtils(endpoint, options);
         }
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
         public CustomQuestionAnswering(string managedIdentityClientId, QnAMakerEndpoint endpoint, QnAMakerOptions options = null, HttpClient httpClient = null, IBotTelemetryClient telemetryClient = null, bool logPersonalInformation = false)
             : this(endpoint, telemetryClient, logPersonalInformation, httpClient)
         {
-            _languageServiceHelper = new LanguageServiceUtils(managedIdentityClientId, endpoint, options, _httpClient, TelemetryClient);
+            _languageServiceHelper = new LanguageServiceUtils(managedIdentityClientId, endpoint, options);
         }
 
         internal CustomQuestionAnswering(QnAMakerEndpoint endpoint, IBotTelemetryClient telemetryClient = null, bool logPersonalInformation = false, HttpClient httpClient = null)

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/CustomQuestionAnswering.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/CustomQuestionAnswering.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
                 throw new ArgumentException(nameof(endpoint.EndpointKey));
             }
 
-            _languageServiceHelper = new LanguageServiceUtils(endpoint, options);
+            _languageServiceHelper = new LanguageServiceUtils(endpoint, options, _httpClient);
         }
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
         public CustomQuestionAnswering(string managedIdentityClientId, QnAMakerEndpoint endpoint, QnAMakerOptions options = null, HttpClient httpClient = null, IBotTelemetryClient telemetryClient = null, bool logPersonalInformation = false)
             : this(endpoint, telemetryClient, logPersonalInformation, httpClient)
         {
-            _languageServiceHelper = new LanguageServiceUtils(managedIdentityClientId, endpoint, options);
+            _languageServiceHelper = new LanguageServiceUtils(managedIdentityClientId, endpoint, options, _httpClient);
         }
 
         internal CustomQuestionAnswering(QnAMakerEndpoint endpoint, IBotTelemetryClient telemetryClient = null, bool logPersonalInformation = false, HttpClient httpClient = null)
@@ -95,6 +95,15 @@ namespace Microsoft.Bot.Builder.AI.QnA
 
             TelemetryClient = telemetryClient ?? new NullBotTelemetryClient();
             LogPersonalInformation = logPersonalInformation;
+        }
+
+        internal CustomQuestionAnswering(CustomQuestionAnsweringClient client, QnAMakerEndpoint endpoint, QnAMakerOptions options, HttpClient httpClient = null, IBotTelemetryClient telemetryClient = null, bool logPersonalInformation = false)
+        {
+            _endpoint = endpoint ?? throw new ArgumentNullException(nameof(endpoint));
+            _httpClient = httpClient ?? DefaultHttpClient;
+            TelemetryClient = telemetryClient ?? new NullBotTelemetryClient();
+            LogPersonalInformation = logPersonalInformation;
+            _languageServiceHelper = new LanguageServiceUtils(client, endpoint, options);
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/CustomQuestionAnswering.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/CustomQuestionAnswering.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Bot.Builder.AI.QnA.Models;
 using Microsoft.Bot.Builder.AI.QnA.Utils;
 using Newtonsoft.Json;
 
@@ -35,33 +34,12 @@ namespace Microsoft.Bot.Builder.AI.QnA
         /// <param name="telemetryClient">The IBotTelemetryClient used for logging telemetry events.</param>
         /// <param name="logPersonalInformation">Set to true to include personally identifiable information in telemetry events.</param>
         public CustomQuestionAnswering(QnAMakerEndpoint endpoint, QnAMakerOptions options, HttpClient httpClient, IBotTelemetryClient telemetryClient, bool logPersonalInformation = false)
+            : this(endpoint, telemetryClient, logPersonalInformation, httpClient)
         {
-            _endpoint = endpoint ?? throw new ArgumentNullException(nameof(endpoint));
-
-            if (string.IsNullOrEmpty(endpoint.KnowledgeBaseId))
-            {
-                throw new ArgumentException(nameof(endpoint.KnowledgeBaseId));
-            }
-
-            if (string.IsNullOrEmpty(endpoint.Host))
-            {
-                throw new ArgumentException(nameof(endpoint.Host));
-            }
-
             if (string.IsNullOrEmpty(endpoint.EndpointKey))
             {
                 throw new ArgumentException(nameof(endpoint.EndpointKey));
             }
-
-            if (_endpoint.Host.EndsWith("v2.0", StringComparison.Ordinal) || _endpoint.Host.EndsWith("v3.0", StringComparison.Ordinal))
-            {
-                throw new NotSupportedException("v2.0 and v3.0 of QnA Maker service is no longer supported in the QnA Maker.");
-            }
-
-            _httpClient = httpClient ?? DefaultHttpClient;
-
-            TelemetryClient = telemetryClient ?? new NullBotTelemetryClient();
-            LogPersonalInformation = logPersonalInformation;
 
             _languageServiceHelper = new LanguageServiceUtils(TelemetryClient, _httpClient, endpoint, options);
         }
@@ -76,6 +54,47 @@ namespace Microsoft.Bot.Builder.AI.QnA
         public CustomQuestionAnswering(QnAMakerEndpoint endpoint, QnAMakerOptions options = null, HttpClient httpClient = null)
             : this(endpoint, options, httpClient, null)
         {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CustomQuestionAnswering"/> class.
+        /// </summary>
+        /// <param name="managedIdentityClientId">The ClientId of the Managed Identity resource.</param>
+        /// <param name="endpoint">The <see cref="QnAMakerEndpoint"/> of the knowledge base to query.</param>
+        /// <param name="options">The <see cref="QnAMakerOptions"/> for the Custom Question Answering Knowledge Base.</param>
+        /// <param name="httpClient">An alternate client with which to talk to Language Service.
+        /// If null, a default client is used for this instance.</param>
+        /// <param name="telemetryClient">The IBotTelemetryClient used for logging telemetry events.</param>
+        /// <param name="logPersonalInformation">Set to true to include personally identifiable information in telemetry events.</param>
+        public CustomQuestionAnswering(string managedIdentityClientId, QnAMakerEndpoint endpoint, QnAMakerOptions options = null, HttpClient httpClient = null, IBotTelemetryClient telemetryClient = null, bool logPersonalInformation = false)
+            : this(endpoint, telemetryClient, logPersonalInformation, httpClient)
+        {
+            _languageServiceHelper = new LanguageServiceUtils(managedIdentityClientId, endpoint, options, _httpClient, TelemetryClient);
+        }
+
+        internal CustomQuestionAnswering(QnAMakerEndpoint endpoint, IBotTelemetryClient telemetryClient = null, bool logPersonalInformation = false, HttpClient httpClient = null)
+        {
+            _endpoint = endpoint ?? throw new ArgumentNullException(nameof(endpoint));
+
+            if (string.IsNullOrEmpty(endpoint.KnowledgeBaseId))
+            {
+                throw new ArgumentException(nameof(endpoint.KnowledgeBaseId));
+            }
+
+            if (string.IsNullOrEmpty(endpoint.Host))
+            {
+                throw new ArgumentException(nameof(endpoint.Host));
+            }
+
+            if (_endpoint.Host.EndsWith("v2.0", StringComparison.Ordinal) || _endpoint.Host.EndsWith("v3.0", StringComparison.Ordinal))
+            {
+                throw new NotSupportedException("v2.0 and v3.0 of QnA Maker service is no longer supported in the QnA Maker.");
+            }
+
+            _httpClient = httpClient ?? DefaultHttpClient;
+
+            TelemetryClient = telemetryClient ?? new NullBotTelemetryClient();
+            LogPersonalInformation = logPersonalInformation;
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
@@ -260,7 +260,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
             : this(
                 dialogId,
                 knowledgeBaseId,
-                hostName.ToString(),
+                hostName?.ToString() ?? throw new ArgumentNullException(nameof(hostName)),
                 noAnswer,
                 threshold,
                 activeLearningCardTitle,

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
@@ -31,6 +31,10 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.QnAMakerDialog";
 
+#pragma warning disable SA1401 // Fields should be private - used for internal testing.
+        internal CustomQuestionAnsweringClient CQAClient;
+#pragma warning restore SA1401 // Fields should be private
+
         /// <summary>
         /// The path for storing and retrieving QnA Maker context data.
         /// </summary>
@@ -662,6 +666,11 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
 
             if (endpoint.QnAServiceType == ServiceType.Language)
             {
+                if (CQAClient != null)
+                {
+                    return new CustomQuestionAnswering(CQAClient, endpoint, options, httpClient, TelemetryClient, LogPersonalInformation.GetValue(dc.State));
+                }
+
                 if (ManagedIdentityClientId != null)
                 {
                     return new CustomQuestionAnswering(ManagedIdentityClientId.GetValue(dc.State), endpoint, options, httpClient, TelemetryClient, LogPersonalInformation.GetValue(dc.State));

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
@@ -9,7 +9,6 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using AdaptiveExpressions.Properties;
-using Azure.Core;
 using Microsoft.Bot.Builder.AI.QnA.Models;
 using Microsoft.Bot.Builder.AI.QnA.Utils;
 using Microsoft.Bot.Builder.Dialogs;
@@ -272,7 +271,12 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
                 useTeamsAdaptiveCard,
                 httpClient)
         {
-            ManagedIdentityClientId = managedIdentityClientId ?? throw new ArgumentNullException(nameof(managedIdentityClientId));
+            if (string.IsNullOrWhiteSpace(managedIdentityClientId))
+            {
+                throw new ArgumentException("managedIdentityClientId cannot be null, empty, or consist only of whitespace.", nameof(managedIdentityClientId));
+            }
+
+            ManagedIdentityClientId = managedIdentityClientId;
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Microsoft.Bot.Builder.AI.QnA.csproj
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Microsoft.Bot.Builder.AI.QnA.csproj
@@ -38,6 +38,8 @@
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Condition=" '$(ReleasePackageVersion)' != '' " Version="$(ReleasePackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Azure.Identity" Version="1.13.2" />
+    <PackageReference Include="Azure.AI.Language.QuestionAnswering" Version="1.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/CustomQuestionAnsweringClient.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/CustomQuestionAnsweringClient.cs
@@ -1,0 +1,155 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure;
+using Azure.AI.Language.QuestionAnswering;
+using Azure.AI.Language.QuestionAnswering.Authoring;
+using Azure.Core;
+using Microsoft.Bot.Builder.AI.QnA.Models;
+using Microsoft.Bot.Schema;
+
+namespace Microsoft.Bot.Builder.AI.QnA.Utils
+{
+    /// <summary>
+    /// A custom class to manage the <see cref="QuestionAnsweringClient"/> related operations.
+    /// </summary>
+    internal class CustomQuestionAnsweringClient
+    {
+        private readonly QuestionAnsweringClient _client;
+        private readonly QuestionAnsweringAuthoringClient _authoring;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CustomQuestionAnsweringClient"/> class.
+        /// </summary>
+        /// <param name="client">The <see cref="QuestionAnsweringClient"/> instance.</param>
+        /// <param name="authoring">The <see cref="QuestionAnsweringAuthoringClient"/> instance.</param>
+        internal CustomQuestionAnsweringClient(QuestionAnsweringClient client, QuestionAnsweringAuthoringClient authoring)
+        {
+            _client = client;
+            _authoring = authoring;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CustomQuestionAnsweringClient"/> class.
+        /// </summary>
+        internal CustomQuestionAnsweringClient()
+        {
+            // This constructor is used for mocking purposes.
+        }
+
+        /// <summary>
+        /// See <see cref="QuestionAnsweringClient.GetAnswersAsync(string, QuestionAnsweringProject, AnswersOptions, CancellationToken)"/>.
+        /// </summary>
+        /// <param name="activity">Activity.</param>
+        /// <param name="endpoint">QnAMakerEndpoint.</param>
+        /// <param name="options">QnAMakerOptions.</param>
+        /// <param name="cancellationToken">CancellationToken.</param>
+        /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
+        public virtual async Task<KnowledgeBaseAnswers> GetAnswersAsync(Activity activity, QnAMakerEndpoint endpoint, QnAMakerOptions options = null, CancellationToken cancellationToken = default)
+        {
+            var deploymentName = options.IsTest ? "test" : "production";
+            var project = new QuestionAnsweringProject(endpoint.KnowledgeBaseId, deploymentName);
+
+            var newOptions = new AnswersOptions
+            {
+                ConfidenceThreshold = options.ScoreThreshold,
+                IncludeUnstructuredSources = options.IncludeUnstructuredSources.Value,
+                RankerKind = options.RankerType,
+                Size = options.Top,
+                UserId = activity.From?.Id,
+                Filters = new QueryFilters
+                {
+                    MetadataFilter = new Azure.AI.Language.QuestionAnswering.MetadataFilter(),
+                },
+            };
+
+            if (options.Context?.PreviousQnAId != null && options.Context?.PreviousUserQuery != null)
+            {
+                newOptions.AnswerContext = new KnowledgeBaseAnswerContext(options.Context.PreviousQnAId)
+                {
+                    PreviousQuestion = options.Context.PreviousUserQuery,
+                };
+            }
+
+            if (!string.IsNullOrWhiteSpace(options.Filters?.LogicalOperation))
+            {
+                newOptions.Filters.LogicalOperation = options.Filters.LogicalOperation;
+            }
+
+            if (!string.IsNullOrWhiteSpace(options.Filters?.MetadataFilter?.LogicalOperation))
+            {
+                newOptions.Filters.MetadataFilter.LogicalOperation = options.Filters.MetadataFilter.LogicalOperation;
+            }
+
+            if (options.EnablePreciseAnswer.Value)
+            {
+                newOptions.ShortAnswerOptions = new ShortAnswerOptions
+                {
+                    ConfidenceThreshold = 1,
+                };
+            }
+
+            var result = await _client.GetAnswersAsync(activity.Text, project, newOptions, cancellationToken).ConfigureAwait(false);
+
+            var kbAnswers = new KnowledgeBaseAnswers();
+            foreach (var answer in result.Value.Answers)
+            {
+                var kbAnswer = new Models.KnowledgeBaseAnswer
+                {
+                    Id = (int)answer.QnaId,
+                    Answer = answer.Answer,
+                    ConfidenceScore = (float)answer.Confidence,
+                    Source = answer.Source
+                };
+
+                foreach (var questionItem in answer.Questions)
+                {
+                    kbAnswer.Questions.Add(questionItem);
+                }
+
+                if (answer.ShortAnswer != null)
+                {
+                    kbAnswer.AnswerSpan = new KnowledgeBaseAnswerSpan
+                    {
+                        ConfidenceScore = (float)answer.Confidence,
+                        Length = (int)answer.ShortAnswer?.Length,
+                        Offset = (int)answer.ShortAnswer?.Offset,
+                    };
+                }
+
+                if (answer.Dialog != null)
+                {
+                    kbAnswer.Dialog = new QnAResponseContext
+                    {
+                        Prompts = answer.Dialog.Prompts.Select(e => new QnaMakerPrompt
+                        {
+                            DisplayOrder = (int)e.DisplayOrder,
+                            DisplayText = e.DisplayText,
+                            Qna = null,
+                            QnaId = (int)e.QnaId
+                        }).ToArray()
+                    };
+                }
+
+                kbAnswers.Answers.Add(kbAnswer);
+            }
+
+            return kbAnswers;
+        }
+
+        /// <summary>
+        /// See <see cref="QuestionAnsweringAuthoringClient.AddFeedbackAsync(string, RequestContent, RequestContext)"/>.
+        /// </summary>
+        /// <param name="projectName">Project name.</param>
+        /// <param name="content">RequestContent.</param>
+        /// <param name="context">RequestContext.</param>
+        /// <returns>A task response.</returns>
+        public virtual Task<Response> AddFeedbackAsync(string projectName, RequestContent content, RequestContext context = null)
+        {
+            return _authoring.AddFeedbackAsync(projectName, content, context);
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/CustomQuestionAnsweringClient.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/CustomQuestionAnsweringClient.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Utils
                 newOptions.Filters.MetadataFilter.LogicalOperation = options.Filters.MetadataFilter.LogicalOperation;
             }
 
-            if (options.EnablePreciseAnswer.Value)
+            if (options.EnablePreciseAnswer != null && options.EnablePreciseAnswer.Value)
             {
                 newOptions.ShortAnswerOptions = new ShortAnswerOptions
                 {

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/LanguageServiceUtils.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/LanguageServiceUtils.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Azure;
 using Azure.AI.Language.QuestionAnswering;
@@ -22,10 +21,6 @@ namespace Microsoft.Bot.Builder.AI.QnA.Utils
     /// </summary>
     internal class LanguageServiceUtils
     {
-        private const string ApiVersionQueryParam = "api-version=2021-10-01";
-
-        private readonly IBotTelemetryClient _telemetryClient;
-        private readonly HttpClient _httpClient;
         private readonly QnAMakerOptions _options;
         private readonly QnAMakerEndpoint _endpoint;
         private readonly JsonSerializerSettings _settings = new JsonSerializerSettings { MaxDepth = null };
@@ -38,10 +33,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Utils
         /// <param name="managedIdentityClientId">The ClientId of the Managed Identity resource.</param>
         /// <param name="endpoint">Language Service endpoint details.</param>
         /// <param name="options">The options for the QnA Maker knowledge base.</param>
-        /// <param name="httpClient">A client with which to talk to Language Service.</param>
-        /// <param name="telemetryClient">The IBotTelemetryClient used for logging telemetry events.</param>
-        public LanguageServiceUtils(string managedIdentityClientId, QnAMakerEndpoint endpoint, QnAMakerOptions options, HttpClient httpClient, IBotTelemetryClient telemetryClient)
-            : this(endpoint, options, httpClient, telemetryClient)
+        public LanguageServiceUtils(string managedIdentityClientId, QnAMakerEndpoint endpoint, QnAMakerOptions options)
         {
             if (string.IsNullOrEmpty(managedIdentityClientId))
             {
@@ -51,17 +43,18 @@ namespace Microsoft.Bot.Builder.AI.QnA.Utils
             var credential = new ManagedIdentityCredential(managedIdentityClientId);
             _client = new QuestionAnsweringClient(new Uri(_endpoint.Host), credential);
             _authoringClient = new QuestionAnsweringAuthoringClient(new Uri(_endpoint.Host), credential);
+            
+            _endpoint = endpoint;
+            _options = options ?? new QnAMakerOptions();
+            ValidateOptions(_options);
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LanguageServiceUtils"/> class.
         /// </summary>
-        /// <param name="telemetryClient">The IBotTelemetryClient used for logging telemetry events.</param>
         /// <param name="endpoint">Language Service endpoint details.</param>
         /// <param name="options">The options for the QnA Maker knowledge base.</param>
-        /// <param name="httpClient">A client with which to talk to Language Service.</param>
-        public LanguageServiceUtils(IBotTelemetryClient telemetryClient, HttpClient httpClient, QnAMakerEndpoint endpoint, QnAMakerOptions options)
-            : this(endpoint, options, httpClient, telemetryClient)
+        public LanguageServiceUtils(QnAMakerEndpoint endpoint, QnAMakerOptions options)
         {
             if (string.IsNullOrEmpty(endpoint.EndpointKey))
             {
@@ -71,16 +64,10 @@ namespace Microsoft.Bot.Builder.AI.QnA.Utils
             var credential = new AzureKeyCredential(endpoint.EndpointKey);
             _client = new QuestionAnsweringClient(new Uri(_endpoint.Host), credential);
             _authoringClient = new QuestionAnsweringAuthoringClient(new Uri(_endpoint.Host), credential);
-        }
-
-        internal LanguageServiceUtils(QnAMakerEndpoint endpoint, QnAMakerOptions options, HttpClient httpClient, IBotTelemetryClient telemetryClient)
-        {
-            _telemetryClient = telemetryClient;
+            
             _endpoint = endpoint;
-            _httpClient = httpClient;
             _options = options ?? new QnAMakerOptions();
             ValidateOptions(_options);
-            _httpClient = httpClient;
         }
 
         /// <summary>

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/Microsoft.Bot.Builder.AI.QnA.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/Microsoft.Bot.Builder.AI.QnA.Tests.csproj
@@ -17,6 +17,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Azure.AI.Language.QuestionAnswering" Version="1.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
@@ -1986,7 +1986,7 @@ namespace Microsoft.Bot.Builder.AI.Tests
             public QnaMakerTestDialog(string knowledgeBaseId, string endpointKey, string hostName, HttpClient httpClient)
                 : base(nameof(QnaMakerTestDialog))
             {
-                AddDialog(new QnAMakerDialog(knowledgeBaseId, endpointKey, hostName, httpClient: httpClient));
+                AddDialog(new QnAMakerDialog(knowledgeBaseId, endpointKey: endpointKey, hostName, httpClient: httpClient));
             }
 
             /// <summary>


### PR DESCRIPTION
Fixes # 6889

## Description
This PR adds the ability to use a Managed Identity ClientId to authenticate to the Language service.

## Specific Changes
  - Added QuestionAnswering and Azure.Identity packages
  - Updated/Added constructors to receive the Managed Identity ClientId.
  - Updated GetAnswers and AddFeedback methods to match the new QuestionAnswering package.

## Testing
The following images show the GetAnswers and AddFeedback functionalities working with the existing EndpointKey and the new MSI ClientId.
![imagen](https://github.com/user-attachments/assets/0800f56b-ab32-4441-813b-5e188191b3cc)
![imagen](https://github.com/user-attachments/assets/22f810b8-25ec-46cb-81f3-c72d2a060d3f)
