### PR TITLE
[#6883] Capture x-ms-correlation-id and use in all outgoing requests

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/SkillDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/SkillDialog.cs
@@ -249,6 +249,9 @@ namespace Microsoft.Bot.Builder.Dialogs
             await DialogOptions.ConversationState.SaveChangesAsync(context, true, cancellationToken).ConfigureAwait(false);
 
             var skillInfo = DialogOptions.Skill;
+
+            DialogOptions.SkillClient.AddDefaultHeaders();
+            
             var response = await DialogOptions.SkillClient.PostActivityAsync<ExpectedReplies>(DialogOptions.BotId, skillInfo.AppId, skillInfo.SkillEndpoint, DialogOptions.SkillHostEndpoint, skillConversationId, activity, cancellationToken).ConfigureAwait(false);
 
             // Inspect the skill response status

--- a/libraries/Microsoft.Bot.Builder/CloudAdapterBase.cs
+++ b/libraries/Microsoft.Bot.Builder/CloudAdapterBase.cs
@@ -259,7 +259,7 @@ namespace Microsoft.Bot.Builder
         /// <param name="callback">The method to call for the resulting bot turn.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A task that represents the work queued to execute.</returns>
-        protected async Task ProcessProactiveAsync(ClaimsIdentity claimsIdentity, Activity continuationActivity, string audience, BotCallbackHandler callback, CancellationToken cancellationToken)
+        protected virtual async Task ProcessProactiveAsync(ClaimsIdentity claimsIdentity, Activity continuationActivity, string audience, BotCallbackHandler callback, CancellationToken cancellationToken)
         {
             Logger.LogInformation($"ProcessProactiveAsync for Conversation Id: {continuationActivity.Conversation.Id}");
 

--- a/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkClientImpl.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkClientImpl.cs
@@ -121,6 +121,11 @@ namespace Microsoft.Bot.Connector.Authentication
             }
         }
 
+        public override void AddDefaultHeaders()
+        {
+            ConnectorClient.AddDefaultRequestHeaders(_httpClient);
+        }
+
         protected override void Dispose(bool disposing)
         {
             if (_disposed)

--- a/libraries/Microsoft.Bot.Connector/Bot.Builder/BotFrameworkClient.cs
+++ b/libraries/Microsoft.Bot.Connector/Bot.Builder/BotFrameworkClient.cs
@@ -45,6 +45,13 @@ namespace Microsoft.Bot.Builder.Skills
         /// <returns>Async task with optional invokeResponse.</returns>
         public abstract Task<InvokeResponse<T>> PostActivityAsync<T>(string fromBotId, string toBotId, Uri toUrl, Uri serviceUrl, string conversationId, Activity activity, CancellationToken cancellationToken = default);
 
+        /// <summary>
+        /// Allows to add default headers to the HTTP client after the creation of the instance.
+        /// </summary>
+        public virtual void AddDefaultHeaders()
+        {
+        }
+
         /// <inheritdoc/>
         public void Dispose()
         {

--- a/libraries/Microsoft.Bot.Connector/ConnectorClientEx.cs
+++ b/libraries/Microsoft.Bot.Connector/ConnectorClientEx.cs
@@ -250,6 +250,19 @@ namespace Microsoft.Bot.Connector
                     }
                 }
 
+                var filteredHeaders = HeaderPropagation.FilterHeaders();
+
+                if (filteredHeaders != null && filteredHeaders.Count > 0)
+                {
+                    foreach (var header in filteredHeaders)
+                    {
+                        if (!httpClient.DefaultRequestHeaders.Contains(header.Key))
+                        {
+                            httpClient.DefaultRequestHeaders.Add(header.Key, header.Value.ToArray());
+                        }
+                    }
+                }
+
                 httpClient.DefaultRequestHeaders.ExpectContinue = false;
 
                 var jsonAcceptHeader = new MediaTypeWithQualityHeaderValue("*/*");

--- a/libraries/Microsoft.Bot.Connector/ConnectorClientEx.cs
+++ b/libraries/Microsoft.Bot.Connector/ConnectorClientEx.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
@@ -9,6 +10,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text.RegularExpressions;
 using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Extensions.Primitives;
 using Microsoft.Rest;
 using Newtonsoft.Json.Serialization;
 
@@ -250,11 +252,11 @@ namespace Microsoft.Bot.Connector
                     }
                 }
 
-                var filteredHeaders = HeaderPropagation.FilterHeaders();
+                var headersToPropagate = HeaderPropagation.HeadersToPropagate;
 
-                if (filteredHeaders != null && filteredHeaders.Count > 0)
+                if (headersToPropagate != null && headersToPropagate.Count > 0)
                 {
-                    foreach (var header in filteredHeaders)
+                    foreach (var header in headersToPropagate)
                     {
                         if (!httpClient.DefaultRequestHeaders.Contains(header.Key))
                         {

--- a/libraries/Microsoft.Bot.Connector/ConnectorClientEx.cs
+++ b/libraries/Microsoft.Bot.Connector/ConnectorClientEx.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
@@ -10,7 +9,6 @@ using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text.RegularExpressions;
 using Microsoft.Bot.Connector.Authentication;
-using Microsoft.Extensions.Primitives;
 using Microsoft.Rest;
 using Newtonsoft.Json.Serialization;
 

--- a/libraries/Microsoft.Bot.Connector/HeaderPropagation.cs
+++ b/libraries/Microsoft.Bot.Connector/HeaderPropagation.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.Bot.Connector
+{
+    /// <summary>
+    /// Class to handle header propagation from incoming request to outgoing request.
+    /// </summary>
+    public static class HeaderPropagation
+    {
+        private static readonly AsyncLocal<IDictionary<string, StringValues>> _headers = new ();
+
+        private static readonly AsyncLocal<IDictionary<string, StringValues>> _headersToPropagate = new ();
+
+        /// <summary>
+        /// Gets or sets the headers from an incoming request.
+        /// </summary>
+        /// <value>.</value>
+        public static IDictionary<string, StringValues> Headers
+        {
+            get => _headers.Value ?? new Dictionary<string, StringValues>();
+            set => _headers.Value = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the selected headers for propagation.
+        /// </summary>
+        /// <value>.</value>
+        public static IDictionary<string, StringValues> HeadersToPropagate
+        {
+            get => _headersToPropagate.Value ?? new Dictionary<string, StringValues>();
+            set => _headersToPropagate.Value = value;
+        }
+
+        /// <summary>
+        /// Filters the headers to only include those that are relevant for propagation.
+        /// </summary>
+        /// <returns>The filtered headers.</returns>
+        public static IDictionary<string, StringValues> FilterHeaders()
+        {
+            var filteredHeaders = new Dictionary<string, StringValues>();
+
+            if (Headers.TryGetValue("X-Ms-Correlation-Id", out var value))
+            {
+                filteredHeaders.Add("X-Ms-Correlation-Id", value);
+            }
+
+            foreach (var header in HeadersToPropagate)
+            {
+                if (!string.IsNullOrEmpty(header.Value))
+                {
+                    filteredHeaders.Add(header.Key, header.Value);
+                }
+                else
+                {
+                    if (Headers.TryGetValue(header.Key, out var headerValue))
+                    {
+                        filteredHeaders.Add(header.Key, headerValue);
+                    }
+                }
+            }
+
+            return filteredHeaders;
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Connector/HeaderPropagation.cs
+++ b/libraries/Microsoft.Bot.Connector/HeaderPropagation.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Bot.Connector
     /// </summary>
     public static class HeaderPropagation
     {
-        private static readonly AsyncLocal<IDictionary<string, StringValues>> _headers = new ();
+        private static readonly AsyncLocal<IDictionary<string, StringValues>> _requestHeaders = new ();
 
         private static readonly AsyncLocal<IDictionary<string, StringValues>> _headersToPropagate = new ();
 
@@ -20,10 +20,10 @@ namespace Microsoft.Bot.Connector
         /// Gets or sets the headers from an incoming request.
         /// </summary>
         /// <value>.</value>
-        public static IDictionary<string, StringValues> Headers
+        public static IDictionary<string, StringValues> RequestHeaders
         {
-            get => _headers.Value ?? new Dictionary<string, StringValues>();
-            set => _headers.Value = value;
+            get => _requestHeaders.Value ?? new Dictionary<string, StringValues>();
+            set => _requestHeaders.Value = value;
         }
 
         /// <summary>
@@ -37,29 +37,30 @@ namespace Microsoft.Bot.Connector
         }
 
         /// <summary>
-        /// Filters the headers to only include those that are relevant for propagation.
+        /// Filters the request's headers to only include those that are relevant for propagation.
         /// </summary>
+        /// <param name="headerFilter">The headers to filter.</param>
         /// <returns>The filtered headers.</returns>
-        public static IDictionary<string, StringValues> FilterHeaders()
+        public static IDictionary<string, StringValues> FilterHeaders(IDictionary<string, StringValues> headerFilter)
         {
             var filteredHeaders = new Dictionary<string, StringValues>();
 
-            if (Headers.TryGetValue("X-Ms-Correlation-Id", out var value))
+            if (RequestHeaders.TryGetValue("X-Ms-Correlation-Id", out var value))
             {
                 filteredHeaders.Add("X-Ms-Correlation-Id", value);
             }
 
-            foreach (var header in HeadersToPropagate)
+            foreach (var filter in headerFilter)
             {
-                if (!string.IsNullOrEmpty(header.Value))
+                if (!string.IsNullOrEmpty(filter.Value))
                 {
-                    filteredHeaders.Add(header.Key, header.Value);
+                    filteredHeaders.Add(filter.Key, filter.Value);
                 }
                 else
                 {
-                    if (Headers.TryGetValue(header.Key, out var headerValue))
+                    if (RequestHeaders.TryGetValue(filter.Key, out var headerValue))
                     {
-                        filteredHeaders.Add(header.Key, headerValue);
+                        filteredHeaders.Add(filter.Key, headerValue);
                     }
                 }
             }

--- a/libraries/Microsoft.Bot.Connector/HeaderPropagation.cs
+++ b/libraries/Microsoft.Bot.Connector/HeaderPropagation.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Bot.Connector
         /// <summary>
         /// Gets or sets the headers from an incoming request.
         /// </summary>
-        /// <value>.</value>
+        /// <value>The headers from an incoming request.</value>
         public static IDictionary<string, StringValues> RequestHeaders
         {
             get => _requestHeaders.Value ?? new Dictionary<string, StringValues>();
@@ -29,7 +29,7 @@ namespace Microsoft.Bot.Connector
         /// <summary>
         /// Gets or sets the selected headers for propagation.
         /// </summary>
-        /// <value>.</value>
+        /// <value>The selected headers for propagation.</value>
         public static IDictionary<string, StringValues> HeadersToPropagate
         {
             get => _headersToPropagate.Value ?? new Dictionary<string, StringValues>();
@@ -37,9 +37,9 @@ namespace Microsoft.Bot.Connector
         }
 
         /// <summary>
-        /// Filters the request's headers to only include those that are relevant for propagation.
+        /// Filters the request's headers to include only those relevant for propagation.
         /// </summary>
-        /// <param name="headerFilter">The headers to filter.</param>
+        /// <param name="headerFilter">The chosen headers to propagate.</param>
         /// <returns>The filtered headers.</returns>
         public static IDictionary<string, StringValues> FilterHeaders(HeaderPropagationEntryCollection headerFilter)
         {

--- a/libraries/Microsoft.Bot.Connector/HeaderPropagationEntry.cs
+++ b/libraries/Microsoft.Bot.Connector/HeaderPropagationEntry.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Runtime.Serialization;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.Bot.Connector
+{
+    /// <summary>
+    /// Represents the action of the header entry.
+    /// </summary>
+    public enum HeaderPropagationEntryAction
+    {
+        /// <summary>
+        /// Adds a new header entry to the outgoing request.
+        /// </summary>
+        [EnumMember(Value = "add")]
+        Add,
+
+        /// <summary>
+        /// Appends a new header value to an existing key in the outgoing request.
+        /// </summary>
+        [EnumMember(Value = "append")]
+        Append,
+
+        /// <summary>
+        /// Propagates the header entry from the incoming request to the outgoing request without modifications.
+        /// </summary>
+        [EnumMember(Value = "propagate")]
+        Propagate,
+
+        /// <summary>
+        /// Overrides an existing header entry in the outgoing request.
+        /// </summary>
+        [EnumMember(Value = "override")]
+        Override
+    }
+
+    /// <summary>
+    /// Represents a single header entry used for header propagation.
+    /// </summary>
+    public class HeaderPropagationEntry
+    {
+        /// <summary>
+        /// Gets or sets the key of the header entry.
+        /// </summary>
+        /// <value>Key of the header entry.</value>
+        public string Key { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the value of the header entry.
+        /// </summary>
+        /// <value>Value of the header entry.</value>
+        public StringValues Value { get; set; } = new StringValues(string.Empty);
+
+        /// <summary>
+        /// Gets or sets the action of the header entry (Add, Append, Override or Propagate).
+        /// </summary>
+        /// <value>Action of the header entry.</value>
+        public HeaderPropagationEntryAction Action { get; set; } = HeaderPropagationEntryAction.Propagate;
+    }
+}

--- a/libraries/Microsoft.Bot.Connector/HeaderPropagationEntry.cs
+++ b/libraries/Microsoft.Bot.Connector/HeaderPropagationEntry.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Primitives;
 namespace Microsoft.Bot.Connector
 {
     /// <summary>
-    /// Represents the action of the header entry.
+    /// Represents the action to perform with the header entry.
     /// </summary>
     public enum HeaderPropagationEntryAction
     {

--- a/libraries/Microsoft.Bot.Connector/HeaderPropagationEntryCollection.cs
+++ b/libraries/Microsoft.Bot.Connector/HeaderPropagationEntryCollection.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Primitives;
+
+#pragma warning disable SA1010 // OpeningSquareBracketsMustBeSpacedCorrectly
+
+namespace Microsoft.Bot.Connector
+{
+    /// <summary>
+    /// Represents a collection of all the header entries configured to be propagated to outgoing requests.
+    /// </summary>
+    public class HeaderPropagationEntryCollection
+    {
+        private readonly Dictionary<string, HeaderPropagationEntry> _entries = [];
+
+        /// <summary>
+        /// Gets the collection of header entries to be propagated to outgoing requests.
+        /// </summary>
+        /// <value>The collection of header entries.</value>
+        public List<HeaderPropagationEntry> Entries => [.. _entries.Select(x => x.Value)];
+
+        /// <summary>
+        /// Attempts to add a new header entry to the collection.
+        /// </summary>
+        /// <remarks>
+        /// If the key already exists, it will be ignored.
+        /// </remarks>
+        /// <param name="key">The key of the element to add.</param>
+        /// <param name="value">The value to add for the specified key.</param>
+        public void Add(string key, StringValues value)
+        {
+            _entries[key] = new HeaderPropagationEntry
+            {
+                Key = key,
+                Value = value,
+                Action = HeaderPropagationEntryAction.Add
+            };
+        }
+
+        /// <summary>
+        /// Appends a new header value to an existing key.
+        /// </summary>
+        /// <remarks>
+        /// If the key does not exist, it will be ignored.
+        /// </remarks>
+        /// <param name="key">The key of the element to append the value.</param>
+        /// <param name="value">The value to append for the specified key.</param>
+        public void Append(string key, StringValues value)
+        {
+            _entries[key] = new HeaderPropagationEntry
+            {
+                Key = key,
+                Value = value,
+                Action = HeaderPropagationEntryAction.Append
+            };
+        }
+
+        /// <summary>
+        /// Propagates the incoming request header value to outgoing requests without modifications.
+        /// </summary>
+        /// <remarks>
+        /// If the key does not exist, it will be ignored.
+        /// </remarks>
+        /// <param name="key">The key of the element to propagate.</param>
+        public void Propagate(string key)
+        {
+            _entries[key] = new HeaderPropagationEntry
+            {
+                Key = key,
+                Action = HeaderPropagationEntryAction.Propagate
+            };
+        }
+
+        /// <summary>
+        /// Overrides the header value of an existing key.
+        /// </summary>
+        /// <remarks>
+        /// If the key does not exist, it will add it.
+        /// </remarks>
+        /// <param name="key">The key of the element to override.</param>
+        /// <param name="value">The value to override in the specified key.</param>
+        public void Override(string key, StringValues value)
+        {
+            _entries[key] = new HeaderPropagationEntry
+            {
+                Key = key,
+                Value = value,
+                Action = HeaderPropagationEntryAction.Override
+            };
+        }
+    }
+}
+ 
+#pragma warning restore SA1010 // OpeningSquareBracketsMustBeSpacedCorrectly

--- a/libraries/Microsoft.Bot.Connector/HeaderPropagationEntryCollection.cs
+++ b/libraries/Microsoft.Bot.Connector/HeaderPropagationEntryCollection.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Primitives;
 namespace Microsoft.Bot.Connector
 {
     /// <summary>
-    /// Represents a collection of all the header entries configured to be propagated to outgoing requests.
+    /// Represents a collection of the header entries configured to be propagated to outgoing requests.
     /// </summary>
     public class HeaderPropagationEntryCollection
     {

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsHeaderPropagation.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsHeaderPropagation.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Collections.Generic;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Bot.Connector.Teams
@@ -15,17 +14,17 @@ namespace Microsoft.Bot.Connector.Teams
         /// Returns the headers to propagate from incoming request to outgoing request.
         /// </summary>
         /// <returns>.</returns>
-        public static Dictionary<string, StringValues> GetHeadersToPropagate()
+        public static HeaderPropagationEntryCollection GetHeadersToPropagate()
         {
-            var headersToPropagate = new Dictionary<string, StringValues>
-            {
-                ["X-Ms-Teams-Id"] = string.Empty,
-                ["X-Ms-Teams-Custom"] = "Custom-Value"
-            };
+            // Propagate headers to the outgoing request by adding them to the HeaderPropagationEntryCollection. For example:
+            var headersToPropagate = new HeaderPropagationEntryCollection();
+
+            headersToPropagate.Propagate("X-Ms-Teams-Id");
+            headersToPropagate.Add("X-Ms-Teams-Custom", new StringValues("Custom-Value"));
+            headersToPropagate.Append("X-Ms-Teams-Channel", new StringValues("-SubChannel-Id"));
+            headersToPropagate.Override("X-Ms-Other", new StringValues("new-value"));
 
             return headersToPropagate;
-            
-            // HeaderPropagation.HeadersToPropagate = headersToPropagate;
         }
     }
 }

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsHeaderPropagation.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsHeaderPropagation.cs
@@ -12,9 +12,10 @@ namespace Microsoft.Bot.Connector.Teams
     public static class TeamsHeaderPropagation
     {
         /// <summary>
-        /// Set the headers to propagate from incoming request to outgoing request.
+        /// Returns the headers to propagate from incoming request to outgoing request.
         /// </summary>
-        public static void SetHeaderPropagation()
+        /// <returns>.</returns>
+        public static Dictionary<string, StringValues> GetHeadersToPropagate()
         {
             var headersToPropagate = new Dictionary<string, StringValues>
             {
@@ -22,7 +23,9 @@ namespace Microsoft.Bot.Connector.Teams
                 ["X-Ms-Teams-Custom"] = "Custom-Value"
             };
 
-            HeaderPropagation.HeadersToPropagate = headersToPropagate;
+            return headersToPropagate;
+            
+            // HeaderPropagation.HeadersToPropagate = headersToPropagate;
         }
     }
 }

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsHeaderPropagation.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsHeaderPropagation.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.Bot.Connector.Teams
+{
+    /// <summary>
+    /// Instantiate this class to set the headers to propagate from incoming request to outgoing request.
+    /// </summary>
+    public static class TeamsHeaderPropagation
+    {
+        /// <summary>
+        /// Set the headers to propagate from incoming request to outgoing request.
+        /// </summary>
+        public static void SetHeaderPropagation()
+        {
+            var headersToPropagate = new Dictionary<string, StringValues>
+            {
+                ["X-Ms-Teams-Id"] = string.Empty,
+                ["X-Ms-Teams-Custom"] = "Custom-Value"
+            };
+
+            HeaderPropagation.HeadersToPropagate = headersToPropagate;
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsHeaderPropagation.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsHeaderPropagation.cs
@@ -13,16 +13,17 @@ namespace Microsoft.Bot.Connector.Teams
         /// <summary>
         /// Returns the headers to propagate from incoming request to outgoing request.
         /// </summary>
-        /// <returns>.</returns>
+        /// <returns>The collection of headers to propagate.</returns>
         public static HeaderPropagationEntryCollection GetHeadersToPropagate()
         {
-            // Propagate headers to the outgoing request by adding them to the HeaderPropagationEntryCollection. For example:
+            // Propagate headers to the outgoing request by adding them to the HeaderPropagationEntryCollection.
+            // For example:
             var headersToPropagate = new HeaderPropagationEntryCollection();
 
-            headersToPropagate.Propagate("X-Ms-Teams-Id");
-            headersToPropagate.Add("X-Ms-Teams-Custom", new StringValues("Custom-Value"));
-            headersToPropagate.Append("X-Ms-Teams-Channel", new StringValues("-SubChannel-Id"));
-            headersToPropagate.Override("X-Ms-Other", new StringValues("new-value"));
+            //headersToPropagate.Propagate("X-Ms-Teams-Id");
+            //headersToPropagate.Add("X-Ms-Teams-Custom", new StringValues("Custom-Value"));
+            //headersToPropagate.Append("X-Ms-Teams-Channel", new StringValues("-SubChannel-Id"));
+            //headersToPropagate.Override("X-Ms-Other", new StringValues("new-value"));
 
             return headersToPropagate;
         }

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/CloudAdapter.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/CloudAdapter.cs
@@ -276,7 +276,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
             HeaderPropagation.RequestHeaders = headers;
 
             // Look for the selected filters to propagate.
-            var teamsHeaders = new Dictionary<string, StringValues>();
+            var teamsHeaders = new HeaderPropagationEntryCollection();
 
             if (activity.ChannelId == Channels.Msteams)
             {

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/CloudAdapter.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/CloudAdapter.cs
@@ -275,15 +275,16 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
 
             HeaderPropagation.RequestHeaders = headers;
 
-            // Look for the selected filters to propagate.
-            var teamsHeaders = new HeaderPropagationEntryCollection();
+            // Look for the selected headers to propagate.
+            var headersCollection = new HeaderPropagationEntryCollection();
 
-            if (activity.ChannelId == Channels.Msteams)
-            {
-                teamsHeaders = TeamsHeaderPropagation.GetHeadersToPropagate();
-            }
+            // TODO: If a channel implements a static class to configure header propagation, add it to this block.
+            //if (activity.ChannelId == Channels.Msteams)
+            //{
+            //    headersCollection = TeamsHeaderPropagation.GetHeadersToPropagate();
+            //}
 
-            var filteredHeaders = HeaderPropagation.FilterHeaders(teamsHeaders);
+            var filteredHeaders = HeaderPropagation.FilterHeaders(headersCollection);
 
             HeaderPropagation.HeadersToPropagate = filteredHeaders;
 

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/CloudAdapterTests.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/CloudAdapterTests.cs
@@ -41,13 +41,13 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
         public async Task BasicMessageActivity()
         {
             // Arrange
-            var headerDictionaryMock = new Mock<IHeaderDictionary>();
-            headerDictionaryMock.Setup(h => h[It.Is<string>(v => v == "Authorization")]).Returns<string>(null);
-
             var httpRequestMock = new Mock<HttpRequest>();
             httpRequestMock.Setup(r => r.Method).Returns(HttpMethods.Post);
             httpRequestMock.Setup(r => r.Body).Returns(CreateMessageActivityStream());
-            httpRequestMock.Setup(r => r.Headers).Returns(headerDictionaryMock.Object);
+            httpRequestMock.Setup(r => r.Headers).Returns(new HeaderDictionary
+            {
+                { "Authorization", StringValues.Empty }
+            });
 
             var httpResponseMock = new Mock<HttpResponse>();
 
@@ -66,13 +66,13 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
         public async Task InvokeActivity()
         {
             // Arrange
-            var headerDictionaryMock = new Mock<IHeaderDictionary>();
-            headerDictionaryMock.Setup(h => h[It.Is<string>(v => v == "Authorization")]).Returns<string>(null);
-
             var httpRequestMock = new Mock<HttpRequest>();
             httpRequestMock.Setup(r => r.Method).Returns(HttpMethods.Post);
             httpRequestMock.Setup(r => r.Body).Returns(CreateInvokeActivityStream());
-            httpRequestMock.Setup(r => r.Headers).Returns(headerDictionaryMock.Object);
+            httpRequestMock.Setup(r => r.Headers).Returns(new HeaderDictionary
+            {
+                { "Authorization", StringValues.Empty }
+            });
 
             var response = new MemoryStream();
             var httpResponseMock = new Mock<HttpResponse>();
@@ -389,13 +389,13 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
         public async Task MessageActivityWithHttpClient()
         {
             // Arrange
-            var headerDictionaryMock = new Mock<IHeaderDictionary>();
-            headerDictionaryMock.Setup(h => h[It.Is<string>(v => v == "Authorization")]).Returns<string>(null);
-
             var httpRequestMock = new Mock<HttpRequest>();
             httpRequestMock.Setup(r => r.Method).Returns(HttpMethods.Post);
             httpRequestMock.Setup(r => r.Body).Returns(CreateMessageActivityStream());
-            httpRequestMock.Setup(r => r.Headers).Returns(headerDictionaryMock.Object);
+            httpRequestMock.Setup(r => r.Headers).Returns(new HeaderDictionary
+            {
+                { "Authorization", StringValues.Empty }
+            });
 
             var httpResponseMock = new Mock<HttpResponse>();
 
@@ -474,13 +474,13 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
         public async Task InjectCloudEnvironment()
         {
             // Arrange
-            var headerDictionaryMock = new Mock<IHeaderDictionary>();
-            headerDictionaryMock.Setup(h => h[It.Is<string>(v => v == "Authorization")]).Returns<string>(null);
-
             var httpRequestMock = new Mock<HttpRequest>();
             httpRequestMock.Setup(r => r.Method).Returns(HttpMethods.Post);
             httpRequestMock.Setup(r => r.Body).Returns(CreateMessageActivityStream());
-            httpRequestMock.Setup(r => r.Headers).Returns(headerDictionaryMock.Object);
+            httpRequestMock.Setup(r => r.Headers).Returns(new HeaderDictionary
+            {
+                { "Authorization", StringValues.Empty }
+            });
 
             var httpResponseMock = new Mock<HttpResponse>();
 
@@ -527,13 +527,13 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             string relatesToActivityId = "relatesToActivityId";
             string connectionName = "connectionName";
 
-            var headerDictionaryMock = new Mock<IHeaderDictionary>();
-            headerDictionaryMock.Setup(h => h[It.Is<string>(v => v == "Authorization")]).Returns<string>(null);
-
             var httpRequestMock = new Mock<HttpRequest>();
             httpRequestMock.Setup(r => r.Method).Returns(HttpMethods.Post);
             httpRequestMock.Setup(r => r.Body).Returns(CreateMessageActivityStream(userId, channelId, conversationId, recipientId, relatesToActivityId));
-            httpRequestMock.Setup(r => r.Headers).Returns(headerDictionaryMock.Object);
+            httpRequestMock.Setup(r => r.Headers).Returns(new HeaderDictionary
+            {
+                { "Authorization", StringValues.Empty }
+            });
 
             var httpResponseMock = new Mock<HttpResponse>();
 
@@ -609,14 +609,13 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             // this is just a basic test to verify the wire-up of a ConnectorFactory in the CloudAdapter
 
             // Arrange
-
-            var headerDictionaryMock = new Mock<IHeaderDictionary>();
-            headerDictionaryMock.Setup(h => h[It.Is<string>(v => v == "Authorization")]).Returns<string>(null);
-
             var httpRequestMock = new Mock<HttpRequest>();
             httpRequestMock.Setup(r => r.Method).Returns(HttpMethods.Post);
             httpRequestMock.Setup(r => r.Body).Returns(CreateMessageActivityStream());
-            httpRequestMock.Setup(r => r.Headers).Returns(headerDictionaryMock.Object);
+            httpRequestMock.Setup(r => r.Headers).Returns(new HeaderDictionary
+            {
+                { "Authorization", StringValues.Empty }
+            });
 
             var httpResponseMock = new Mock<HttpResponse>();
 
@@ -809,7 +808,6 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
         public async Task ExpiredTokenShouldThrowUnauthorizedAccessException()
         {
             // Arrange
-            var headerDictionaryMock = new Mock<IHeaderDictionary>();
 
             // Expired token with removed AppID
             // This token will be validated against real endpoint https://login.microsoftonline.com/common/discovery/v2.0/keys
@@ -826,12 +824,13 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             // - delete the app
             var token = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ii1LSTNROW5OUjdiUm9meG1lWm9YcWJIWkdldyIsImtpZCI6Ii1LSTNROW5OUjdiUm9meG1lWm9YcWJIWkdldyJ9.eyJhdWQiOiJodHRwczovL2FwaS5ib3RmcmFtZXdvcmsuY29tIiwiaXNzIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvZDZkNDk0MjAtZjM5Yi00ZGY3LWExZGMtZDU5YTkzNTg3MWRiLyIsImlhdCI6MTY5Mjg3MDMwMiwibmJmIjoxNjkyODcwMzAyLCJleHAiOjE2OTI5NTcwMDIsImFpbyI6IkUyRmdZUGhhdFZ6czVydGFFYTlWbDN2ZnIyQ2JBZ0E9IiwiYXBwaWQiOiIxNWYwMTZmZS00ODhjLTQwZTktOWNiZS00Yjk0OGY5OGUyMmMiLCJhcHBpZGFjciI6IjEiLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9kNmQ0OTQyMC1mMzliLTRkZjctYTFkYy1kNTlhOTM1ODcxZGIvIiwicmgiOiIwLkFXNEFJSlRVMXB2ejkwMmgzTldhazFoeDIwSXpMWTBwejFsSmxYY09EcS05RnJ4dUFBQS4iLCJ0aWQiOiJkNmQ0OTQyMC1mMzliLTRkZjctYTFkYy1kNTlhOTM1ODcxZGIiLCJ1dGkiOiJkenVwa1dWd2FVT2x1RldkbnlvLUFBIiwidmVyIjoiMS4wIn0.sbQH997Q2GDKiiYd6l5MIz_XNfXypJd6zLY9xjtvEgXMBB0x0Vu3fv9W0nM57_ZipQiZDTZuSQA5BE30KBBwU-ZVqQ7MgiTkmE9eF6Ngie_5HwSr9xMK3EiDghHiOP9pIj3oEwGOSyjR5L9n-7tLSdUbKVyV14nS8OQtoPd1LZfoZI3e7tVu3vx8Lx3KzudanXX8Vz7RKaYndj3RyRi4wEN5hV9ab40d7fQsUzygFd5n_PXC2rs0OhjZJzjCOTC0VLQEn1KwiTkSH1E-OSzkrMltn1sbhD2tv_H-4rqQd51vAEJ7esC76qQjz_pfDRLs6T2jvJyhd5MZrN_MT0TqlA";
 
-            headerDictionaryMock.Setup(h => h[It.Is<string>(v => v == "Authorization")]).Returns<string>((_) => token);
-
             var httpRequestMock = new Mock<HttpRequest>();
             httpRequestMock.Setup(r => r.Method).Returns(HttpMethods.Post);
             httpRequestMock.Setup(r => r.Body).Returns(CreateInvokeActivityStream());
-            httpRequestMock.Setup(r => r.Headers).Returns(headerDictionaryMock.Object);
+            httpRequestMock.Setup(r => r.Headers).Returns(new HeaderDictionary
+            {
+                { "Authorization", token }
+            });
 
             var response = new MemoryStream();
             var httpResponseMock = new Mock<HttpResponse>().SetupAllProperties();


### PR DESCRIPTION
Fixes # 6883
#minor

## Description
This PR adds the ability to select headers from incoming requests to be propagated to outgoing requests. 
This feature supports **4 possible operations**: 
- The choice of an existing header for propagation (known as the **propagate** operation).
- The ability to add a new header to the outgoing request (referred to as the **add** operation). 
- The ability to replace the value of an existing header (**override** operation).
- The option to concatenate a new value to that of an existing header (**append** operation).
 
Proactive scenarios are supported by incorporating an _IStorage_ instance which stores the selected headers from the reception of the incoming request until the moment the bot sends the proactive message.

## Specific Changes
  - Added new classes to handle the header propagation in _Microsoft.Bot.Connector_:
     - HeaderPropagation 
     - HeaderPropagationEntry
     - HeaderPropagationEntryCollection
  - Updated **_ProcessAsync_** and **_ProcessProactiveAsync_** methods in CloudAdapter to receive and filter the incoming headers.
  - Updated **_AddDefaultRequestHeaders_** method in ConnectorClientEx to read the collection of headers to propagate and set them in the _HttpClient_.
  - Added an optional **_IStorage_** parameter in CloudAdapter to store headers for proactive scenarios.
  - Added a call to _AddDefaultRequestHeaders_ in **_SkillDialog_** to support dialogs root-skill scenarios.
  - Added **_TeamsHeaderPropagation_** class as an example of how header propagations should be implemented for different channels.
  - Fixed failing tests in **_CloudAdapterTests_**.

## Testing
This image shows an outgoing request with the headers propagated.
![image](https://github.com/user-attachments/assets/fbbd9c8b-631a-42c0-bead-0f0d8e55e854)
